### PR TITLE
Migrate DllImport to LibraryImport in core modules

### DIFF
--- a/src/Tizen.Account.AccountManager/Interop/Interop.Account.cs
+++ b/src/Tizen.Account.AccountManager/Interop/Interop.Account.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Account.AccountManager;
 /// <summary>
 /// Interop for Account class APIs.
@@ -29,119 +30,119 @@ internal static partial class Interop
     /// <since_tizen> 3 </since_tizen>
     internal static partial class Account
     {
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_create", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int Create(out SafeAccountHandle handle);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Create(out SafeAccountHandle handle);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_create", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int CreateUnmanagedHandle(out IntPtr handle);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CreateUnmanagedHandle(out IntPtr handle);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_destroy", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int Destroy(IntPtr handle);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Destroy(IntPtr handle);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_get_account_id", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAccountId(SafeAccountHandle data, out int accountId);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_get_account_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountId(SafeAccountHandle data, out int accountId);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_get_user_name", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAccountUserName(SafeAccountHandle data, out string userName);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_get_user_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountUserName(SafeAccountHandle data, out string userName);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_set_user_name", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int SetAccountUserName(SafeAccountHandle handle, string userName);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_set_user_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAccountUserName(SafeAccountHandle handle, string userName);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_get_display_name", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAccountDisplayName(SafeAccountHandle handle, out string displayName);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_get_display_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountDisplayName(SafeAccountHandle handle, out string displayName);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_set_display_name", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int SetAccountDisplayName(SafeAccountHandle handle, string displayName);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_set_display_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAccountDisplayName(SafeAccountHandle handle, string displayName);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_get_capability", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAccountCapability(SafeAccountHandle handle, string capabilityType, out int capabilityValue);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_get_capability", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountCapability(SafeAccountHandle handle, string capabilityType, out int capabilityValue);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_set_capability", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int SetAccountCapability(SafeAccountHandle handle, string capabilityType, int capabilityValue);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_set_capability", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAccountCapability(SafeAccountHandle handle, string capabilityType, int capabilityValue);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_get_icon_path", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAccountIconPath(SafeAccountHandle handle, out string iconPath);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_get_icon_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountIconPath(SafeAccountHandle handle, out string iconPath);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_set_icon_path", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int SetAccountIconPath(SafeAccountHandle handle, string iconPath);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_set_icon_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAccountIconPath(SafeAccountHandle handle, string iconPath);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_get_domain_name", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAccountDomainName(SafeAccountHandle handle, out string domainName);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_get_domain_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountDomainName(SafeAccountHandle handle, out string domainName);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_set_domain_name", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int SetAccountDomainName(SafeAccountHandle handle, string domainName);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_set_domain_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAccountDomainName(SafeAccountHandle handle, string domainName);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_get_email_address", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAccountEmail(SafeAccountHandle handle, out string email);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_get_email_address", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountEmail(SafeAccountHandle handle, out string email);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_set_email_address", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int SetAccountEmail(SafeAccountHandle handle, string email);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_set_email_address", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAccountEmail(SafeAccountHandle handle, string email);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_get_package_name", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAccountPackageName(SafeAccountHandle handle, out string name);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_get_package_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountPackageName(SafeAccountHandle handle, out string name);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_set_package_name", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int SetAccountPackageName(SafeAccountHandle handle, string name);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_set_package_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAccountPackageName(SafeAccountHandle handle, string name);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_get_access_token", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAccountAccessToken(SafeAccountHandle handle, out string accessToken);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_get_access_token", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountAccessToken(SafeAccountHandle handle, out string accessToken);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_set_access_token", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int SetAccountAccessToken(SafeAccountHandle handle, string accessToken);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_set_access_token", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAccountAccessToken(SafeAccountHandle handle, string accessToken);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_get_user_text", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAccountUserText(SafeAccountHandle handle, int index, out string userText);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_get_user_text", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountUserText(SafeAccountHandle handle, int index, out string userText);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_set_user_text", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int SetAccountUserText(SafeAccountHandle handle, int index, string userText);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_set_user_text", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAccountUserText(SafeAccountHandle handle, int index, string userText);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_get_user_int", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAccountUserInt(SafeAccountHandle handle, int index, out int value);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_get_user_int", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountUserInt(SafeAccountHandle handle, int index, out int value);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_set_user_int", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int SetAccountUserInt(SafeAccountHandle handle, int index, int value);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_set_user_int", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAccountUserInt(SafeAccountHandle handle, int index, int value);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_get_auth_type", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAccountAuthType(SafeAccountHandle handle, out int authType);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_get_auth_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountAuthType(SafeAccountHandle handle, out int authType);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_set_auth_type", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int SetAccountAuthType(SafeAccountHandle handle, int authType);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_set_auth_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAccountAuthType(SafeAccountHandle handle, int authType);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_get_secret", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAccountSercet(SafeAccountHandle handle, out int secretType);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_get_secret", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountSercet(SafeAccountHandle handle, out int secretType);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_set_secret", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int SetAccountSecret(SafeAccountHandle handle, int secretType);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_set_secret", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAccountSecret(SafeAccountHandle handle, int secretType);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_get_sync_support", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAccountSyncSupport(SafeAccountHandle handle, out int syncType);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_get_sync_support", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountSyncSupport(SafeAccountHandle handle, out int syncType);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_set_sync_support", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int SetAccountSyncSupport(SafeAccountHandle handle, int syncType);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_set_sync_support", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAccountSyncSupport(SafeAccountHandle handle, int syncType);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_get_source", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAccountSource(SafeAccountHandle handle, out string source);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_get_source", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountSource(SafeAccountHandle handle, out string source);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_set_source", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int SetAccountSource(SafeAccountHandle handle, string source);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_set_source", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAccountSource(SafeAccountHandle handle, string source);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_get_custom", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAccountCustomValue(SafeAccountHandle handle, string key, out string value);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_get_custom", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountCustomValue(SafeAccountHandle handle, string key, out string value);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_set_custom", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int SetAccountCustomValue(SafeAccountHandle handle, string key, string value);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_set_custom", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAccountCustomValue(SafeAccountHandle handle, string key, string value);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_update_sync_status_by_id", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int UpdateAccountSyncStatusById(int accountId, int status);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_update_sync_status_by_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UpdateAccountSyncStatusById(int accountId, int status);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_get_capability_all")]
-        internal static extern int GetAllAccountCapabilities(SafeAccountHandle handle, AccountCapabilityCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_get_capability_all", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAllAccountCapabilities(SafeAccountHandle handle, AccountCapabilityCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_query_capability_by_account_id")]
-        internal static extern int QueryAccountCapabilityById(AccountCapabilityCallback callback, int accountId, IntPtr userData);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_query_capability_by_account_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int QueryAccountCapabilityById(AccountCapabilityCallback callback, int accountId, IntPtr userData);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_get_custom_all")]
-        internal static extern int GetAllAccountCustomValues(SafeAccountHandle handle, AccountCustomCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_get_custom_all", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAllAccountCustomValues(SafeAccountHandle handle, AccountCustomCallback callback, IntPtr userData);
 
         //Callbacks
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/src/Tizen.Account.AccountManager/Interop/Interop.AccountProvider.cs
+++ b/src/Tizen.Account.AccountManager/Interop/Interop.AccountProvider.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Account.AccountManager;
 
 /// <summary>
@@ -31,51 +32,51 @@ internal static partial class Interop
     internal static partial class AccountProvider
     {
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_type_create", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int Create(out IntPtr handle);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_type_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Create(out IntPtr handle);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_type_destroy", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int Destroy(IntPtr handle);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_type_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Destroy(IntPtr handle);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_type_get_app_id", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAppId(IntPtr handle, out string appId);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_type_get_app_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAppId(IntPtr handle, out string appId);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_type_query_supported_feature", CallingConvention = CallingConvention.Cdecl)]
-	[return: MarshalAs(UnmanagedType.I1)]
-        internal static extern bool IsFeatureSupported(string appId, string capability);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_type_query_supported_feature", StringMarshalling = StringMarshalling.Utf8)]
+        [return: MarshalAs(UnmanagedType.U1)]
+        internal static partial bool IsFeatureSupported(string appId, string capability);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_type_get_service_provider_id", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetServiceProviderId(IntPtr handle, out string providerId);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_type_get_service_provider_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetServiceProviderId(IntPtr handle, out string providerId);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_type_get_icon_path", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAccountProviderIconPath(IntPtr handle, out string iconPath);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_type_get_icon_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountProviderIconPath(IntPtr handle, out string iconPath);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_type_get_small_icon_path", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAccountProviderSmallIconPath(IntPtr handle, out string iconPath);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_type_get_small_icon_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountProviderSmallIconPath(IntPtr handle, out string iconPath);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_type_get_multiple_account_support", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetMultipleAccountSupport(IntPtr handle, out int suppport);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_type_get_multiple_account_support", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetMultipleAccountSupport(IntPtr handle, out int suppport);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_type_get_label_by_locale", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetlabelbyLocale(IntPtr handle, string locale, out string label);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_type_get_label_by_locale", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetlabelbyLocale(IntPtr handle, string locale, out string label);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_type_query_app_id_exist", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAppIdExists(string appId);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_type_query_app_id_exist", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAppIdExists(string appId);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_type_foreach_account_type_from_db", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAllAccountProviders(AccountProviderCallback callback, IntPtr data);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_type_foreach_account_type_from_db", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAllAccountProviders(AccountProviderCallback callback, IntPtr data);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_type_query_provider_feature_by_app_id")]
-        internal static extern int GetAccountProviderFeaturesByAppId(AccountProviderFeatureCallback callback, string appId, IntPtr userData);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_type_query_provider_feature_by_app_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountProviderFeaturesByAppId(AccountProviderFeatureCallback callback, string appId, IntPtr userData);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_type_get_provider_feature_all")]
-        internal static extern int GetAccountProviderFeatures(IntPtr handle, AccountProviderFeatureCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_type_get_provider_feature_all", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountProviderFeatures(IntPtr handle, AccountProviderFeatureCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_type_get_label")]
-        internal static extern int GetAccountProviderLabels(IntPtr handle, LabelCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_type_get_label", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountProviderLabels(IntPtr handle, LabelCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_type_query_label_by_app_id")]
-        internal static extern int GetLablesByAppId(LabelCallback callback, string appId, IntPtr userData);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_type_query_label_by_app_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetLablesByAppId(LabelCallback callback, string appId, IntPtr userData);
 
 
         //Callbacks

--- a/src/Tizen.Account.AccountManager/Interop/Interop.AccountService.cs
+++ b/src/Tizen.Account.AccountManager/Interop/Interop.AccountService.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Account.AccountManager;
 
 /// <summary>
@@ -30,68 +31,68 @@ internal static partial class Interop
     /// <since_tizen> 3 </since_tizen>
     internal static partial class AccountService
     {
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_update_to_db_by_id", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int UpdateAccountToDBById(SafeAccountHandle handle, int id);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_update_to_db_by_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UpdateAccountToDBById(SafeAccountHandle handle, int id);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_update_to_db_by_user_name", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int UpdateAccountToDBByUserName(IntPtr handle, string userName, string packageName);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_update_to_db_by_user_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UpdateAccountToDBByUserName(IntPtr handle, string userName, string packageName);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_query_account_by_account_id", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int QueryAccountById(int accountId, ref SafeAccountHandle handle);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_query_account_by_account_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int QueryAccountById(int accountId, ref SafeAccountHandle handle);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_query_account_by_user_name", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int QueryAccountByUserName(Interop.Account.AccountCallback callback, string userName, IntPtr userData);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_query_account_by_user_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int QueryAccountByUserName(Interop.Account.AccountCallback callback, string userName, IntPtr userData);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_query_account_by_package_name", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int QueryAccountByPackageName(Interop.Account.AccountCallback callback, string packageName, IntPtr userData);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_query_account_by_package_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int QueryAccountByPackageName(Interop.Account.AccountCallback callback, string packageName, IntPtr userData);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_query_capability_by_account_id", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int QueryAccountCapabilityById(Interop.Account.AccountCapabilityCallback callback, int accoutId, IntPtr data);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_query_capability_by_account_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int QueryAccountCapabilityById(Interop.Account.AccountCapabilityCallback callback, int accoutId, IntPtr data);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_update_sync_status_by_id", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int UpdateAccountSyncStatusById(int accoutId, int status);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_update_sync_status_by_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UpdateAccountSyncStatusById(int accoutId, int status);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_insert_to_db", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int AddAccount(SafeAccountHandle handle, out int accountId);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_insert_to_db", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int AddAccount(SafeAccountHandle handle, out int accountId);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_delete_from_db_by_id", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int DeleteAccountById(int accountId);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_delete_from_db_by_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int DeleteAccountById(int accountId);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_delete_from_db_by_user_name", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int DeleteAccountByUser(string userName, string packageName);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_delete_from_db_by_user_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int DeleteAccountByUser(string userName, string packageName);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_delete_from_db_by_package_name", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int DeleteAccountByPackage(string packageName);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_delete_from_db_by_package_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int DeleteAccountByPackage(string packageName);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_get_total_count_from_db", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int GetAccountCount(out int count);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_get_total_count_from_db", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountCount(out int count);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_foreach_account_from_db")]
-        internal static extern int AccountForeachAccountFromDb(Interop.Account.AccountCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_foreach_account_from_db", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int AccountForeachAccountFromDb(Interop.Account.AccountCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_query_account_by_capability")]
-        internal static extern int GetAccountByCapability(Interop.Account.AccountCallback callback, string capabilityType, int value, IntPtr userData);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_query_account_by_capability", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountByCapability(Interop.Account.AccountCallback callback, string capabilityType, int value, IntPtr userData);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_query_account_by_capability_type")]
-        internal static extern int GetAccountByCapabilityType(Interop.Account.AccountCallback callback, string capabilityType, IntPtr userData);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_query_account_by_capability_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountByCapabilityType(Interop.Account.AccountCallback callback, string capabilityType, IntPtr userData);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_type_foreach_account_type_from_db")]
-        internal static extern int GetAllAccountproviders(Interop.AccountProvider.AccountProviderCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_type_foreach_account_type_from_db", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAllAccountproviders(Interop.AccountProvider.AccountProviderCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_type_query_by_provider_feature")]
-        internal static extern int GetAccountProviderByFeature(Interop.AccountProvider.AccountProviderCallback callback, string key, IntPtr userData);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_type_query_by_provider_feature", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountProviderByFeature(Interop.AccountProvider.AccountProviderCallback callback, string key, IntPtr userData);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_type_query_by_app_id")]
-        internal static extern int GetAccountProviderByAppId(string appId, out IntPtr handle);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_type_query_by_app_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccountProviderByAppId(string appId, out IntPtr handle);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_subscribe_create")]
-        internal static extern int CreateAccountSubscriber(out Interop.AccountService.SafeAccountSubscriberHandle handle);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_subscribe_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CreateAccountSubscriber(out Interop.AccountService.SafeAccountSubscriberHandle handle);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_subscribe_notification")]
-        internal static extern int RegisterSubscriber(Interop.AccountService.SafeAccountSubscriberHandle handle, Interop.AccountService.SubscribeCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_subscribe_notification", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RegisterSubscriber(Interop.AccountService.SafeAccountSubscriberHandle handle, Interop.AccountService.SubscribeCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.AccountSvc, EntryPoint = "account_unsubscribe_notification")]
-        internal static extern int UnregisterSubscriber(Interop.AccountService.SafeAccountSubscriberHandle handle);
+        [LibraryImport(Libraries.AccountSvc, EntryPoint = "account_unsubscribe_notification", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UnregisterSubscriber(Interop.AccountService.SafeAccountSubscriberHandle handle);
 
         //Callbacks
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/src/Tizen.Account.OAuth2/Interop/Interop.Error.cs
+++ b/src/Tizen.Account.OAuth2/Interop/Interop.Error.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 /// <summary>
 /// Contains Interop declarations of OAuth2 classes.
@@ -27,17 +28,17 @@ internal static partial class Interop
     /// </summary>
     internal static partial class Error
     {
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_error_get_code")]
-        internal static extern int GetCode(IntPtr /* oauth2_error_h */ handle, out int serverErrorCode, out int platformErrorCode);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_error_get_code", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetCode(IntPtr /* oauth2_error_h */ handle, out int serverErrorCode, out int platformErrorCode);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_error_get_description")]
-        internal static extern int GetDescription(IntPtr /* oauth2_error_h */ handle, out string description);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_error_get_description", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetDescription(IntPtr /* oauth2_error_h */ handle, out string description);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_error_get_uri")]
-        internal static extern int GetUri(IntPtr /* oauth2_error_h */ handle, out string uri);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_error_get_uri", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetUri(IntPtr /* oauth2_error_h */ handle, out string uri);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_error_get_custom_data")]
-        internal static extern int GetCustomData(IntPtr /* oauth2_error_h */ handle, string customKey, out string customValue);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_error_get_custom_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetCustomData(IntPtr /* oauth2_error_h */ handle, string customKey, out string customValue);
 
 
     }

--- a/src/Tizen.Account.OAuth2/Interop/Interop.Manager.cs
+++ b/src/Tizen.Account.OAuth2/Interop/Interop.Manager.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 /// <summary>
 /// Contains Interop declarations of OAuth2 classes.
@@ -39,32 +40,32 @@ internal static partial class Interop
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
         internal delegate void Oauth2RefreshTokenCallback(IntPtr /* oauth2_response_h */ response, IntPtr /* void */ userData);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_manager_create")]
-        internal static extern int Create(out IntPtr /* oauth2_manager_h */ handle);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_manager_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Create(out IntPtr /* oauth2_manager_h */ handle);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_manager_destroy")]
-        internal static extern int Destroy(IntPtr /* oauth2_manager_h */ handle);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_manager_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Destroy(IntPtr /* oauth2_manager_h */ handle);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_manager_request_token")]
-        internal static extern int RequestToken(IntPtr /* oauth2_manager_h */ handle, IntPtr /* oauth2_request_h */ request, Oauth2TokenCallback callback, IntPtr /* void */ userData);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_manager_request_token", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RequestToken(IntPtr /* oauth2_manager_h */ handle, IntPtr /* oauth2_request_h */ request, Oauth2TokenCallback callback, IntPtr /* void */ userData);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_manager_request_authorization_grant")]
-        internal static extern int RequestAuthorizationGrant(IntPtr /* oauth2_manager_h */ handle, IntPtr /* oauth2_request_h */ request, Oauth2AuthGrantCallback callback, IntPtr /* void */ userData);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_manager_request_authorization_grant", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RequestAuthorizationGrant(IntPtr /* oauth2_manager_h */ handle, IntPtr /* oauth2_request_h */ request, Oauth2AuthGrantCallback callback, IntPtr /* void */ userData);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_manager_request_access_token")]
-        internal static extern int RequestAccessToken(IntPtr /* oauth2_manager_h */ handle, IntPtr /* oauth2_request_h */ request, Oauth2AccessTokenCallback callback, IntPtr /* void */ userData);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_manager_request_access_token", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RequestAccessToken(IntPtr /* oauth2_manager_h */ handle, IntPtr /* oauth2_request_h */ request, Oauth2AccessTokenCallback callback, IntPtr /* void */ userData);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_manager_refresh_access_token")]
-        internal static extern int RefreshAccessToken(IntPtr /* oauth2_manager_h */ handle, IntPtr /* oauth2_request_h */ request, Oauth2RefreshTokenCallback callback, IntPtr /* void */ userData);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_manager_refresh_access_token", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RefreshAccessToken(IntPtr /* oauth2_manager_h */ handle, IntPtr /* oauth2_request_h */ request, Oauth2RefreshTokenCallback callback, IntPtr /* void */ userData);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_manager_is_request_in_progress")]
-        [return: MarshalAs(UnmanagedType.I1)]
-        internal static extern bool IsRequestInProgress(IntPtr /* oauth2_manager_h */ handle);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_manager_is_request_in_progress", StringMarshalling = StringMarshalling.Utf8)]
+        [return: MarshalAs(UnmanagedType.U1)]
+        internal static partial bool IsRequestInProgress(IntPtr /* oauth2_manager_h */ handle);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_manager_clear_cookies")]
-        internal static extern int ClearCookies(IntPtr /* oauth2_manager_h */ handle);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_manager_clear_cookies", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int ClearCookies(IntPtr /* oauth2_manager_h */ handle);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_manager_clear_cache")]
-        internal static extern int ClearCache(IntPtr /* oauth2_manager_h */ handle);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_manager_clear_cache", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int ClearCache(IntPtr /* oauth2_manager_h */ handle);
     }
 }

--- a/src/Tizen.Account.OAuth2/Interop/Interop.Request.cs
+++ b/src/Tizen.Account.OAuth2/Interop/Interop.Request.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 /// <summary>
 /// Contains Interop declarations of OAuth2 classes.
@@ -27,103 +28,103 @@ internal static partial class Interop
     /// </summary>
     internal static partial class Request
     {
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_create")]
-        internal static extern int Create(out IntPtr /* oauth2_request_h */ handle);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Create(out IntPtr /* oauth2_request_h */ handle);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_destroy")]
-        internal static extern int Destroy(IntPtr /* oauth2_request_h */ handle);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Destroy(IntPtr /* oauth2_request_h */ handle);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_auth_end_point_url")]
-        internal static extern int SetAuthEndPointUrl(IntPtr /* oauth2_request_h */ handle, string url);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_auth_end_point_url", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAuthEndPointUrl(IntPtr /* oauth2_request_h */ handle, string url);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_token_end_point_url")]
-        internal static extern int SetTokenEndPointUrl(IntPtr /* oauth2_request_h */ handle, string url);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_token_end_point_url", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetTokenEndPointUrl(IntPtr /* oauth2_request_h */ handle, string url);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_redirection_url")]
-        internal static extern int SetRedirectionUrl(IntPtr /* oauth2_request_h */ handle, string url);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_redirection_url", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetRedirectionUrl(IntPtr /* oauth2_request_h */ handle, string url);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_refresh_token_url")]
-        internal static extern int SetRefreshTokenUrl(IntPtr /* oauth2_request_h */ handle, string url);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_refresh_token_url", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetRefreshTokenUrl(IntPtr /* oauth2_request_h */ handle, string url);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_refresh_token")]
-        internal static extern int SetRefreshToken(IntPtr /* oauth2_request_h */ handle, string refreshToken);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_refresh_token", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetRefreshToken(IntPtr /* oauth2_request_h */ handle, string refreshToken);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_response_type")]
-        internal static extern int SetResponseType(IntPtr /* oauth2_request_h */ handle, ResponseType /* oauth2_response_type_e */ responseType);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_response_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetResponseType(IntPtr /* oauth2_request_h */ handle, ResponseType /* oauth2_response_type_e */ responseType);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_client_id")]
-        internal static extern int SetClientId(IntPtr /* oauth2_request_h */ handle, string clientId);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_client_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetClientId(IntPtr /* oauth2_request_h */ handle, string clientId);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_client_secret")]
-        internal static extern int SetClientSecret(IntPtr /* oauth2_request_h */ handle, string clientSecret);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_client_secret", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetClientSecret(IntPtr /* oauth2_request_h */ handle, string clientSecret);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_client_authentication_type")]
-        internal static extern int SetClientAuthenticationType(IntPtr /* oauth2_request_h */ handle, int /* oauth2_client_authentication_type_e */ clientAuthType);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_client_authentication_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetClientAuthenticationType(IntPtr /* oauth2_request_h */ handle, int /* oauth2_client_authentication_type_e */ clientAuthType);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_scope")]
-        internal static extern int SetScope(IntPtr /* oauth2_request_h */ handle, string scope);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_scope", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetScope(IntPtr /* oauth2_request_h */ handle, string scope);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_state")]
-        internal static extern int SetState(IntPtr /* oauth2_request_h */ handle, string state);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetState(IntPtr /* oauth2_request_h */ handle, string state);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_grant_type")]
-        internal static extern int SetGrantType(IntPtr /* oauth2_request_h */ handle, GrantType /* oauth2_grant_type_e */ grantType);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_grant_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetGrantType(IntPtr /* oauth2_request_h */ handle, GrantType /* oauth2_grant_type_e */ grantType);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_authorization_code")]
-        internal static extern int SetAuthorizationCode(IntPtr /* oauth2_request_h */ handle, string code);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_authorization_code", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAuthorizationCode(IntPtr /* oauth2_request_h */ handle, string code);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_user_name")]
-        internal static extern int SetUserName(IntPtr /* oauth2_request_h */ handle, string userName);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_user_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetUserName(IntPtr /* oauth2_request_h */ handle, string userName);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_password")]
-        internal static extern int SetPassword(IntPtr /* oauth2_request_h */ handle, string password);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_set_password", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetPassword(IntPtr /* oauth2_request_h */ handle, string password);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_add_custom_data")]
-        internal static extern int AddCustomData(IntPtr /* oauth2_request_h */ handle, string key, string value);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_add_custom_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int AddCustomData(IntPtr /* oauth2_request_h */ handle, string key, string value);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_auth_end_point_url")]
-        internal static extern int GetAuthEndPointUrl(IntPtr /* oauth2_request_h */ handle, out string url);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_auth_end_point_url", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAuthEndPointUrl(IntPtr /* oauth2_request_h */ handle, out string url);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_token_end_point_url")]
-        internal static extern int GetTokenEndPointUrl(IntPtr /* oauth2_request_h */ handle, out string url);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_token_end_point_url", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetTokenEndPointUrl(IntPtr /* oauth2_request_h */ handle, out string url);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_redirection_url")]
-        internal static extern int GetRedirectionUrl(IntPtr /* oauth2_request_h */ handle, out string url);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_redirection_url", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetRedirectionUrl(IntPtr /* oauth2_request_h */ handle, out string url);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_refresh_token_url")]
-        internal static extern int GetRefreshTokenUrl(IntPtr /* oauth2_request_h */ handle, out string url);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_refresh_token_url", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetRefreshTokenUrl(IntPtr /* oauth2_request_h */ handle, out string url);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_refresh_token")]
-        internal static extern int GetRefreshToken(IntPtr /* oauth2_request_h */ handle, out string refreshToken);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_refresh_token", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetRefreshToken(IntPtr /* oauth2_request_h */ handle, out string refreshToken);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_response_type")]
-        internal static extern int GetResponseType(IntPtr /* oauth2_request_h */ handle, out ResponseType /* oauth2_response_type_e */ responseType);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_response_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetResponseType(IntPtr /* oauth2_request_h */ handle, out ResponseType /* oauth2_response_type_e */ responseType);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_client_id")]
-        internal static extern int GetClientId(IntPtr /* oauth2_request_h */ handle, out string clientId);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_client_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetClientId(IntPtr /* oauth2_request_h */ handle, out string clientId);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_client_secret")]
-        internal static extern int GetClientSecret(IntPtr /* oauth2_request_h */ handle, out string clientSecret);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_client_secret", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetClientSecret(IntPtr /* oauth2_request_h */ handle, out string clientSecret);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_scope")]
-        internal static extern int GetScope(IntPtr /* oauth2_request_h */ handle, out string scope);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_scope", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetScope(IntPtr /* oauth2_request_h */ handle, out string scope);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_state")]
-        internal static extern int GetState(IntPtr /* oauth2_request_h */ handle, out string state);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetState(IntPtr /* oauth2_request_h */ handle, out string state);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_grant_type")]
-        internal static extern int GetGrantType(IntPtr /* oauth2_request_h */ handle, out GrantType /* oauth2_grant_type_e */ grantType);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_grant_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetGrantType(IntPtr /* oauth2_request_h */ handle, out GrantType /* oauth2_grant_type_e */ grantType);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_authorization_code")]
-        internal static extern int GetAuthorizationCode(IntPtr /* oauth2_request_h */ handle, out string code);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_authorization_code", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAuthorizationCode(IntPtr /* oauth2_request_h */ handle, out string code);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_user_name")]
-        internal static extern int GetUserName(IntPtr /* oauth2_request_h */ handle, out string userName);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_user_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetUserName(IntPtr /* oauth2_request_h */ handle, out string userName);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_password")]
-        internal static extern int GetPassword(IntPtr /* oauth2_request_h */ handle, out string password);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_password", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetPassword(IntPtr /* oauth2_request_h */ handle, out string password);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_custom_data")]
-        internal static extern int GetCustomData(IntPtr /* oauth2_request_h */ handle, string customKey, out string customValue);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_request_get_custom_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetCustomData(IntPtr /* oauth2_request_h */ handle, string customKey, out string customValue);
     }
 }

--- a/src/Tizen.Account.OAuth2/Interop/Interop.Response.cs
+++ b/src/Tizen.Account.OAuth2/Interop/Interop.Response.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 /// <summary>
 /// Contains Interop declarations of OAuth2 classes.
@@ -27,35 +28,35 @@ internal static partial class Interop
     /// </summary>
     internal static partial class Response
     {
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_response_destroy")]
-        internal static extern int Destroy(IntPtr /* oauth2_response_h */ handle);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_response_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Destroy(IntPtr /* oauth2_response_h */ handle);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_response_get_authorization_code")]
-        internal static extern int GetAuthorizationCode(IntPtr /* oauth2_response_h */ handle, out IntPtr code);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_response_get_authorization_code", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAuthorizationCode(IntPtr /* oauth2_response_h */ handle, out IntPtr code);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_response_get_state")]
-        internal static extern int GetState(IntPtr /* oauth2_response_h */ handle, out IntPtr state);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_response_get_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetState(IntPtr /* oauth2_response_h */ handle, out IntPtr state);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_response_get_access_token")]
-        internal static extern int GetAccessToken(IntPtr /* oauth2_response_h */ handle, out IntPtr accessToken);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_response_get_access_token", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAccessToken(IntPtr /* oauth2_response_h */ handle, out IntPtr accessToken);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_response_get_token_type")]
-        internal static extern int GetTokenType(IntPtr /* oauth2_response_h */ handle, out IntPtr tokenType);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_response_get_token_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetTokenType(IntPtr /* oauth2_response_h */ handle, out IntPtr tokenType);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_response_get_expires_in")]
-        internal static extern int GetExpiresIn(IntPtr /* oauth2_response_h */ handle, out long expiresIn);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_response_get_expires_in", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetExpiresIn(IntPtr /* oauth2_response_h */ handle, out long expiresIn);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_response_get_refresh_token")]
-        internal static extern int GetRefreshToken(IntPtr /* oauth2_response_h */ handle, out IntPtr refreshToken);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_response_get_refresh_token", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetRefreshToken(IntPtr /* oauth2_response_h */ handle, out IntPtr refreshToken);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_response_get_scope")]
-        internal static extern int GetScope(IntPtr /* oauth2_response_h */ handle, out IntPtr scope);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_response_get_scope", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetScope(IntPtr /* oauth2_response_h */ handle, out IntPtr scope);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_response_get_error")]
-        internal static extern int GetError(IntPtr /* oauth2_response_h */ handle, out IntPtr /* oauth2_error_h */ error);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_response_get_error", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetError(IntPtr /* oauth2_response_h */ handle, out IntPtr /* oauth2_error_h */ error);
 
-        [DllImport(Libraries.OAuth2, EntryPoint = "oauth2_response_get_custom_data")]
-        internal static extern int GetCustomData(IntPtr /* oauth2_response_h */ handle, string customKey, out IntPtr customValue);
+        [LibraryImport(Libraries.OAuth2, EntryPoint = "oauth2_response_get_custom_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetCustomData(IntPtr /* oauth2_response_h */ handle, string customKey, out IntPtr customValue);
 
 
    }

--- a/src/Tizen.Account.SyncManager/Interop/Interop.Adapter.cs
+++ b/src/Tizen.Account.SyncManager/Interop/Interop.Adapter.cs
@@ -8,16 +8,17 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
     internal static partial class Adapter
     {
-        [DllImport(Libraries.SyncManager, EntryPoint = "sync_adapter_set_callbacks")]
-        internal static extern int SetCallbacks(SyncAdapterStartSyncCallback onStartCb, SyncAdapterCancelSyncCallback onCancelCb);
+        [LibraryImport(Libraries.SyncManager, EntryPoint = "sync_adapter_set_callbacks", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetCallbacks(SyncAdapterStartSyncCallback onStartCb, SyncAdapterCancelSyncCallback onCancelCb);
 
-        [DllImport(Libraries.SyncManager, EntryPoint = "sync_adapter_unset_callbacks")]
-        internal static extern int UnsetCallbacks();
+        [LibraryImport(Libraries.SyncManager, EntryPoint = "sync_adapter_unset_callbacks", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UnsetCallbacks();
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
         internal delegate bool SyncAdapterStartSyncCallback(IntPtr account, string syncJobName, string syncCapability, IntPtr syncJobUserData);

--- a/src/Tizen.Account.SyncManager/Interop/Interop.Manager.cs
+++ b/src/Tizen.Account.SyncManager/Interop/Interop.Manager.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 using Tizen.Account.AccountManager;
 
@@ -15,20 +16,20 @@ internal static partial class Interop
 {
     internal static partial class Manager
     {
-        [DllImport(Libraries.SyncManager, EntryPoint = "sync_manager_on_demand_sync_job")]
-        internal static extern int RequestOnDemandSyncJob(SafeAccountHandle account, string syncJobName, int syncOption, SafeBundleHandle syncJobUserData, out int syncJobId);
+        [LibraryImport(Libraries.SyncManager, EntryPoint = "sync_manager_on_demand_sync_job", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RequestOnDemandSyncJob(SafeAccountHandle account, string syncJobName, int syncOption, SafeBundleHandle syncJobUserData, out int syncJobId);
 
-        [DllImport(Libraries.SyncManager, EntryPoint = "sync_manager_add_periodic_sync_job")]
-        internal static extern int AddPeriodicSyncJob(SafeAccountHandle account, string syncJobName, int syncPeriod, int syncOption, SafeBundleHandle syncJobUserData, out int syncJobId);
+        [LibraryImport(Libraries.SyncManager, EntryPoint = "sync_manager_add_periodic_sync_job", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int AddPeriodicSyncJob(SafeAccountHandle account, string syncJobName, int syncPeriod, int syncOption, SafeBundleHandle syncJobUserData, out int syncJobId);
 
-        [DllImport(Libraries.SyncManager, EntryPoint = "sync_manager_add_data_change_sync_job")]
-        internal static extern int AddDataChangeSyncJob(SafeAccountHandle account, string syncCapability, int syncOption, SafeBundleHandle syncJobUserData, out int syncJobId);
+        [LibraryImport(Libraries.SyncManager, EntryPoint = "sync_manager_add_data_change_sync_job", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int AddDataChangeSyncJob(SafeAccountHandle account, string syncCapability, int syncOption, SafeBundleHandle syncJobUserData, out int syncJobId);
 
-        [DllImport(Libraries.SyncManager, EntryPoint = "sync_manager_remove_sync_job")]
-        internal static extern int RemoveSyncJob(int syncJobId);
+        [LibraryImport(Libraries.SyncManager, EntryPoint = "sync_manager_remove_sync_job", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RemoveSyncJob(int syncJobId);
 
-        [DllImport(Libraries.SyncManager, EntryPoint = "sync_manager_foreach_sync_job")]
-        internal static extern int ForeachSyncJob(SyncManagerSyncJobCallback syncJobCb, IntPtr userData);
+        [LibraryImport(Libraries.SyncManager, EntryPoint = "sync_manager_foreach_sync_job", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int ForeachSyncJob(SyncManagerSyncJobCallback syncJobCb, IntPtr userData);
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
         internal delegate bool SyncManagerSyncJobCallback(IntPtr account, string syncJobName, string syncCapability, int syncJobId, IntPtr syncJobUserData, IntPtr userData);

--- a/src/Tizen.Applications.Alarm/Interop/Interop.Alarm.cs
+++ b/src/Tizen.Applications.Alarm/Interop/Interop.Alarm.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Tizen.Internals;
 using Tizen.Applications;
@@ -42,83 +43,87 @@ internal static partial class Interop
             internal IntPtr tm_zone;
         };
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_after_delay")]
-        internal static extern int CreateAlarmAfterDelay(SafeAppControlHandle appControl, int delay, int period, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_after_delay", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CreateAlarmAfterDelay(SafeAppControlHandle appControl, int delay, int period, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_once_after_delay")]
-        internal static extern int CreateAlarmOnceAfterDelay(SafeAppControlHandle appControl, int delay, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_once_after_delay", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CreateAlarmOnceAfterDelay(SafeAppControlHandle appControl, int delay, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_once_at_date")]
-        internal static extern int CreateAlarmOnceAtDate(SafeAppControlHandle appControl, ref DateTime date, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_once_at_date", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CreateAlarmOnceAtDate(SafeAppControlHandle appControl, ref DateTime date, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_with_recurrence_week_flag")]
-        internal static extern int CreateAlarmRecurWeek(SafeAppControlHandle appControl, ref DateTime date, int week, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_with_recurrence_week_flag", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CreateAlarmRecurWeek(SafeAppControlHandle appControl, ref DateTime date, int week, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_service_with_recurrence_seconds")]
-        internal static extern int CreateAlarmRecurForService(SafeAppControlHandle appControl, ref DateTime date, int period, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_service_with_recurrence_seconds", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CreateAlarmRecurForService(SafeAppControlHandle appControl, ref DateTime date, int period, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_service_once_after_delay")]
-        internal static extern int CreateAlarmOnceAfterDelayForService(SafeAppControlHandle appControl, int delay, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_service_once_after_delay", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CreateAlarmOnceAfterDelayForService(SafeAppControlHandle appControl, int delay, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_service_once_at_date")]
-        internal static extern int CreateAlarmOnceAtDateForService(SafeAppControlHandle appControl, ref DateTime date, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_service_once_at_date", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CreateAlarmOnceAtDateForService(SafeAppControlHandle appControl, ref DateTime date, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_get_scheduled_recurrence_week_flag")]
-        internal static extern int GetAlarmWeekFlag(int alarmId, out int weekFlag);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_get_scheduled_recurrence_week_flag", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAlarmWeekFlag(int alarmId, out int weekFlag);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_cancel")]
-        internal static extern int CancelAlarm(int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_cancel", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CancelAlarm(int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_cancel_all")]
-        internal static extern int CancelAllAlarms();
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_cancel_all", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CancelAllAlarms();
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_get_scheduled_date")]
-        internal static extern int GetAlarmScheduledDate(int alarmId, out DateTime date);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_get_scheduled_date", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAlarmScheduledDate(int alarmId, out DateTime date);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_get_current_time")]
-        internal static extern int GetCurrentTime(out DateTime date);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_get_current_time", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetCurrentTime(out DateTime date);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_get_app_control")]
-        internal static extern int GetAlarmAppControl(int alarmId, out SafeAppControlHandle control);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_get_app_control", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAlarmAppControl(int alarmId, out SafeAppControlHandle control);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_get_scheduled_period")]
-        internal static extern int GetAlarmScheduledPeriod(int alarmId, out int period);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_get_scheduled_period", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAlarmScheduledPeriod(int alarmId, out int period);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_set_global")]
-        internal static extern int SetAlarmGlobalFlag(int alarmId, bool global);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_set_global", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAlarmGlobalFlag(int alarmId, [MarshalAs(UnmanagedType.U1)] bool global);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_get_global")]
-        internal static extern int GetAlarmGlobalFlag(int alarmId, out bool global);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_get_global", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAlarmGlobalFlag(int alarmId, [MarshalAs(UnmanagedType.U1)] out bool global);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_foreach_registered_alarm")]
-        internal static extern int GetAllRegisteredAlarms(RegisteredAlarmCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_foreach_registered_alarm", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAllRegisteredAlarms(RegisteredAlarmCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_noti_once_at_date")]
-        internal static extern AlarmError CreateAlarmNotiOnceAtDate(NotificationSafeHandle noti, ref DateTime date, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_noti_once_at_date", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial AlarmError CreateAlarmNotiOnceAtDate(NotificationSafeHandle noti, ref DateTime date, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_noti_after_delay")]
-        internal static extern AlarmError CreateAlarmNotiAfterDelay(NotificationSafeHandle noti, int delay, int period, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_noti_after_delay", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial AlarmError CreateAlarmNotiAfterDelay(NotificationSafeHandle noti, int delay, int period, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_noti_once_after_delay")]
-        internal static extern AlarmError CreateAlarmNotiOnceAfterDelay(NotificationSafeHandle noti, int delay, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_noti_once_after_delay", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial AlarmError CreateAlarmNotiOnceAfterDelay(NotificationSafeHandle noti, int delay, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_noti_with_recurrence_week_flag")]
-        internal static extern AlarmError CreateAlarmNotiRecurWeek(NotificationSafeHandle noti, ref DateTime date, int week, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_noti_with_recurrence_week_flag", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial AlarmError CreateAlarmNotiRecurWeek(NotificationSafeHandle noti, ref DateTime date, int week, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_update_delay")]
-        internal static extern AlarmError UpdateDelay(int alarmId, int delay);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_update_delay", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial AlarmError UpdateDelay(int alarmId, int delay);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_update_date")]
-        internal static extern AlarmError UpdateDate(int alarmId, ref DateTime date);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_update_date", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial AlarmError UpdateDate(int alarmId, ref DateTime date);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_update_period")]
-        internal static extern AlarmError UpdatePeriod(int alarmId, int period);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_update_period", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial AlarmError UpdatePeriod(int alarmId, int period);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_update_week_flag")]
-        internal static extern AlarmError UpdateWeekFlag(int alarmId, int week);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_update_week_flag", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial AlarmError UpdateWeekFlag(int alarmId, int week);
 
         //callback
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool RegisteredAlarmCallback(int alarmId, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool RegisteredAlarmCallback(int alarmId, IntPtr userData);
     }
 }
+
+
+
+

--- a/src/Tizen.Applications.Alarm/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.Alarm/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string Alarm = "libcapi-appfw-alarm.so.0";
     }
 }
+
+
+

--- a/src/Tizen.Applications.AttachPanel/Interop/Interop.AttachPanel.cs
+++ b/src/Tizen.Applications.AttachPanel/Interop/Interop.AttachPanel.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 
 /// <summary>
@@ -30,49 +31,51 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void AttachPanelResultCallback(IntPtr attachPanel, int category, IntPtr result, int resultCode, IntPtr userData);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_create")]
-        internal static extern ErrorCode CreateAttachPanel(IntPtr conform, out IntPtr attach_panel);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CreateAttachPanel(IntPtr conform, out IntPtr attach_panel);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_destroy")]
-        internal static extern ErrorCode DestroyAttachPanel(IntPtr attach_panel);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode DestroyAttachPanel(IntPtr attach_panel);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_add_content_category")]
-        internal static extern ErrorCode AddCategory(IntPtr attach_panel, int content_category, IntPtr extraData);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_add_content_category", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AddCategory(IntPtr attach_panel, int content_category, IntPtr extraData);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_remove_content_category")]
-        internal static extern ErrorCode RemoveCategory(IntPtr attach_panel, int content_category);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_remove_content_category", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode RemoveCategory(IntPtr attach_panel, int content_category);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_set_extra_data")]
-        internal static extern ErrorCode SetExtraData(IntPtr attach_panel, int content_category, IntPtr extraData);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_set_extra_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetExtraData(IntPtr attach_panel, int content_category, IntPtr extraData);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_set_result_cb")]
-        internal static extern ErrorCode SetResultCb(IntPtr attach_panel, AttachPanelResultCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_set_result_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetResultCb(IntPtr attach_panel, AttachPanelResultCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_unset_result_cb")]
-        internal static extern ErrorCode UnsetResultCb(IntPtr attach_panel);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_unset_result_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode UnsetResultCb(IntPtr attach_panel);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_set_event_cb")]
-        internal static extern ErrorCode SetEventCb(IntPtr attach_panel, AttachPanelEventCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_set_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetEventCb(IntPtr attach_panel, AttachPanelEventCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_unset_event_cb")]
-        internal static extern ErrorCode UnsetEventCb(IntPtr attach_panel);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_unset_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode UnsetEventCb(IntPtr attach_panel);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_show")]
-        internal static extern ErrorCode Show(IntPtr attach_panel);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_show", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode Show(IntPtr attach_panel);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_show_without_animation")]
-        internal static extern ErrorCode ShowWithoutAnimation(IntPtr attach_panel);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_show_without_animation", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ShowWithoutAnimation(IntPtr attach_panel);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_hide")]
-        internal static extern ErrorCode Hide(IntPtr attach_panel);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_hide", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode Hide(IntPtr attach_panel);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_hide_without_animation")]
-        internal static extern ErrorCode HideWithoutAnimation(IntPtr attach_panel);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_hide_without_animation", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode HideWithoutAnimation(IntPtr attach_panel);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_get_visibility")]
-        internal static extern ErrorCode GetVisibility(IntPtr attach_panel, out int visible);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_get_visibility", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetVisibility(IntPtr attach_panel, out int visible);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_get_state")]
-        internal static extern ErrorCode GetState(IntPtr attach_panel, out int state);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_get_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetState(IntPtr attach_panel, out int state);
     }
 }
+
+

--- a/src/Tizen.Applications.AttachPanel/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.AttachPanel/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/// <summary>
+﻿/// <summary>
 /// The Interoperability support class for the attach panel APIs.
 /// </summary>
 internal static partial class Interop
@@ -11,3 +11,6 @@ internal static partial class Interop
         public const string AttachPanel = "libattach-panel.so.0.1.0";
     }
 }
+
+
+

--- a/src/Tizen.Applications.Badge/Interop/Interop.Badge.cs
+++ b/src/Tizen.Applications.Badge/Interop/Interop.Badge.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 
 internal static partial class Interop
@@ -31,35 +32,39 @@ internal static partial class Interop
             ServiceReady
         }
 
-        internal delegate bool ForeachCallback(string appId, uint count, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool ForeachCallback(string appId, uint count, IntPtr userData);
 
         internal delegate void ChangedCallback(Action action, string appId, uint count, IntPtr userData);
 
-        [DllImport(Libraries.Badge, EntryPoint = "badge_add")]
-        internal static extern BadgeError Add(string appId);
+        [LibraryImport(Libraries.Badge, EntryPoint = "badge_add", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial BadgeError Add(string appId);
 
-        [DllImport(Libraries.Badge, EntryPoint = "badge_remove")]
-        internal static extern BadgeError Remove(string appId);
+        [LibraryImport(Libraries.Badge, EntryPoint = "badge_remove", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial BadgeError Remove(string appId);
 
-        [DllImport(Libraries.Badge, EntryPoint = "badge_set_count")]
-        internal static extern BadgeError SetCount(string appId, uint count);
+        [LibraryImport(Libraries.Badge, EntryPoint = "badge_set_count", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial BadgeError SetCount(string appId, uint count);
 
-        [DllImport(Libraries.Badge, EntryPoint = "badge_get_count")]
-        internal static extern BadgeError GetCount(string appId, out uint count);
+        [LibraryImport(Libraries.Badge, EntryPoint = "badge_get_count", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial BadgeError GetCount(string appId, out uint count);
 
-        [DllImport(Libraries.Badge, EntryPoint = "badge_set_display")]
-        internal static extern BadgeError SetDisplay(string appId, uint isDisplay);
+        [LibraryImport(Libraries.Badge, EntryPoint = "badge_set_display", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial BadgeError SetDisplay(string appId, uint isDisplay);
 
-        [DllImport(Libraries.Badge, EntryPoint = "badge_get_display")]
-        internal static extern BadgeError GetDisplay(string appId, out uint isDisplay);
+        [LibraryImport(Libraries.Badge, EntryPoint = "badge_get_display", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial BadgeError GetDisplay(string appId, out uint isDisplay);
 
-        [DllImport(Libraries.Badge, EntryPoint = "badge_foreach")]
-        internal static extern BadgeError Foreach(ForeachCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Badge, EntryPoint = "badge_foreach", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial BadgeError Foreach(ForeachCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Badge, EntryPoint = "badge_register_changed_cb")]
-        internal static extern BadgeError SetChangedCallback(ChangedCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Badge, EntryPoint = "badge_register_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial BadgeError SetChangedCallback(ChangedCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Badge, EntryPoint = "badge_unregister_changed_cb")]
-        internal static extern BadgeError UnsetChangedCallback(ChangedCallback callback);
+        [LibraryImport(Libraries.Badge, EntryPoint = "badge_unregister_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial BadgeError UnsetChangedCallback(ChangedCallback callback);
     }
 }
+
+
+
+

--- a/src/Tizen.Applications.Badge/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.Badge/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string Badge = "libbadge.so.0";
     }
 }
+
+
+

--- a/src/Tizen.Applications.Cion/Interop/Interop.Cion.cs
+++ b/src/Tizen.Applications.Cion/Interop/Interop.Cion.cs
@@ -36,3 +36,6 @@ internal static partial class Interop
         }
     }
 }
+
+
+

--- a/src/Tizen.Applications.Cion/Interop/Interop.CionClient.cs
+++ b/src/Tizen.Applications.Cion/Interop/Interop.CionClient.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications.Cion;
 
 using ErrorCode = Interop.Cion.ErrorCode;
@@ -39,46 +40,49 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void CionClientPayloadAsyncResultCb(IntPtr result, IntPtr userData);        
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_client_create")]
-        internal static extern ErrorCode CionClientCreate(out ClientSafeHandle client, string serviceName, IntPtr security);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_client_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionClientCreate(out ClientSafeHandle client, string serviceName, IntPtr security);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_client_destroy")]
-        internal static extern ErrorCode CionClientDestroy(IntPtr client);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_client_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionClientDestroy(IntPtr client);
         
-        [DllImport(Libraries.Cion, EntryPoint = "cion_client_try_discovery")]
-        internal static extern ErrorCode CionClientTryDiscovery(ClientSafeHandle client, CionClientServerDiscoveredCb cb, IntPtr userData);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_client_try_discovery", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionClientTryDiscovery(ClientSafeHandle client, CionClientServerDiscoveredCb cb, IntPtr userData);
         
-        [DllImport(Libraries.Cion, EntryPoint = "cion_client_stop_discovery")]
-        internal static extern ErrorCode CionClientStopDiscovery(ClientSafeHandle client);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_client_stop_discovery", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionClientStopDiscovery(ClientSafeHandle client);
         
-        [DllImport(Libraries.Cion, EntryPoint = "cion_client_connect")]
-        internal static extern ErrorCode CionClientConnect(ClientSafeHandle client, PeerInfoSafeHandle peerInfo);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_client_connect", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionClientConnect(ClientSafeHandle client, PeerInfoSafeHandle peerInfo);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_client_disconnect")]
-        internal static extern ErrorCode CionClientDisconnect(ClientSafeHandle client);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_client_disconnect", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionClientDisconnect(ClientSafeHandle client);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_client_send_data")]
-        internal static extern ErrorCode CionClientSendData(ClientSafeHandle client, byte[] data, int dataSize, int timeout, out IntPtr returnData, out int returnDataSize);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_client_send_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionClientSendData(ClientSafeHandle client, byte[] data, int dataSize, int timeout, out IntPtr returnData, out int returnDataSize);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_client_send_payload_async")]
-        internal static extern ErrorCode CionClientSendPayloadAsync(ClientSafeHandle client, PayloadSafeHandle payload, CionClientPayloadAsyncResultCb cb, IntPtr userData);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_client_send_payload_async", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionClientSendPayloadAsync(ClientSafeHandle client, PayloadSafeHandle payload, CionClientPayloadAsyncResultCb cb, IntPtr userData);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_client_add_connection_result_cb")]
-        internal static extern ErrorCode CionClientAddConnectionResultCb(ClientSafeHandle client, CionClientConnectionResultCb cb, IntPtr userData);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_client_add_connection_result_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionClientAddConnectionResultCb(ClientSafeHandle client, CionClientConnectionResultCb cb, IntPtr userData);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_client_remove_connection_result_cb")]
-        internal static extern ErrorCode CionClientRemoveConnectionResultCb(ClientSafeHandle client, CionClientConnectionResultCb cb);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_client_remove_connection_result_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionClientRemoveConnectionResultCb(ClientSafeHandle client, CionClientConnectionResultCb cb);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_client_add_payload_received_cb")]
-        internal static extern ErrorCode CionClientAddPayloadReceivedCb(ClientSafeHandle client, CionClientPayloadReceivedCb cb, IntPtr userData);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_client_add_payload_received_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionClientAddPayloadReceivedCb(ClientSafeHandle client, CionClientPayloadReceivedCb cb, IntPtr userData);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_client_remove_payload_received_cb")]
-        internal static extern ErrorCode CionClientRemovePayloadReceivedCb(ClientSafeHandle client, CionClientPayloadReceivedCb cb);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_client_remove_payload_received_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionClientRemovePayloadReceivedCb(ClientSafeHandle client, CionClientPayloadReceivedCb cb);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_client_add_disconnected_cb")]
-        internal static extern ErrorCode CionClientAddDisconnectedCb(ClientSafeHandle client, CionClientDisconnectedCb cb, IntPtr userData);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_client_add_disconnected_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionClientAddDisconnectedCb(ClientSafeHandle client, CionClientDisconnectedCb cb, IntPtr userData);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_client_remove_disconnected_cb")]
-        internal static extern ErrorCode CionClientRemoveDisconnectedCb(ClientSafeHandle client, CionClientDisconnectedCb cb);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_client_remove_disconnected_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionClientRemoveDisconnectedCb(ClientSafeHandle client, CionClientDisconnectedCb cb);
     }
 }
+
+
+

--- a/src/Tizen.Applications.Cion/Interop/Interop.CionConnectionResult.cs
+++ b/src/Tizen.Applications.Cion/Interop/Interop.CionConnectionResult.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications.Cion;
 
 using ErrorCode = Interop.Cion.ErrorCode;
@@ -24,10 +25,13 @@ internal static partial class Interop
 {
     internal static partial class CionConnectionResult
     {
-        [DllImport(Libraries.Cion, EntryPoint = "cion_connection_result_get_status")]
-        internal static extern ErrorCode CionConnectionResultGetStatus(IntPtr result, out ConnectionStatus status);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_connection_result_get_status", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionConnectionResultGetStatus(IntPtr result, out ConnectionStatus status);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_connection_result_get_reason")]
-        internal static extern ErrorCode CionConnectionResultGetReason(IntPtr result, out string reason);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_connection_result_get_reason", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionConnectionResultGetReason(IntPtr result, out string reason);
     }
 }
+
+
+

--- a/src/Tizen.Applications.Cion/Interop/Interop.CionGroup.cs
+++ b/src/Tizen.Applications.Cion/Interop/Interop.CionGroup.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications.Cion;
 
 using ErrorCode = Interop.Cion.ErrorCode;
@@ -33,37 +34,40 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void CionGroupLeftCb(string topicName, IntPtr peerInfo, IntPtr userData);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_group_create")]
-        internal static extern ErrorCode CionGroupCreate(out GroupSafeHandle group, string topicName, IntPtr security);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_group_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionGroupCreate(out GroupSafeHandle group, string topicName, IntPtr security);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_group_destroy")]
-        internal static extern ErrorCode CionGroupDestroy(IntPtr group);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_group_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionGroupDestroy(IntPtr group);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_group_subscribe")]
-        internal static extern ErrorCode CionGroupSubscribe(GroupSafeHandle group);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_group_subscribe", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionGroupSubscribe(GroupSafeHandle group);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_group_unsubscribe")]
-        internal static extern ErrorCode CionGroupUnsubscribe(GroupSafeHandle group);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_group_unsubscribe", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionGroupUnsubscribe(GroupSafeHandle group);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_group_publish")]
-        internal static extern ErrorCode CionGroupPublish(GroupSafeHandle group, PayloadSafeHandle data);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_group_publish", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionGroupPublish(GroupSafeHandle group, PayloadSafeHandle data);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_group_add_payload_received_cb")]
-        internal static extern ErrorCode CionGroupAddPayloadReceivedCb(GroupSafeHandle group, CionGroupPayloadReceivedCb cb, IntPtr userData);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_group_add_payload_received_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionGroupAddPayloadReceivedCb(GroupSafeHandle group, CionGroupPayloadReceivedCb cb, IntPtr userData);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_group_remove_payload_received_cb")]
-        internal static extern ErrorCode CionGroupRemovePayloadReceivedCb(GroupSafeHandle group, CionGroupPayloadReceivedCb cb);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_group_remove_payload_received_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionGroupRemovePayloadReceivedCb(GroupSafeHandle group, CionGroupPayloadReceivedCb cb);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_group_add_joined_cb")]
-        internal static extern ErrorCode CionGroupAddJoinedCb(GroupSafeHandle group, CionGroupJoinedCb cb, IntPtr userData);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_group_add_joined_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionGroupAddJoinedCb(GroupSafeHandle group, CionGroupJoinedCb cb, IntPtr userData);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_group_remove_joined_cb")]
-        internal static extern ErrorCode CionGroupRemoveJoinedCb(GroupSafeHandle group, CionGroupJoinedCb cb);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_group_remove_joined_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionGroupRemoveJoinedCb(GroupSafeHandle group, CionGroupJoinedCb cb);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_group_add_left_cb")]
-        internal static extern ErrorCode CionGroupAddLeftCb(GroupSafeHandle group, CionGroupLeftCb cb, IntPtr userData);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_group_add_left_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionGroupAddLeftCb(GroupSafeHandle group, CionGroupLeftCb cb, IntPtr userData);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_group_remove_left_cb")]
-        internal static extern ErrorCode CionGroupRemoveLeftCb(GroupSafeHandle group, CionGroupLeftCb cb);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_group_remove_left_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionGroupRemoveLeftCb(GroupSafeHandle group, CionGroupLeftCb cb);
     }
 }
+
+
+

--- a/src/Tizen.Applications.Cion/Interop/Interop.CionPayload.cs
+++ b/src/Tizen.Applications.Cion/Interop/Interop.CionPayload.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications.Cion;
 
 using ErrorCode = Interop.Cion.ErrorCode;
@@ -30,37 +31,40 @@ internal static partial class Interop
             File,
         }
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_payload_create")]
-        internal static extern ErrorCode CionPayloadCreate(out PayloadSafeHandle payload, PayloadType type);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_payload_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPayloadCreate(out PayloadSafeHandle payload, PayloadType type);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_payload_destroy")]
-        internal static extern ErrorCode CionPayloadDestroy(IntPtr payload);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_payload_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPayloadDestroy(IntPtr payload);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_payload_get_type")]
-        internal static extern ErrorCode CionPayloadGetType(IntPtr payload, out PayloadType type);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_payload_get_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPayloadGetType(IntPtr payload, out PayloadType type);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_payload_get_data")]
-        internal static extern ErrorCode CionPayloadGetData(PayloadSafeHandle payload, out IntPtr data, out int dataSize);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_payload_get_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPayloadGetData(PayloadSafeHandle payload, out IntPtr data, out int dataSize);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_payload_set_data")]
-        internal static extern ErrorCode CionPayloadSetData(PayloadSafeHandle payload, byte[] data, int dataSize);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_payload_set_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPayloadSetData(PayloadSafeHandle payload, byte[] data, int dataSize);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_payload_save_as_file")]
-        internal static extern ErrorCode CionPayloadSaveAsFile(PayloadSafeHandle payload, string path);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_payload_save_as_file", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPayloadSaveAsFile(PayloadSafeHandle payload, string path);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_payload_get_received_file_name")]
-        internal static extern ErrorCode CionPayloadGetReceivedFileName(PayloadSafeHandle payload, out string path);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_payload_get_received_file_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPayloadGetReceivedFileName(PayloadSafeHandle payload, out string path);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_payload_get_received_bytes")]
-        internal static extern ErrorCode CionPayloadGetReceivedBytes(PayloadSafeHandle payload, out UInt64 bytes);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_payload_get_received_bytes", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPayloadGetReceivedBytes(PayloadSafeHandle payload, out UInt64 bytes);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_payload_get_total_bytes")]
-        internal static extern ErrorCode CionPayloadGetTotalBytes(PayloadSafeHandle payload, out UInt64 bytes);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_payload_get_total_bytes", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPayloadGetTotalBytes(PayloadSafeHandle payload, out UInt64 bytes);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_payload_set_file_path")]
-        internal static extern ErrorCode CionPayloadSetFilePath(PayloadSafeHandle payload, string path);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_payload_set_file_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPayloadSetFilePath(PayloadSafeHandle payload, string path);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_payload_get_payload_id")]
-        internal static extern ErrorCode CionPayloadGetPayloadID(PayloadSafeHandle payload, out string id);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_payload_get_payload_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPayloadGetPayloadID(PayloadSafeHandle payload, out string id);
     }
 }
+
+
+

--- a/src/Tizen.Applications.Cion/Interop/Interop.CionPayloadAsyncResult.cs
+++ b/src/Tizen.Applications.Cion/Interop/Interop.CionPayloadAsyncResult.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications.Cion;
 
 using ErrorCode = Interop.Cion.ErrorCode;
@@ -24,13 +25,16 @@ internal static partial class Interop
 {
     internal static partial class CionPayloadAsyncResult
     {
-        [DllImport(Libraries.Cion, EntryPoint = "cion_payload_async_result_get_result")]
-        internal static extern ErrorCode CionPayloadAsyncResultGetResult(IntPtr result, out int code);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_payload_async_result_get_result", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPayloadAsyncResultGetResult(IntPtr result, out int code);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_payload_async_result_get_peer_info")]
-        internal static extern ErrorCode CionPayloadAsyncResultGetPeerInfo(IntPtr result, out IntPtr peerInfo);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_payload_async_result_get_peer_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPayloadAsyncResultGetPeerInfo(IntPtr result, out IntPtr peerInfo);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_payload_async_result_get_payload_id")]
-        internal static extern ErrorCode CionPayloadAsyncResultGetPayloadID(IntPtr result, out string payloadID);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_payload_async_result_get_payload_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPayloadAsyncResultGetPayloadID(IntPtr result, out string payloadID);
     }
 }
+
+
+

--- a/src/Tizen.Applications.Cion/Interop/Interop.CionPeerInfo.cs
+++ b/src/Tizen.Applications.Cion/Interop/Interop.CionPeerInfo.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications.Cion;
 
 using ErrorCode = Interop.Cion.ErrorCode;
@@ -24,34 +25,37 @@ internal static partial class Interop
 {
     internal static partial class CionPeerInfo
     {
-        [DllImport(Libraries.Cion, EntryPoint = "cion_peer_info_clone")]
-        internal static extern ErrorCode CionPeerInfoClone(IntPtr peerInfo, out PeerInfoSafeHandle peerInfoClone);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_peer_info_clone", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPeerInfoClone(IntPtr peerInfo, out PeerInfoSafeHandle peerInfoClone);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_peer_info_destroy")]
-        internal static extern ErrorCode CionPeerInfoDestroy(IntPtr peerInfo);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_peer_info_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPeerInfoDestroy(IntPtr peerInfo);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_peer_info_get_device_id")]
-        internal static extern ErrorCode CionPeerInfoGetDeviceId(PeerInfoSafeHandle peerInfo, out string deviceId);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_peer_info_get_device_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPeerInfoGetDeviceId(PeerInfoSafeHandle peerInfo, out string deviceId);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_peer_info_get_device_name")]
-        internal static extern ErrorCode CionPeerInfoGetDeviceName(PeerInfoSafeHandle peerInfo, out string deviceName);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_peer_info_get_device_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPeerInfoGetDeviceName(PeerInfoSafeHandle peerInfo, out string deviceName);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_peer_info_get_device_platform")]
-        internal static extern ErrorCode CionPeerInfoGetDevicePlatform(PeerInfoSafeHandle peerInfo, out string devicePlatform);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_peer_info_get_device_platform", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPeerInfoGetDevicePlatform(PeerInfoSafeHandle peerInfo, out string devicePlatform);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_peer_info_get_device_platform_version")]
-        internal static extern ErrorCode CionPeerInfoGetDevicePlatformVersion(PeerInfoSafeHandle peerInfo, out string devicePlatformVersion);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_peer_info_get_device_platform_version", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPeerInfoGetDevicePlatformVersion(PeerInfoSafeHandle peerInfo, out string devicePlatformVersion);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_peer_info_get_device_type")]
-        internal static extern ErrorCode CionPeerInfoGetDeviceType(PeerInfoSafeHandle peerInfo, out string deviceType);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_peer_info_get_device_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPeerInfoGetDeviceType(PeerInfoSafeHandle peerInfo, out string deviceType);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_peer_info_get_app_id")]
-        internal static extern ErrorCode CionPeerInfoGetAppId(PeerInfoSafeHandle peerInfo, out string appId);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_peer_info_get_app_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPeerInfoGetAppId(PeerInfoSafeHandle peerInfo, out string appId);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_peer_info_get_app_version")]
-        internal static extern ErrorCode CionPeerInfoGetAppVersion(PeerInfoSafeHandle peerInfo, out string appVersion);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_peer_info_get_app_version", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPeerInfoGetAppVersion(PeerInfoSafeHandle peerInfo, out string appVersion);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_peer_info_get_uuid")]
-        internal static extern ErrorCode CionPeerInfoGetUuid(PeerInfoSafeHandle peerInfo, out string uuid);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_peer_info_get_uuid", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionPeerInfoGetUuid(PeerInfoSafeHandle peerInfo, out string uuid);
     }
 }
+
+
+

--- a/src/Tizen.Applications.Cion/Interop/Interop.CionSecurity.cs
+++ b/src/Tizen.Applications.Cion/Interop/Interop.CionSecurity.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications.Cion;
 
 using ErrorCode = Interop.Cion.ErrorCode;
@@ -24,28 +25,31 @@ internal static partial class Interop
 {
     internal static partial class CionSecurity
     {
-        [DllImport(Libraries.Cion, EntryPoint = "cion_security_create")]
-        internal static extern ErrorCode CionSecurityCreate(out SecuritySafeHandle security);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_security_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionSecurityCreate(out SecuritySafeHandle security);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_security_destroy")]
-        internal static extern ErrorCode CionSecurityDestroy(IntPtr security);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_security_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionSecurityDestroy(IntPtr security);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_security_set_ca_path")]
-        internal static extern ErrorCode CionSecuritySetCaPath(SecuritySafeHandle peerInfo, string caPath);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_security_set_ca_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionSecuritySetCaPath(SecuritySafeHandle peerInfo, string caPath);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_security_set_cert_path")]
-        internal static extern ErrorCode CionSecuritySetCertPath(SecuritySafeHandle peerInfo, string certPath);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_security_set_cert_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionSecuritySetCertPath(SecuritySafeHandle peerInfo, string certPath);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_security_set_private_key_path")]
-        internal static extern ErrorCode CionSecuritySetPrivateKeyPath(SecuritySafeHandle peerInfo, string keyPath);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_security_set_private_key_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionSecuritySetPrivateKeyPath(SecuritySafeHandle peerInfo, string keyPath);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_security_get_ca_path")]
-        internal static extern ErrorCode CionSecurityGetCaPath(SecuritySafeHandle peerInfo, out string caPath);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_security_get_ca_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionSecurityGetCaPath(SecuritySafeHandle peerInfo, out string caPath);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_security_get_cert_path")]
-        internal static extern ErrorCode CionSecurityGetCertPath(SecuritySafeHandle peerInfo, out string certPath);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_security_get_cert_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionSecurityGetCertPath(SecuritySafeHandle peerInfo, out string certPath);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_security_get_private_key_path")]
-        internal static extern ErrorCode CionSecurityGetPrivateKeyPath(SecuritySafeHandle peerInfo, out string keyPath);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_security_get_private_key_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionSecurityGetPrivateKeyPath(SecuritySafeHandle peerInfo, out string keyPath);
     }
 }
+
+
+

--- a/src/Tizen.Applications.Cion/Interop/Interop.CionServer.cs
+++ b/src/Tizen.Applications.Cion/Interop/Interop.CionServer.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications.Cion;
 
 using ErrorCode = Interop.Cion.ErrorCode;
@@ -25,7 +26,7 @@ internal static partial class Interop
     internal static partial class CionServer
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool CionServerPeerInfoIterator(IntPtr peerInfo, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool CionServerPeerInfoIterator(IntPtr peerInfo, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void CionServerPayloadAsyncResultCb(IntPtr result, IntPtr userData);
@@ -48,61 +49,65 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void CionServerDisconnectedCb(string serviceName, IntPtr peerInfo, IntPtr userData);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_server_create")]
-        internal static extern ErrorCode CionServerCreate(out ServerSafeHandle server, string serviceName, string displayName, IntPtr security);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_server_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionServerCreate(out ServerSafeHandle server, string serviceName, string displayName, IntPtr security);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_server_destroy")]
-        internal static extern ErrorCode CionServerDestroy(IntPtr server);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_server_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionServerDestroy(IntPtr server);
         
-        [DllImport(Libraries.Cion, EntryPoint = "cion_server_listen")]
-        internal static extern ErrorCode CionServerListen(ServerSafeHandle server, CionServerConnectionRequestCb cb, IntPtr userData);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_server_listen", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionServerListen(ServerSafeHandle server, CionServerConnectionRequestCb cb, IntPtr userData);
         
-        [DllImport(Libraries.Cion, EntryPoint = "cion_server_stop")]
-        internal static extern ErrorCode CionServerStop(ServerSafeHandle server);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_server_stop", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionServerStop(ServerSafeHandle server);
         
-        [DllImport(Libraries.Cion, EntryPoint = "cion_server_accept")]
-        internal static extern ErrorCode CionServerAccept(ServerSafeHandle server, PeerInfoSafeHandle peerInfo);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_server_accept", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionServerAccept(ServerSafeHandle server, PeerInfoSafeHandle peerInfo);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_server_reject")]
-        internal static extern ErrorCode CionServerReject(ServerSafeHandle server, PeerInfoSafeHandle peerInfo, string reason);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_server_reject", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionServerReject(ServerSafeHandle server, PeerInfoSafeHandle peerInfo, string reason);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_server_disconnect")]
-        internal static extern ErrorCode CionServerDisconnect(ServerSafeHandle server, PeerInfoSafeHandle peerInfo);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_server_disconnect", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionServerDisconnect(ServerSafeHandle server, PeerInfoSafeHandle peerInfo);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_server_send_payload_async")]
-        internal static extern ErrorCode CionServerSendPayloadAsync(ServerSafeHandle server, PeerInfoSafeHandle peerInfo, PayloadSafeHandle payload, CionServerPayloadAsyncResultCb cb, IntPtr userData);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_server_send_payload_async", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionServerSendPayloadAsync(ServerSafeHandle server, PeerInfoSafeHandle peerInfo, PayloadSafeHandle payload, CionServerPayloadAsyncResultCb cb, IntPtr userData);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_server_foreach_connected_peer_info")]
-        internal static extern ErrorCode CionServerForeachConnectedPeerInfo(ServerSafeHandle server, CionServerPeerInfoIterator cb, IntPtr userData);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_server_foreach_connected_peer_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionServerForeachConnectedPeerInfo(ServerSafeHandle server, CionServerPeerInfoIterator cb, IntPtr userData);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_server_add_connection_result_cb")]
-        internal static extern ErrorCode CionServerAddConnectionResultCb(ServerSafeHandle server, CionServerConnectionResultCb cb, IntPtr userData);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_server_add_connection_result_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionServerAddConnectionResultCb(ServerSafeHandle server, CionServerConnectionResultCb cb, IntPtr userData);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_server_remove_connection_result_cb")]
-        internal static extern ErrorCode CionServerRemoveConnectionResultCb(ServerSafeHandle server, CionServerConnectionResultCb cb);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_server_remove_connection_result_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionServerRemoveConnectionResultCb(ServerSafeHandle server, CionServerConnectionResultCb cb);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_server_add_payload_received_cb")]
-        internal static extern ErrorCode CionServerAddPayloadReceivedCb(ServerSafeHandle server, CionServerPayloadReceivedCb cb, IntPtr userData);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_server_add_payload_received_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionServerAddPayloadReceivedCb(ServerSafeHandle server, CionServerPayloadReceivedCb cb, IntPtr userData);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_server_remove_payload_received_cb")]
-        internal static extern ErrorCode CionServerRemovePayloadReceivedCb(ServerSafeHandle server, CionServerPayloadReceivedCb cb, IntPtr userData);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_server_remove_payload_received_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionServerRemovePayloadReceivedCb(ServerSafeHandle server, CionServerPayloadReceivedCb cb, IntPtr userData);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_server_set_data_received_cb")]
-        internal static extern ErrorCode CionServerSetDataReceivedCb(ServerSafeHandle server, CionServerDataReceivedCb cb, IntPtr userData);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_server_set_data_received_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionServerSetDataReceivedCb(ServerSafeHandle server, CionServerDataReceivedCb cb, IntPtr userData);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_server_unset_data_received_cb")]
-        internal static extern ErrorCode CionServerUnsetDataReceivedCb(ServerSafeHandle server, CionServerDataReceivedCb cb);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_server_unset_data_received_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionServerUnsetDataReceivedCb(ServerSafeHandle server, CionServerDataReceivedCb cb);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_server_add_disconnected_cb")]
-        internal static extern ErrorCode CionServerAddDisconnectedCb(ServerSafeHandle server, CionServerDisconnectedCb cb, IntPtr userData);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_server_add_disconnected_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionServerAddDisconnectedCb(ServerSafeHandle server, CionServerDisconnectedCb cb, IntPtr userData);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_server_remove_disconnected_cb")]
-        internal static extern ErrorCode CionServerRemoveDisconnectedCb(ServerSafeHandle server, CionServerDisconnectedCb cb);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_server_remove_disconnected_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionServerRemoveDisconnectedCb(ServerSafeHandle server, CionServerDisconnectedCb cb);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_server_set_on_demand_launch_enabled")]
-        internal static extern ErrorCode CionServerSetOnDemandLaunchEnabled(ServerSafeHandle server, bool enable);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_server_set_on_demand_launch_enabled", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionServerSetOnDemandLaunchEnabled(ServerSafeHandle server, [MarshalAs(UnmanagedType.U1)] bool enable);
 
-        [DllImport(Libraries.Cion, EntryPoint = "cion_server_set_display_name")]
-        internal static extern ErrorCode CionServerSetDisplayName(ServerSafeHandle server, string displayName);
+        [LibraryImport(Libraries.Cion, EntryPoint = "cion_server_set_display_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CionServerSetDisplayName(ServerSafeHandle server, string displayName);
     }
 }
+
+
+
+

--- a/src/Tizen.Applications.Cion/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.Cion/Interop/Interop.Libraries.cs
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string Cion = "libcion.so.1";
     }
 }
+
+
+

--- a/src/Tizen.Applications.Common/Interop/Interop.AppCommon.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.AppCommon.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Tizen.Internals.Errors;
 using Tizen.Applications;
@@ -42,109 +43,112 @@ internal static partial class Interop
             PermissionDenied = Tizen.Internals.Errors.ErrorCode.PermissionDenied,
         }
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_get_id")]
-        internal static extern ErrorCode AppGetId(out string appId);
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_get_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppGetId(out string appId);
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_get_name")]
-        internal static extern ErrorCode AppGetName(out string name);
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_get_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppGetName(out string name);
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_get_resource_path")]
-        internal static extern string AppGetResourcePath();
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_get_resource_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string AppGetResourcePath();
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_get_data_path")]
-        internal static extern string AppGetDataPath();
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_get_data_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string AppGetDataPath();
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_get_cache_path")]
-        internal static extern string AppGetCachePath();
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_get_cache_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string AppGetCachePath();
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_get_shared_data_path")]
-        internal static extern string AppGetSharedDataPath();
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_get_shared_data_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string AppGetSharedDataPath();
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_get_shared_resource_path")]
-        internal static extern string AppGetSharedResourcePath();
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_get_shared_resource_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string AppGetSharedResourcePath();
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_get_shared_trusted_path")]
-        internal static extern string AppGetSharedTrustedPath();
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_get_shared_trusted_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string AppGetSharedTrustedPath();
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_get_tep_resource_path")]
-        internal static extern string AppGetTepResourcePath();
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_get_tep_resource_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string AppGetTepResourcePath();
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_get_external_cache_path")]
-        internal static extern string AppGetExternalCachePath();
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_get_external_cache_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string AppGetExternalCachePath();
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_get_external_data_path")]
-        internal static extern string AppGetExternalDataPath();
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_get_external_data_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string AppGetExternalDataPath();
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_get_external_shared_data_path")]
-        internal static extern string AppGetExternalSharedDataPath();
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_get_external_shared_data_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string AppGetExternalSharedDataPath();
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_get_common_data_path")]
-        internal static extern string AppGetCommonDataPath();
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_get_common_data_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string AppGetCommonDataPath();
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_get_common_cache_path")]
-        internal static extern string AppGetCommonCachePath();
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_get_common_cache_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string AppGetCommonCachePath();
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_get_common_shared_data_path")]
-        internal static extern string AppGetCommonSharedDataPath();
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_get_common_shared_data_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string AppGetCommonSharedDataPath();
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_get_common_shared_trusted_path")]
-        internal static extern string AppGetCommonSharedTrustedPath();
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_get_common_shared_trusted_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string AppGetCommonSharedTrustedPath();
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_get_version")]
-        internal static extern ErrorCode AppGetVersion(out string version);
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_get_version", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppGetVersion(out string version);
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_event_get_low_memory_status")]
-        internal static extern ErrorCode AppEventGetLowMemoryStatus(IntPtr handle, out LowMemoryStatus status);
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_event_get_low_memory_status", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppEventGetLowMemoryStatus(IntPtr handle, out LowMemoryStatus status);
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_event_get_low_battery_status")]
-        internal static extern ErrorCode AppEventGetLowBatteryStatus(IntPtr handle, out LowBatteryStatus status);
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_event_get_low_battery_status", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppEventGetLowBatteryStatus(IntPtr handle, out LowBatteryStatus status);
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_event_get_language")]
-        internal static extern ErrorCode AppEventGetLanguage(IntPtr handle, out string lang);
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_event_get_language", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppEventGetLanguage(IntPtr handle, out string lang);
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_event_get_region_format")]
-        internal static extern ErrorCode AppEventGetRegionFormat(IntPtr handle, out string region);
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_event_get_region_format", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppEventGetRegionFormat(IntPtr handle, out string region);
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_resource_manager_get")]
-        internal static extern ErrorCode AppResourceManagerGet(ResourceCategory category, string id, out string path);
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_resource_manager_get", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppResourceManagerGet(ResourceCategory category, string id, out string path);
 
-        [DllImport(Libraries.Application, EntryPoint = "app_resource_manager_get")]
-        internal static extern ErrorCode LegacyAppResourceManagerGet(ResourceCategory category, string id, out string path);
+        [LibraryImport(Libraries.Application, EntryPoint = "app_resource_manager_get", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode LegacyAppResourceManagerGet(ResourceCategory category, string id, out string path);
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_event_get_device_orientation")]
-        internal static extern ErrorCode AppEventGetDeviceOrientation(IntPtr handle, out DeviceOrientation orientation);
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_event_get_device_orientation", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppEventGetDeviceOrientation(IntPtr handle, out DeviceOrientation orientation);
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_event_get_suspended_state")]
-        internal static extern ErrorCode AppEventGetSuspendedState(IntPtr handle, out SuspendedState state);
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_event_get_suspended_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppEventGetSuspendedState(IntPtr handle, out SuspendedState state);
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_get_res_control_allowed_resource_path")]
-        internal static extern AppCommonErrorCode AppGetResControlAllowedResourcePath(string applicationId, out string path);
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_get_res_control_allowed_resource_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial AppCommonErrorCode AppGetResControlAllowedResourcePath(string applicationId, out string path);
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_get_res_control_global_resource_path")]
-        internal static extern AppCommonErrorCode AppGetResControlGlobalResourcePath(string applicationId, out string path);
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_get_res_control_global_resource_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial AppCommonErrorCode AppGetResControlGlobalResourcePath(string applicationId, out string path);
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_event_get_time_zone")]
-        internal static extern ErrorCode AppEventGetTimeZone(IntPtr handle, out string timeZone, out string timeZoneId);
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_event_get_time_zone", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppEventGetTimeZone(IntPtr handle, out string timeZone, out string timeZoneId);
         
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_watchdog_timer_enable")]
-        internal static extern AppCommonErrorCode AppWatchdogTimerEnable();
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_watchdog_timer_enable", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial AppCommonErrorCode AppWatchdogTimerEnable();
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_watchdog_timer_disable")]
-        internal static extern AppCommonErrorCode AppWatchdogTimerDisable();
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_watchdog_timer_disable", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial AppCommonErrorCode AppWatchdogTimerDisable();
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_watchdog_timer_kick")]
-        internal static extern AppCommonErrorCode AppWatchdogTimerKick();
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_watchdog_timer_kick", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial AppCommonErrorCode AppWatchdogTimerKick();
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_locale_manager_set_language")]
-        internal static extern AppCommonErrorCode AppLocaleManagerSetLanguage(string lang);
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_locale_manager_set_language", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial AppCommonErrorCode AppLocaleManagerSetLanguage(string lang);
         // int app_locale_manager_set_language(const char *lang)
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_locale_manager_get_language")]
-        internal static extern AppCommonErrorCode AppLocaleManagerGetLanguage(out IntPtr langPtr);
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_locale_manager_get_language", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial AppCommonErrorCode AppLocaleManagerGetLanguage(out IntPtr langPtr);
         // int app_locale_manager_get_language(char **lang)
 
-        [DllImport(Libraries.AppCommon, EntryPoint = "app_locale_manager_get_system_language")]
-        internal static extern AppCommonErrorCode AppLocaleManagerGetSystemLanguage(out IntPtr langPtr);
+        [LibraryImport(Libraries.AppCommon, EntryPoint = "app_locale_manager_get_system_language", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial AppCommonErrorCode AppLocaleManagerGetSystemLanguage(out IntPtr langPtr);
         // int app_locale_manager_get_system_language(char **lang)
     }
 }
+
+
+

--- a/src/Tizen.Applications.Common/Interop/Interop.AppControl.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.AppControl.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Tizen.Applications;
 
@@ -26,10 +27,10 @@ internal static partial class Interop
         internal const int AppStartedStatus = 1;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool ExtraDataCallback(IntPtr handle, string key, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool ExtraDataCallback(IntPtr handle, string key, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool AppMatchedCallback(IntPtr handle, string applicationId, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool AppMatchedCallback(IntPtr handle, string applicationId, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void ReplyCallback(IntPtr request, IntPtr reply, int result, IntPtr userData);
@@ -38,7 +39,7 @@ internal static partial class Interop
         internal delegate void ResultCallback(IntPtr request, int result, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool DefaultApplicationCallback(string applicationId, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool DefaultApplicationCallback(string applicationId, IntPtr userData);
 
         internal enum ErrorCode
         {
@@ -56,136 +57,140 @@ internal static partial class Interop
             TimedOut = Tizen.Internals.Errors.ErrorCode.TimedOut,
         }
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_create")]
-        internal static extern ErrorCode Create(out SafeAppControlHandle handle);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode Create(out SafeAppControlHandle handle);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_clone")]
-        internal static extern ErrorCode DangerousClone(out SafeAppControlHandle clone, IntPtr handle);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_clone", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode DangerousClone(out SafeAppControlHandle clone, IntPtr handle);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_get_app_id")]
-        internal static extern ErrorCode GetAppId(IntPtr app_control, out IntPtr app_id);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_get_app_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetAppId(IntPtr app_control, out IntPtr app_id);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_get_operation")]
-        internal static extern ErrorCode GetOperation(SafeAppControlHandle handle, out string operation);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_get_operation", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetOperation(SafeAppControlHandle handle, out string operation);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_set_operation")]
-        internal static extern ErrorCode SetOperation(SafeAppControlHandle handle, string operation);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_set_operation", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetOperation(SafeAppControlHandle handle, string operation);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_get_uri")]
-        internal static extern ErrorCode GetUri(SafeAppControlHandle handle, out string uri);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_get_uri", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetUri(SafeAppControlHandle handle, out string uri);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_set_uri")]
-        internal static extern ErrorCode SetUri(SafeAppControlHandle handle, string uri);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_set_uri", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetUri(SafeAppControlHandle handle, string uri);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_get_mime")]
-        internal static extern ErrorCode GetMime(SafeAppControlHandle handle, out string mime);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_get_mime", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetMime(SafeAppControlHandle handle, out string mime);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_set_mime")]
-        internal static extern ErrorCode SetMime(SafeAppControlHandle handle, string mime);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_set_mime", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetMime(SafeAppControlHandle handle, string mime);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_get_category")]
-        internal static extern ErrorCode GetCategory(SafeAppControlHandle handle, out string category);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_get_category", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetCategory(SafeAppControlHandle handle, out string category);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_set_category")]
-        internal static extern ErrorCode SetCategory(SafeAppControlHandle handle, string category);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_set_category", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetCategory(SafeAppControlHandle handle, string category);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_get_app_id")]
-        internal static extern ErrorCode GetAppId(SafeAppControlHandle handle, out string appId);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_get_app_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetAppId(SafeAppControlHandle handle, out string appId);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_set_app_id")]
-        internal static extern ErrorCode SetAppId(SafeAppControlHandle handle, string appId);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_set_app_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetAppId(SafeAppControlHandle handle, string appId);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_set_launch_mode")]
-        internal static extern ErrorCode SetLaunchMode(SafeAppControlHandle handle, int mode);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_set_launch_mode", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetLaunchMode(SafeAppControlHandle handle, int mode);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_get_launch_mode")]
-        internal static extern ErrorCode GetLaunchMode(SafeAppControlHandle handle, out int mode);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_get_launch_mode", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetLaunchMode(SafeAppControlHandle handle, out int mode);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_get_caller")]
-        internal static extern ErrorCode GetCaller(SafeAppControlHandle handle, out string caller);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_get_caller", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetCaller(SafeAppControlHandle handle, out string caller);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_is_reply_requested")]
-        internal static extern ErrorCode IsReplyRequested(SafeAppControlHandle handle, out bool requested);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_is_reply_requested", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode IsReplyRequested(SafeAppControlHandle handle, [MarshalAs(UnmanagedType.U1)] out bool requested);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_add_extra_data")]
-        internal static extern ErrorCode AddExtraData(SafeAppControlHandle handle, string key, string value);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_add_extra_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AddExtraData(SafeAppControlHandle handle, string key, string value);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_remove_extra_data")]
-        internal static extern ErrorCode RemoveExtraData(SafeAppControlHandle handle, string key);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_remove_extra_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode RemoveExtraData(SafeAppControlHandle handle, string key);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_get_extra_data")]
-        internal static extern ErrorCode GetExtraData(SafeAppControlHandle handle, string key, out string value);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_get_extra_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetExtraData(SafeAppControlHandle handle, string key, out string value);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_add_extra_data_array")]
-        internal static extern ErrorCode AddExtraDataArray(SafeAppControlHandle handle, string key, string[] value, int length);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_add_extra_data_array", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AddExtraDataArray(SafeAppControlHandle handle, string key, string[] value, int length);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_get_extra_data_array")]
-        internal static extern ErrorCode GetExtraDataArray(SafeAppControlHandle handle, string key, out IntPtr value, out int length);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_get_extra_data_array", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetExtraDataArray(SafeAppControlHandle handle, string key, out IntPtr value, out int length);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_is_extra_data_array")]
-        internal static extern ErrorCode IsExtraDataArray(SafeAppControlHandle handle, string key, out bool array);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_is_extra_data_array", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode IsExtraDataArray(SafeAppControlHandle handle, string key, [MarshalAs(UnmanagedType.U1)] out bool array);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_destroy")]
-        internal static extern ErrorCode DangerousDestroy(IntPtr handle);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode DangerousDestroy(IntPtr handle);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_foreach_extra_data")]
-        internal static extern ErrorCode ForeachExtraData(SafeAppControlHandle handle, ExtraDataCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_foreach_extra_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ForeachExtraData(SafeAppControlHandle handle, ExtraDataCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_foreach_app_matched")]
-        internal static extern ErrorCode ForeachAppMatched(SafeAppControlHandle handle, AppMatchedCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_foreach_app_matched", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ForeachAppMatched(SafeAppControlHandle handle, AppMatchedCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_send_launch_request")]
-        internal static extern ErrorCode SendLaunchRequest(SafeAppControlHandle handle, ReplyCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_send_launch_request", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SendLaunchRequest(SafeAppControlHandle handle, ReplyCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_send_terminate_request")]
-        internal static extern ErrorCode SendTerminateRequest(SafeAppControlHandle handle);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_send_terminate_request", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SendTerminateRequest(SafeAppControlHandle handle);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_reply_to_launch_request")]
-        internal static extern ErrorCode ReplyToLaunchRequest(SafeAppControlHandle reply, SafeAppControlHandle request, int result);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_reply_to_launch_request", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ReplyToLaunchRequest(SafeAppControlHandle reply, SafeAppControlHandle request, int result);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_enable_app_started_result_event")]
-        internal static extern ErrorCode EnableAppStartedResultEvent(SafeAppControlHandle handle);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_enable_app_started_result_event", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode EnableAppStartedResultEvent(SafeAppControlHandle handle);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_send_launch_request_async")]
-        internal static extern ErrorCode SendLaunchRequestAsync(SafeAppControlHandle handle, ResultCallback resultCallback, ReplyCallback replyCallback, IntPtr userData);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_send_launch_request_async", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SendLaunchRequestAsync(SafeAppControlHandle handle, ResultCallback resultCallback, ReplyCallback replyCallback, IntPtr userData);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_set_component_id")]
-        internal static extern ErrorCode SetComponentId(SafeAppControlHandle handle, string componentId);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_set_component_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetComponentId(SafeAppControlHandle handle, string componentId);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_get_component_id")]
-        internal static extern ErrorCode GetComponentId(SafeAppControlHandle handle, out string componentId);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_get_component_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetComponentId(SafeAppControlHandle handle, out string componentId);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_set_auto_restart")]
-        internal static extern ErrorCode SetAutoRestart(SafeAppControlHandle handle);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_set_auto_restart", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetAutoRestart(SafeAppControlHandle handle);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_send_launch_request_with_timeout")]
-        internal static extern ErrorCode SendLaunchRequestWithTimeout(SafeAppControlHandle handle, uint timeout, ReplyCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_send_launch_request_with_timeout", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SendLaunchRequestWithTimeout(SafeAppControlHandle handle, uint timeout, ReplyCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_foreach_default_application")]
-        internal static extern ErrorCode ForeachDefaultApplication(DefaultApplicationCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_foreach_default_application", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ForeachDefaultApplication(DefaultApplicationCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_set_window_position")]
-        internal static extern ErrorCode SetWindowPosition(SafeAppControlHandle handle, int x, int y, int w, int h);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_set_window_position", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetWindowPosition(SafeAppControlHandle handle, int x, int y, int w, int h);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_get_window_position")]
-        internal static extern ErrorCode GetWindowPosition(SafeAppControlHandle handle, out int x, out int y, out int w, out int h);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_get_window_position", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetWindowPosition(SafeAppControlHandle handle, out int x, out int y, out int w, out int h);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_unset_auto_restart")]
-        internal static extern ErrorCode UnsetAutoRestart();
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_unset_auto_restart", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode UnsetAutoRestart();
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_set_screen_name")]
-        internal static extern ErrorCode SetScreenName(SafeAppControlHandle handle, string screen_name);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_set_screen_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetScreenName(SafeAppControlHandle handle, string screen_name);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_get_screen_name")]
-        internal static extern ErrorCode GetScreenName(SafeAppControlHandle handle, out string screen_name);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_get_screen_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetScreenName(SafeAppControlHandle handle, out string screen_name);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_set_defapp")]
-        internal static extern ErrorCode SetDefaultApplication(SafeAppControlHandle handle, string appId);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_set_defapp", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetDefaultApplication(SafeAppControlHandle handle, string appId);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_unset_defapp")]
-        internal static extern ErrorCode UnsetDefaultApplication(string appId);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_unset_defapp", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode UnsetDefaultApplication(string appId);
 
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_export_as_bundle")]
-        internal static extern ErrorCode ExportAsBundle(SafeAppControlHandle handle, out IntPtr bundle);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_export_as_bundle", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ExportAsBundle(SafeAppControlHandle handle, out IntPtr bundle);
     }
 }
+
+
+
+

--- a/src/Tizen.Applications.Common/Interop/Interop.AppCoreUI.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.AppCoreUI.cs
@@ -16,12 +16,16 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
     internal static partial class AppCoreUI
     {
-        [DllImport(Libraries.AppCoreUI, EntryPoint = "app_core_ui_base_get_tizen_glib_context", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr GetTizenGlibContext();
+        [LibraryImport(Libraries.AppCoreUI, EntryPoint = "app_core_ui_base_get_tizen_glib_context", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr GetTizenGlibContext();
     }
 }
+
+
+

--- a/src/Tizen.Applications.Common/Interop/Interop.ApplicationManager.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.ApplicationManager.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Tizen.Internals;
 
@@ -81,8 +82,8 @@ internal static partial class Interop
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void AppManagerLifecycleStateChangedCallback(string appId, int pid, AppLifecycleState state, bool hasFocus, IntPtr userData);
-        //void (*app_manager_lifecycle_state_changed_cb)(const char *app_id, pid_t pid, app_manager_lifecycle_state_e state, bool has_focus, void *user_data)
+        internal delegate void AppManagerLifecycleStateChangedCallback(string appId, int pid, AppLifecycleState state, [MarshalAs(UnmanagedType.U1)] bool hasFocus, IntPtr userData);
+        //void (*app_manager_lifecycle_state_changed_cb)(const char *app_id, pid_t pid, app_manager_lifecycle_state_e state, [MarshalAs(UnmanagedType.U1)] bool has_focus, void *user_data)
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void AppManagerEventCallback(string appType, string appId, AppManagerEventType eventType, AppManagerEventState eventState, IntPtr eventHandle, IntPtr userData);
@@ -94,312 +95,312 @@ internal static partial class Interop
         //void(* app_manager_app_context_event_cb)(app_context_h app_context, app_context_event_e event, void *user_data)
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool AppManagerAppInfoCallback(IntPtr handle, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool AppManagerAppInfoCallback(IntPtr handle, IntPtr userData);
         //bool(* app_manager_app_info_cb )(app_info_h app_info, void *user_data)
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool AppManagerAppContextCallback(IntPtr handle, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool AppManagerAppContextCallback(IntPtr handle, IntPtr userData);
         //bool(* app_manager_app_context_cb)(app_context_h app_context, void *user_data)
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool AppInfoFilterCallback(IntPtr handle, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool AppInfoFilterCallback(IntPtr handle, IntPtr userData);
         //bool(* app_info_filter_cb )(app_info_h app_info, void *user_data)
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool AppInfoMetadataCallback(string key, string value, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool AppInfoMetadataCallback(string key, string value, IntPtr userData);
         //bool(* app_info_metadata_cb )(const char *metadata_key, const char *metadata_value, void *user_data)
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool AppInfoCategoryCallback(string category, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool AppInfoCategoryCallback(string category, IntPtr userData);
         //bool (*app_info_category_cb) (const char *category, void *user_data)
 
-        internal delegate bool AppInfoResControlCallback(string resType, string minResVersion, string maxResVersion, string autoClose, IntPtr userUdata);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool AppInfoResControlCallback(string resType, string minResVersion, string maxResVersion, string autoClose, IntPtr userUdata);
         //bool (*app_info_res_control_cb) (const char *res_type, const char *min_res_version, const char *max_res_version, const char *auto_close, void *user_data);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_set_app_context_event_cb")]
-        internal static extern ErrorCode AppManagerSetAppContextEvent(AppManagerAppContextEventCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_set_app_context_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerSetAppContextEvent(AppManagerAppContextEventCallback callback, IntPtr userData);
         //int app_manager_set_app_context_event_cb( app_manager_app_context_event_cb callback, void * user_data)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_unset_app_context_event_cb")]
-        internal static extern void AppManagerUnSetAppContextEvent();
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_unset_app_context_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void AppManagerUnSetAppContextEvent();
         //void app_manager_unset_app_context_event_cb (void);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_set_lifecycle_state_changed_cb")]
-        internal static extern ErrorCode AppManagerSetLifecycleStateChangedCb(AppManagerLifecycleStateChangedCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_set_lifecycle_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerSetLifecycleStateChangedCb(AppManagerLifecycleStateChangedCallback callback, IntPtr userData);
         //int app_manager_set_lifecycle_state_changed_cb(app_manager_lifecycle_state_changed_cb callback, void *user_data)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_unset_lifecycle_state_changed_cb")]
-        internal static extern void AppManagerUnsetLifecycleStateChangedCb();
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_unset_lifecycle_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void AppManagerUnsetLifecycleStateChangedCb();
         //void app_manager_unset_lifecycle_state_changed_cb(void)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_add_lifecycle_state_changed_cb")]
-        internal static extern ErrorCode AppManagerAddLifecycleStateChangedCb(
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_add_lifecycle_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerAddLifecycleStateChangedCb(
             AppManagerLifecycleStateChangedCallback callback, IntPtr userData, out IntPtr handle);
         // int app_manager_add_lifecycle_state_changed_cb(app_manager_lifecycle_state_changed_cb callback,
         // void *user_data, app_manager_lifecycle_noti_h *handle)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_remove_lifecycle_state_changed_cb")]
-        internal static extern ErrorCode AppManagerRemoveLifecycleStateChangedCb(IntPtr handle);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_remove_lifecycle_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerRemoveLifecycleStateChangedCb(IntPtr handle);
         // int app_manager_remove_lifecycle_state_changed_cb(app_manager_lifecycle_noti_h handle)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_foreach_running_app_context")]
-        internal static extern ErrorCode AppManagerForeachRunningAppContext(AppManagerAppContextCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_foreach_running_app_context", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerForeachRunningAppContext(AppManagerAppContextCallback callback, IntPtr userData);
         //int app_manager_foreach_running_app_context(app_manager_app_context_cb callback, void *user_data)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_foreach_app_context")]
-        internal static extern ErrorCode AppManagerForeachAppContext(AppManagerAppContextCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_foreach_app_context", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerForeachAppContext(AppManagerAppContextCallback callback, IntPtr userData);
         //int app_manager_foreach_app_context(app_manager_app_context_cb callback, void *user_data)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_get_app_context")]
-        internal static extern ErrorCode AppManagerGetAppContext(string applicationId, out IntPtr handle);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_get_app_context", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerGetAppContext(string applicationId, out IntPtr handle);
         //int app_manager_get_app_context(const char* app_id, app_context_h *app_context);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_get_app_id")]
-        internal static extern ErrorCode AppManagerGetAppId(int processId, out string applicationId);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_get_app_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerGetAppId(int processId, out string applicationId);
         //int app_manager_get_app_id (pid_t pid, char **appid);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_is_running")]
-        internal static extern ErrorCode AppManagerIsRunning(string applicationId, out bool running);
-        //int app_manager_is_running (const char *appid, bool *running);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_is_running", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerIsRunning(string applicationId, [MarshalAs(UnmanagedType.U1)] out bool running);
+        //int app_manager_is_running (const char *appid, [MarshalAs(UnmanagedType.U1)] bool *running);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_resume_app")]
-        internal static extern ErrorCode AppManagerResumeApp(IntPtr handle);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_resume_app", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerResumeApp(IntPtr handle);
         //int app_manager_resume_app (app_context_h handle);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_request_terminate_bg_app")]
-        internal static extern ErrorCode AppManagerRequestTerminateBgApp(IntPtr handle);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_request_terminate_bg_app", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerRequestTerminateBgApp(IntPtr handle);
         //int app_manager_request_terminate_bg_app (app_context_h handle);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_foreach_app_info")]
-        internal static extern ErrorCode AppManagerForeachAppInfo(AppManagerAppInfoCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_foreach_app_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerForeachAppInfo(AppManagerAppInfoCallback callback, IntPtr userData);
         //int app_manager_foreach_app_info(app_manager_app_info_cb callback, void *user_data)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_get_app_info")]
-        internal static extern ErrorCode AppManagerGetAppInfo(string applicationId, out IntPtr handle);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_get_app_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerGetAppInfo(string applicationId, out IntPtr handle);
         //int app_manager_get_app_info(const char * app_id, app_info_h * app_info)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_get_shared_data_path")]
-        internal static extern ErrorCode AppManagerGetSharedDataPath(string applicationId, out string path);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_get_shared_data_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerGetSharedDataPath(string applicationId, out string path);
         //int app_manager_get_shared_data_path (const char *appid, char **path);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_get_shared_resource_path")]
-        internal static extern ErrorCode AppManagerGetSharedResourcePath(string applicationId, out string path);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_get_shared_resource_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerGetSharedResourcePath(string applicationId, out string path);
         //int app_manager_get_shared_resource_path (const char *appid, char **path);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_get_shared_trusted_path")]
-        internal static extern ErrorCode AppManagerGetSharedTrustedPath(string applicationId, out string path);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_get_shared_trusted_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerGetSharedTrustedPath(string applicationId, out string path);
         //int app_manager_get_shared_trusted_path (const char *appid, char **path);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_get_common_shared_data_path")]
-        internal static extern ErrorCode AppManagerGetCommonSharedDataPath(string applicationId, out string path);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_get_common_shared_data_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerGetCommonSharedDataPath(string applicationId, out string path);
         //int app_manager_get_common_shared_data_path (const char *appid, char **path);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_get_common_shared_trusted_path")]
-        internal static extern ErrorCode AppManagerGetCommonSharedTrustedPath(string applicationId, out string path);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_get_common_shared_trusted_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerGetCommonSharedTrustedPath(string applicationId, out string path);
         //int app_manager_get_common_shared_trusted_path (const char *appid, char **path);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_get_external_shared_data_path")]
-        internal static extern ErrorCode AppManagerGetExternalSharedDataPath(string applicationId, out string path);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_get_external_shared_data_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerGetExternalSharedDataPath(string applicationId, out string path);
         //int app_manager_get_external_shared_data_path (const char *appid, char **path);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_event_create")]
-        internal static extern ErrorCode AppManagerEventCreate(out IntPtr handle);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_event_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerEventCreate(out IntPtr handle);
         //int app_manager_event_create (app_manager_event_h *handle);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_event_set_status")]
-        internal static extern ErrorCode AppManagerEventSetStatus(IntPtr handle, AppManagerEventStatusType statusType);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_event_set_status", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerEventSetStatus(IntPtr handle, AppManagerEventStatusType statusType);
         //int app_manager_event_set_status (app_manager_event_h handle, int status_type);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_set_event_cb")]
-        internal static extern ErrorCode AppManagerSetEventCallback(IntPtr handle, AppManagerEventCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_set_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerSetEventCallback(IntPtr handle, AppManagerEventCallback callback, IntPtr userData);
         //int app_manager_set_event_cb (app_manager_event_h handle, app_manager_event_cb callback, void *user_data);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_unset_event_cb")]
-        internal static extern ErrorCode AppManagerUnSetEventCallback(IntPtr handle);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_unset_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerUnSetEventCallback(IntPtr handle);
         //int app_manager_unset_event_cb (app_manager_event_h handle);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_event_destroy")]
-        internal static extern ErrorCode AppManagerEventDestroy(IntPtr handle);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_event_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerEventDestroy(IntPtr handle);
         //int app_manager_event_destroy (app_manager_event_h handle);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_terminate_app")]
-        internal static extern ErrorCode AppManagerTerminateApp(IntPtr handle);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_terminate_app", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerTerminateApp(IntPtr handle);
         //int app_manager_terminate_app (app_context_h app_context);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_terminate_app_without_restarting")]
-        internal static extern ErrorCode AppManagerTerminateAppWithoutRestarting(IntPtr handle);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_terminate_app_without_restarting", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerTerminateAppWithoutRestarting(IntPtr handle);
         //int app_manager_terminate_app_without_restarting (app_context_h app_context);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_get_app_context_by_instance_id")]
-        internal static extern ErrorCode AppManagerGetAppContextByInstanceId(string applicationId, string instanceId, out IntPtr handle);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_get_app_context_by_instance_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerGetAppContextByInstanceId(string applicationId, string instanceId, out IntPtr handle);
         //int app_manager_get_app_context_by_instance_id (const char *app_id, const char *instance_id, app_context_h *app_context);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_attach_window")]
-        internal static extern ErrorCode AppManagerAttachWindow(string parentAppId, string childAppId);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_attach_window", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerAttachWindow(string parentAppId, string childAppId);
         //int app_manager_attach_window(const char *parent_app_id, const char *child_app_id);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_detach_window")]
-        internal static extern ErrorCode AppManagerDetachWindow(string applicationId);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_detach_window", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerDetachWindow(string applicationId);
         //int app_manager_detach_window(const char *app_id);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_attach_window_below")]
-        internal static extern ErrorCode AppManagerAttachWindowBelow(string parentAppId, string childAppId);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_attach_window_below", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerAttachWindowBelow(string parentAppId, string childAppId);
         //int app_manager_attach_window_below(const char *parent_app_id, const char *child_app_id);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_request_remount_subsession")]
-        internal static extern ErrorCode AppManagerRequestRemountSubsession(string subsessionId);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_request_remount_subsession", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppManagerRequestRemountSubsession(string subsessionId);
         //int app_manager_request_remount_subsession(const char *subsession_id);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_context_destroy")]
-        internal static extern ErrorCode AppContextDestroy(IntPtr handle);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_context_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppContextDestroy(IntPtr handle);
         //int app_context_destroy(app_context_h app_context)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_context_get_app_id")]
-        internal static extern ErrorCode AppContextGetAppId(IntPtr handle, out string applicationId);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_context_get_app_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppContextGetAppId(IntPtr handle, out string applicationId);
         //int app_context_get_app_id(app_context_h app_context, char **app_id)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_context_get_package_id")]
-        internal static extern ErrorCode AppContextGetPackageId(IntPtr handle, out string packageId);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_context_get_package_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppContextGetPackageId(IntPtr handle, out string packageId);
         //int app_context_get_package_id(app_context_h app_context, char **package_id)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_context_get_pid")]
-        internal static extern ErrorCode AppContextGetPid(IntPtr handle, out int processId);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_context_get_pid", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppContextGetPid(IntPtr handle, out int processId);
         //int app_context_get_pid (app_context_h app_context, pid_t *pid)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_context_get_app_state")]
-        internal static extern ErrorCode AppContextGetAppState(IntPtr handle, out int state);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_context_get_app_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppContextGetAppState(IntPtr handle, out int state);
         //int app_context_get_app_state (app_context_h app_context, app_state_e *state)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_context_is_terminated")]
-        internal static extern ErrorCode AppContextIsTerminated(IntPtr handle, out bool terminated);
-        //int app_context_is_terminated (app_context_h app_context, bool *terminated);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_context_is_terminated", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppContextIsTerminated(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool terminated);
+        //int app_context_is_terminated (app_context_h app_context, [MarshalAs(UnmanagedType.U1)] bool *terminated);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_context_is_equal")]
-        internal static extern ErrorCode AppContextIsEqual(IntPtr first, IntPtr second, out bool equal);
-        //int app_context_is_equal (app_context_h lhs, app_context_h rhs, bool *equal);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_context_is_equal", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppContextIsEqual(IntPtr first, IntPtr second, [MarshalAs(UnmanagedType.U1)] out bool equal);
+        //int app_context_is_equal (app_context_h lhs, app_context_h rhs, [MarshalAs(UnmanagedType.U1)] bool *equal);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_context_is_sub_app")]
-        internal static extern ErrorCode AppContextIsSubApp(IntPtr handle, out bool is_sub_app);
-        //int app_context_is_sub_app (app_context_h app_context, bool *is_sub_app);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_context_is_sub_app", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppContextIsSubApp(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool is_sub_app);
+        //int app_context_is_sub_app (app_context_h app_context, [MarshalAs(UnmanagedType.U1)] bool *is_sub_app);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_context_clone")]
-        internal static extern ErrorCode AppContextClone(out IntPtr destination, IntPtr source);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_context_clone", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppContextClone(out IntPtr destination, IntPtr source);
         //int app_context_clone (app_context_h *clone, app_context_h app_context);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_create")]
-        internal static extern ErrorCode AppInfoCreate(string applicationId, out IntPtr handle);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoCreate(string applicationId, out IntPtr handle);
         //int app_info_create (const char *app_id, app_info_h *app_info);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_destroy")]
-        internal static extern ErrorCode AppInfoDestroy(IntPtr handle);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoDestroy(IntPtr handle);
         //int app_info_destroy (app_info_h app_info);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_get_app_id")]
-        internal static extern ErrorCode AppInfoGetAppId(IntPtr handle, out string applicationId);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_get_app_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoGetAppId(IntPtr handle, out string applicationId);
         //int app_info_get_app_id (app_info_h app_info, char **app_id);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_get_exec")]
-        internal static extern ErrorCode AppInfoGetExec(IntPtr handle, out string exec);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_get_exec", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoGetExec(IntPtr handle, out string exec);
         //int app_info_get_exec (app_info_h app_info, char **exec);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_get_label")]
-        internal static extern ErrorCode AppInfoGetLabel(IntPtr handle, out string label);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_get_label", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoGetLabel(IntPtr handle, out string label);
         //int app_info_get_label (app_info_h app_info, char **label);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_get_localed_label")]
-        internal static extern ErrorCode AppInfoGetLocaledLabel(string applicationId, string locale, out string label);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_get_localed_label", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoGetLocaledLabel(string applicationId, string locale, out string label);
         //int app_info_get_localed_label (const char *app_id, const char *locale, char **label);
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_get_icon")]
-        internal static extern ErrorCode AppInfoGetIcon(IntPtr handle, out string path);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_get_icon", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoGetIcon(IntPtr handle, out string path);
         //int app_info_get_icon (app_info_h app_info, char **path)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_get_package")]
-        internal static extern ErrorCode AppInfoGetPackage(IntPtr handle, out string package);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_get_package", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoGetPackage(IntPtr handle, out string package);
         //int app_info_get_package (app_info_h app_info, char **package)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_get_type")]
-        internal static extern ErrorCode AppInfoGetType(IntPtr handle, out string type);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_get_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoGetType(IntPtr handle, out string type);
         //int app_info_get_type (app_info_h app_info, char **type)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_get_app_component_type")]
-        internal static extern ErrorCode AppInfoGetAppComponentType(IntPtr handle, out AppInfoAppComponentType type);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_get_app_component_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoGetAppComponentType(IntPtr handle, out AppInfoAppComponentType type);
         //int app_info_get_app_component_type(app_info_h app_info, app_info_app_component_type_e *type)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_foreach_metadata")]
-        internal static extern ErrorCode AppInfoForeachMetadata(IntPtr handle, AppInfoMetadataCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_foreach_metadata", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoForeachMetadata(IntPtr handle, AppInfoMetadataCallback callback, IntPtr userData);
         //int app_info_foreach_metadata(app_info_h app_info, app_info_metadata_cb callback, void *user_data)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_is_nodisplay")]
-        internal static extern ErrorCode AppInfoIsNodisplay(IntPtr handle, out bool noDisplay);
-        //int app_info_is_nodisplay (app_info_h app_info, bool *nodisplay)
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_is_nodisplay", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoIsNodisplay(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool noDisplay);
+        //int app_info_is_nodisplay (app_info_h app_info, [MarshalAs(UnmanagedType.U1)] bool *nodisplay)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_is_equal")]
-        internal static extern ErrorCode AppInfoIsEqual(IntPtr first, IntPtr second, out bool equal);
-        //int app_info_is_equal (app_info_h lhs, app_info_h rhs, bool *equal)
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_is_equal", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoIsEqual(IntPtr first, IntPtr second, [MarshalAs(UnmanagedType.U1)] out bool equal);
+        //int app_info_is_equal (app_info_h lhs, app_info_h rhs, [MarshalAs(UnmanagedType.U1)] bool *equal)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_is_enabled")]
-        internal static extern ErrorCode AppInfoIsEnabled(IntPtr handle, out bool enabled);
-        //int app_info_is_enabled (app_info_h app_info, bool *enabled)
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_is_enabled", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoIsEnabled(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool enabled);
+        //int app_info_is_enabled (app_info_h app_info, [MarshalAs(UnmanagedType.U1)] bool *enabled)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_is_onboot")]
-        internal static extern ErrorCode AppInfoIsOnBoot(IntPtr handle, out bool onBoot);
-        //int app_info_is_onboot (app_info_h app_info, bool *onboot)
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_is_onboot", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoIsOnBoot(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool onBoot);
+        //int app_info_is_onboot (app_info_h app_info, [MarshalAs(UnmanagedType.U1)] bool *onboot)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_is_preload")]
-        internal static extern ErrorCode AppInfoIsPreLoad(IntPtr handle, out bool preLoaded);
-        //int app_info_is_preload (app_info_h app_info, bool *preload)
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_is_preload", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoIsPreLoad(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool preLoaded);
+        //int app_info_is_preload (app_info_h app_info, [MarshalAs(UnmanagedType.U1)] bool *preload)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_clone")]
-        internal static extern ErrorCode AppInfoClone(out IntPtr destination, IntPtr source);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_clone", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoClone(out IntPtr destination, IntPtr source);
         //int app_info_clone(app_info_h * clone, app_info_h app_info)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_foreach_category")]
-        internal static extern ErrorCode AppInfoForeachCategory(IntPtr handle, AppInfoCategoryCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_foreach_category", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoForeachCategory(IntPtr handle, AppInfoCategoryCallback callback, IntPtr userData);
         //int app_info_foreach_category(app_info_h app_info, app_info_category_cb callback, void *user_data)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_filter_create")]
-        internal static extern ErrorCode AppInfoFilterCreate(out IntPtr handle);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_filter_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoFilterCreate(out IntPtr handle);
         //int app_info_filter_create(app_info_filter_h * handle)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_filter_destroy")]
-        internal static extern ErrorCode AppInfoFilterDestroy(IntPtr handle);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_filter_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoFilterDestroy(IntPtr handle);
         //int app_info_filter_destroy(app_info_filter_h handle)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_filter_add_bool")]
-        internal static extern ErrorCode AppInfoFilterAddBool(IntPtr handle, string property, bool value);
-        //int app_info_filter_add_bool(app_info_filter_h handle, const char *property, const bool value)
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_filter_add_bool", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoFilterAddBool(IntPtr handle, string property, [MarshalAs(UnmanagedType.U1)] bool value);
+        //int app_info_filter_add_bool(app_info_filter_h handle, const char *property, const [MarshalAs(UnmanagedType.U1)] bool value)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_filter_add_string")]
-        internal static extern ErrorCode AppInfoFilterAddString(IntPtr handle, string property, string value);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_filter_add_string", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoFilterAddString(IntPtr handle, string property, string value);
         //int app_info_filter_add_string(app_info_filter_h handle, const char *property, const char *value)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_filter_count_appinfo")]
-        internal static extern ErrorCode AppInfoFilterCountAppinfo(IntPtr handle, out int count);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_filter_count_appinfo", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoFilterCountAppinfo(IntPtr handle, out int count);
         //int app_info_filter_count_appinfo(app_info_filter_h handle, int *count)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_filter_foreach_appinfo")]
-        internal static extern ErrorCode AppInfoFilterForeachAppinfo(IntPtr handle, AppInfoFilterCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_filter_foreach_appinfo", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoFilterForeachAppinfo(IntPtr handle, AppInfoFilterCallback callback, IntPtr userData);
         //int app_info_filter_foreach_appinfo(app_info_filter_h handle, app_info_filter_cb callback, void * user_data)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_metadata_filter_create")]
-        internal static extern ErrorCode AppInfoMetadataFilterCreate(out IntPtr handle);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_metadata_filter_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoMetadataFilterCreate(out IntPtr handle);
         //int app_info_metadata_filter_create (app_info_metadata_filter_h *handle)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_metadata_filter_destroy")]
-        internal static extern ErrorCode AppInfoMetadataFilterDestroy(IntPtr handle);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_metadata_filter_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoMetadataFilterDestroy(IntPtr handle);
         //int app_info_metadata_filter_destroy (app_info_metadata_filter_h handle)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_metadata_filter_add")]
-        internal static extern ErrorCode AppInfoMetadataFilterAdd(IntPtr handle, string key, string value);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_metadata_filter_add", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoMetadataFilterAdd(IntPtr handle, string key, string value);
         //int app_info_metadata_filter_add (app_info_metadata_filter_h handle, const char *key, const char *value)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_metadata_filter_foreach")]
-        internal static extern ErrorCode AppInfoMetadataFilterForeach(IntPtr handle, AppInfoFilterCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_metadata_filter_foreach", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoMetadataFilterForeach(IntPtr handle, AppInfoFilterCallback callback, IntPtr userData);
         //int app_info_metadata_filter_foreach (app_info_metadata_filter_h handle, app_info_filter_cb callback, void *user_data)
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_info_foreach_res_control")]
-        internal static extern ErrorCode AppInfoForeachResControl(IntPtr handle, AppInfoResControlCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_info_foreach_res_control", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppInfoForeachResControl(IntPtr handle, AppInfoResControlCallback callback, IntPtr userData);
 
         [NativeStruct("struct rua_rec", Include = "rua.h", PkgConfig = "rua")]
         [StructLayout(LayoutKind.Sequential)]
@@ -422,36 +423,36 @@ internal static partial class Interop
         internal delegate void RuaHistoryUpdateCallback(IntPtr table, int nRows, int nCols, IntPtr userData);
         //void (*rua_history_update_cb) (char **table, int nrows, int ncols, void *user_data);
 
-        [DllImport(Libraries.Rua, EntryPoint = "rua_history_get_rec")]
-        internal static extern ErrorCode RuaHistoryGetRecord(out RuaRec record, IntPtr table, int nRows, int nCols, int row);
+        [LibraryImport(Libraries.Rua, EntryPoint = "rua_history_get_rec", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode RuaHistoryGetRecord(out RuaRec record, IntPtr table, int nRows, int nCols, int row);
         //int rua_history_get_rec(struct rua_rec *rec, char** table, int nrows, int ncols, int row);
 
-        [DllImport(Libraries.Rua, EntryPoint = "rua_history_load_db")]
-        internal static extern ErrorCode RuaHistoryLoadDb(out IntPtr table, out int nRows, out int nCols);
+        [LibraryImport(Libraries.Rua, EntryPoint = "rua_history_load_db", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode RuaHistoryLoadDb(out IntPtr table, out int nRows, out int nCols);
         //int rua_history_load_db(char*** table, int *nrows, int *ncols);
 
-        [DllImport(Libraries.Rua, EntryPoint = "rua_history_unload_db")]
-        internal static extern ErrorCode RuaHistoryUnLoadDb(ref IntPtr table);
+        [LibraryImport(Libraries.Rua, EntryPoint = "rua_history_unload_db", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode RuaHistoryUnLoadDb(ref IntPtr table);
         //int rua_history_unload_db(char*** table);
 
-        [DllImport(Libraries.Rua, EntryPoint = "rua_delete_history_with_pkgname")]
-        internal static extern ErrorCode RuaDeleteHistoryWithPkgname(string pkgName);
+        [LibraryImport(Libraries.Rua, EntryPoint = "rua_delete_history_with_pkgname", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode RuaDeleteHistoryWithPkgname(string pkgName);
         //int rua_delete_history_with_pkgname(char* pkg_name);
 
-        [DllImport(Libraries.Rua, EntryPoint = "rua_delete_history_with_apppath")]
-        internal static extern ErrorCode RuaDeleteHistoryWithApppath(string appPath);
+        [LibraryImport(Libraries.Rua, EntryPoint = "rua_delete_history_with_apppath", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode RuaDeleteHistoryWithApppath(string appPath);
         //int rua_delete_history_with_apppath(char* app_path);
 
-        [DllImport(Libraries.Rua, EntryPoint = "rua_clear_history")]
-        internal static extern ErrorCode RuaClearHistory();
+        [LibraryImport(Libraries.Rua, EntryPoint = "rua_clear_history", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode RuaClearHistory();
         //int rua_clear_history(void);
 
-        [DllImport(Libraries.Rua, EntryPoint = "rua_register_update_cb")]
-        internal static extern ErrorCode RuaSetUpdateCallback(RuaHistoryUpdateCallback callback, IntPtr userData, out int id);
+        [LibraryImport(Libraries.Rua, EntryPoint = "rua_register_update_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode RuaSetUpdateCallback(RuaHistoryUpdateCallback callback, IntPtr userData, out int id);
         //int rua_register_update_cb(rua_history_update_cb callback, void *user_data, int *callback_id);
 
-        [DllImport(Libraries.Rua, EntryPoint = "rua_unregister_update_cb")]
-        internal static extern ErrorCode RuaUnSetUpdateCallback(int id);
+        [LibraryImport(Libraries.Rua, EntryPoint = "rua_unregister_update_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode RuaUnSetUpdateCallback(int id);
         //int rua_unregister_update_cb(int callback_id);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -459,10 +460,14 @@ internal static partial class Interop
                                                      IntPtr userData);
         // int (*rua_stat_tag_iter_fn)(const char *rua_stat_tag, void *data)
 
-        [DllImport(Libraries.Rua, EntryPoint = "rua_stat_get_stat_tags")]
-        internal static extern ErrorCode RuaStatGetStatTags(string caller, RuaStatTagIterCallback callback,
+        [LibraryImport(Libraries.Rua, EntryPoint = "rua_stat_get_stat_tags", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode RuaStatGetStatTags(string caller, RuaStatTagIterCallback callback,
                                                             IntPtr userData);
         // int rua_stat_get_stat_tags(char *caller, int (*rua_stat_tag_iter_fn)(const char *rua_stat_tag, void *data),
         // void *data);
     }
 }
+
+
+
+

--- a/src/Tizen.Applications.Common/Interop/Interop.BaseUtilsi18n.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.BaseUtilsi18n.cs
@@ -17,40 +17,45 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using System.Text;
 
 using Tizen.Applications;
 
 internal static partial class Interop
 {
-    internal static partial class BaseUtilsi18n
+    internal static class BaseUtilsi18n
     {
-        [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_canonicalize")]
+        [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_canonicalize", CallingConvention = CallingConvention.Cdecl)]
         internal static extern Int32 Canonicalize(string localeID, [Out] StringBuilder name, Int32 nameCapacity);
         // int32_t i18n_ulocale_canonicalize(const char *locale_id, char *name, int32_t name_capacity);c
 
-        [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_language")]
+        [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_language", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int GetLanguage(string localeID, [Out] StringBuilder language, Int32 languageCapacity, out int bufSizeLanguage);
         // int i18n_ulocale_get_language(const char *locale_id, char *language, int32_t language_capacity, int32_t *buf_size_language);
 
-        [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_script")]
+        [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_script", CallingConvention = CallingConvention.Cdecl)]
         internal static extern Int32 GetScript(string localeID, [Out] StringBuilder script, Int32 scriptCapacity);
         // int32_t i18n_ulocale_get_script(const char *locale_id, char *script, int32_t script_capacity);
 
-        [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_country")]
+        [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_country", CallingConvention = CallingConvention.Cdecl)]
         internal static extern Int32 GetCountry(string localeID, [Out] StringBuilder country, Int32 countryCapacity, out int err);
         // int32_t i18n_ulocale_get_country(const char *locale_id, char *country, int32_t country_capacity, int *error);
 
-        [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_variant")]
+        [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_variant", CallingConvention = CallingConvention.Cdecl)]
         internal static extern Int32 GetVariant(string localeID, [Out] StringBuilder variant, Int32 variantCapacity);
         // int32_t i18n_ulocale_get_variant(const char *locale_id, char *variant, int32_t variant_capacity);
 
-        [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_lcid")]
+        [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_lcid", CallingConvention = CallingConvention.Cdecl)]
         internal static extern UInt32 GetLCID(string localeID);
         // uint32_t i18n_ulocale_get_lcid(const char *locale_id);
 
-        [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_default")]
+        [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_default", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int GetDefault(out IntPtr localeID);
         // int i18n_ulocale_get_default(const char **locale);
     }
 }
+
+
+
+

--- a/src/Tizen.Applications.Common/Interop/Interop.Bundle.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.Bundle.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Tizen.Applications;
 
@@ -26,52 +27,52 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void Iterator(string key, int type, IntPtr keyval, IntPtr userData);
 
-        [DllImport(Libraries.Bundle, EntryPoint = "bundle_create")]
-        internal static extern SafeBundleHandle Create();
+        [LibraryImport(Libraries.Bundle, EntryPoint = "bundle_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial SafeBundleHandle Create();
 
-        [DllImport(Libraries.Bundle, EntryPoint = "bundle_free")]
-        internal static extern int DangerousFree(IntPtr handle);
+        [LibraryImport(Libraries.Bundle, EntryPoint = "bundle_free", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int DangerousFree(IntPtr handle);
 
-        [DllImport(Libraries.Bundle, EntryPoint = "bundle_del")]
-        internal static extern int RemoveItem(SafeBundleHandle handle, string key);
+        [LibraryImport(Libraries.Bundle, EntryPoint = "bundle_del", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RemoveItem(SafeBundleHandle handle, string key);
 
-        [DllImport(Libraries.Bundle, EntryPoint = "bundle_add_str")]
-        internal static extern int AddString(SafeBundleHandle handle, string key, string value);
+        [LibraryImport(Libraries.Bundle, EntryPoint = "bundle_add_str", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int AddString(SafeBundleHandle handle, string key, string value);
 
-        [DllImport(Libraries.Bundle, EntryPoint = "bundle_get_type")]
-        internal static extern int GetType(SafeBundleHandle handle, string key);
+        [LibraryImport(Libraries.Bundle, EntryPoint = "bundle_get_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetType(SafeBundleHandle handle, string key);
 
-        [DllImport(Libraries.Bundle, EntryPoint = "bundle_get_str")]
-        internal static extern int GetString(SafeBundleHandle handle, string key, out IntPtr value);
+        [LibraryImport(Libraries.Bundle, EntryPoint = "bundle_get_str", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetString(SafeBundleHandle handle, string key, out IntPtr value);
 
-        [DllImport(Libraries.Bundle, EntryPoint = "bundle_add_byte")]
-        internal static extern unsafe int AddByte(SafeBundleHandle handle, string key, byte* value, int size);
+        [LibraryImport(Libraries.Bundle, EntryPoint = "bundle_add_byte", StringMarshalling = StringMarshalling.Utf8)]
+        internal static unsafe partial int AddByte(SafeBundleHandle handle, string key, byte* value, int size);
 
-        [DllImport(Libraries.Bundle, EntryPoint = "bundle_get_byte")]
-        internal static extern int GetByte(SafeBundleHandle handle, string key, out IntPtr value, out int size);
+        [LibraryImport(Libraries.Bundle, EntryPoint = "bundle_get_byte", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetByte(SafeBundleHandle handle, string key, out IntPtr value, out int size);
 
-        [DllImport(Libraries.Bundle, EntryPoint = "bundle_add_str_array")]
-        internal static extern int AddStringArray(SafeBundleHandle handle, string key, string[] value, int size);
+        [LibraryImport(Libraries.Bundle, EntryPoint = "bundle_add_str_array", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int AddStringArray(SafeBundleHandle handle, string key, string[] value, int size);
 
-        [DllImport(Libraries.Bundle, EntryPoint = "bundle_get_str_array")]
-        internal static extern IntPtr GetStringArray(SafeBundleHandle handle, string key, out int size);
+        [LibraryImport(Libraries.Bundle, EntryPoint = "bundle_get_str_array", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr GetStringArray(SafeBundleHandle handle, string key, out int size);
 
-        [DllImport(Libraries.Bundle, EntryPoint = "bundle_foreach")]
-        internal static extern void Foreach(SafeBundleHandle handle, Iterator iterator, IntPtr userData);
+        [LibraryImport(Libraries.Bundle, EntryPoint = "bundle_foreach", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void Foreach(SafeBundleHandle handle, Iterator iterator, IntPtr userData);
 
-        [DllImport(Libraries.Bundle, EntryPoint = "bundle_encode")]
-        internal static extern void BundleEncode(SafeBundleHandle handle, out string str, out int len);
+        [LibraryImport(Libraries.Bundle, EntryPoint = "bundle_encode", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void BundleEncode(SafeBundleHandle handle, out string str, out int len);
 
-        [DllImport(Libraries.Bundle, EntryPoint = "bundle_decode")]
-        internal static extern SafeBundleHandle BundleDecode(string bundleRaw, int len);
+        [LibraryImport(Libraries.Bundle, EntryPoint = "bundle_decode", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial SafeBundleHandle BundleDecode(string bundleRaw, int len);
 
-        [DllImport(Libraries.Bundle, EntryPoint = "bundle_dup")]
-        internal static extern SafeBundleHandle DangerousClone(IntPtr handle);
+        [LibraryImport(Libraries.Bundle, EntryPoint = "bundle_dup", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial SafeBundleHandle DangerousClone(IntPtr handle);
 
-        [DllImport(Libraries.Bundle, EntryPoint = "bundle_import_from_argv")]
-        internal static extern SafeBundleHandle ImportFromArgv(int argc, string[] argv);
+        [LibraryImport(Libraries.Bundle, EntryPoint = "bundle_import_from_argv", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial SafeBundleHandle ImportFromArgv(int argc, string[] argv);
 
-        internal static class UnsafeCode
+        internal static partial class UnsafeCode
         {
             internal static unsafe int AddItem(SafeBundleHandle handle, string key, byte[] value, int offset, int count)
             {
@@ -83,3 +84,6 @@ internal static partial class Interop
         }
     }
 }
+
+
+

--- a/src/Tizen.Applications.Common/Interop/Interop.Glib.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.Glib.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,33 +16,40 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
     internal static partial class Glib
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool GSourceFunc(IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool GSourceFunc(IntPtr userData);
 
-        [DllImport(Libraries.Glib, EntryPoint = "g_idle_add", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern uint IdleAdd(GSourceFunc d, IntPtr data);
+        [LibraryImport(Libraries.Glib, EntryPoint = "g_idle_add", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial uint IdleAdd(GSourceFunc d, IntPtr data);
 
-        [DllImport(Libraries.Glib, EntryPoint = "g_source_remove", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern bool RemoveSource(uint source);
+        [LibraryImport(Libraries.Glib, EntryPoint = "g_source_remove", StringMarshalling = StringMarshalling.Utf8)]
+        [return: MarshalAs(UnmanagedType.U1)]
+        internal static partial bool RemoveSource(uint source);
 
-        [DllImport(Libraries.Glib, EntryPoint = "g_idle_source_new", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr IdleSourceNew();
+        [LibraryImport(Libraries.Glib, EntryPoint = "g_idle_source_new", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr IdleSourceNew();
 
-        [DllImport(Libraries.Glib, EntryPoint = "g_source_set_callback", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void SourceSetCallback(IntPtr source, GSourceFunc func, IntPtr data, IntPtr notify);
+        [LibraryImport(Libraries.Glib, EntryPoint = "g_source_set_callback", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void SourceSetCallback(IntPtr source, GSourceFunc func, IntPtr data, IntPtr notify);
 
-        [DllImport(Libraries.Glib, EntryPoint = "g_source_attach", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern uint SourceAttach(IntPtr source, IntPtr context);
+        [LibraryImport(Libraries.Glib, EntryPoint = "g_source_attach", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial uint SourceAttach(IntPtr source, IntPtr context);
 
-        [DllImport(Libraries.Glib, EntryPoint = "g_source_unref", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void SourceUnref(IntPtr source);
+        [LibraryImport(Libraries.Glib, EntryPoint = "g_source_unref", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void SourceUnref(IntPtr source);
 
-        [DllImport(Libraries.Glib, EntryPoint = "g_main_context_get_thread_default", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr MainContextGetThreadDefault();
+        [LibraryImport(Libraries.Glib, EntryPoint = "g_main_context_get_thread_default", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr MainContextGetThreadDefault();
     }
 }
+
+
+
+
+

--- a/src/Tizen.Applications.Common/Interop/Interop.IniParser.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.IniParser.cs
@@ -16,18 +16,21 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
     internal static partial class LibIniParser
     {
-        [DllImport(Libraries.IniParser, EntryPoint = "iniparser_getstring", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr GetString(IntPtr d, string key, IntPtr def);
+        [LibraryImport(Libraries.IniParser, EntryPoint = "iniparser_getstring", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr GetString(IntPtr d, string key, IntPtr def);
 
-        [DllImport(Libraries.IniParser, EntryPoint = "iniparser_load", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr Load(string iniName);
+        [LibraryImport(Libraries.IniParser, EntryPoint = "iniparser_load", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr Load(string iniName);
 
-        [DllImport(Libraries.IniParser, EntryPoint = "iniparser_freedict", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void FreeDict(IntPtr d);
+        [LibraryImport(Libraries.IniParser, EntryPoint = "iniparser_freedict", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void FreeDict(IntPtr d);
     }
 }
+
+

--- a/src/Tizen.Applications.Common/Interop/Interop.Libc.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.Libc.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Tizen.Internals;
 
@@ -23,8 +24,8 @@ internal static partial class Interop
 {
     internal static partial class Libc
     {
-        [DllImport(Libraries.Libc, EntryPoint = "getenv")]
-        internal static extern IntPtr GetEnvironmentVariable(string name);
+        [LibraryImport(Libraries.Libc, EntryPoint = "getenv", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr GetEnvironmentVariable(string name);
 
         [NativeStruct("struct timespec", Include = "time.h")]
         [StructLayout(LayoutKind.Sequential)]
@@ -35,3 +36,6 @@ internal static partial class Interop
         }
     }
 }
+
+
+

--- a/src/Tizen.Applications.Common/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -33,3 +33,6 @@ internal static partial class Interop
         public const string IniParser = "libiniparser.so.4";
     }
 }
+
+
+

--- a/src/Tizen.Applications.Common/Interop/Interop.RPCPort.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.RPCPort.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Tizen.Internals.Errors;
 using Tizen.Applications;
@@ -43,178 +44,178 @@ internal static partial class Interop
         internal static partial class Parcel
         {
             //int rpc_port_parcel_create(rpc_port_parcel_h *h);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_create")]
-            internal static extern ErrorCode Create(out IntPtr handle);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode Create(out IntPtr handle);
 
             //int rpc_port_parcel_create_from_port(rpc_port_parcel_h *h, rpc_port_h port);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_create_from_port")]
-            internal static extern ErrorCode CreateFromPort(out IntPtr parcelHandle, IntPtr portHandle);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_create_from_port", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode CreateFromPort(out IntPtr parcelHandle, IntPtr portHandle);
 
             //int rpc_port_parcel_send(rpc_port_parcel_h h, rpc_port_h port);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_send")]
-            internal static extern ErrorCode Send(IntPtr parcelHandle, IntPtr portHandle);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_send", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode Send(IntPtr parcelHandle, IntPtr portHandle);
 
             //int rpc_port_parcel_destroy(rpc_port_parcel_h h);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_destroy")]
-            internal static extern ErrorCode Destroy(IntPtr handle);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode Destroy(IntPtr handle);
 
             //int rpc_port_parcel_write_byte(rpc_port_parcel_h h, char b);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_byte")]
-            internal static extern ErrorCode WriteByte(IntPtr parcelHandle, byte b);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_byte", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode WriteByte(IntPtr parcelHandle, byte b);
 
             //int rpc_port_parcel_write_int16(rpc_port_parcel_h h, short i);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_int16")]
-            internal static extern ErrorCode WriteInt16(IntPtr parcelHandle, short i);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_int16", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode WriteInt16(IntPtr parcelHandle, short i);
 
             //int rpc_port_parcel_write_int32(rpc_port_parcel_h h, int i);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_int32")]
-            internal static extern ErrorCode WriteInt32(IntPtr parcelHandle, int i);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_int32", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode WriteInt32(IntPtr parcelHandle, int i);
 
             //int rpc_port_parcel_write_int64(rpc_port_parcel_h h, int i);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_int64")]
-            internal static extern ErrorCode WriteInt64(IntPtr parcelHandle, long i);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_int64", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode WriteInt64(IntPtr parcelHandle, long i);
 
             //int rpc_port_parcel_write_float(rpc_port_parcel_h h, float f);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_float")]
-            internal static extern ErrorCode WriteFloat(IntPtr parcelHandle, float f);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_float", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode WriteFloat(IntPtr parcelHandle, float f);
 
             //int rpc_port_parcel_write_double(rpc_port_parcel_h h, double d);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_double")]
-            internal static extern ErrorCode WriteDouble(IntPtr parcelHandle, double d);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_double", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode WriteDouble(IntPtr parcelHandle, double d);
 
             //int rpc_port_parcel_write_string(rpc_port_parcel_h h, const char* str);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_string")]
-            internal static extern ErrorCode WriteString(IntPtr parcelHandle, string str);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_string", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode WriteString(IntPtr parcelHandle, string str);
 
-            //int rpc_port_parcel_write_bool(rpc_port_parcel_h h, bool b);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_bool")]
-            internal static extern ErrorCode WriteBool(IntPtr parcelHandle, bool b);
+            //int rpc_port_parcel_write_bool(rpc_port_parcel_h h, [MarshalAs(UnmanagedType.U1)] bool b);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_bool", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode WriteBool(IntPtr parcelHandle, [MarshalAs(UnmanagedType.U1)] bool b);
 
             //int rpc_port_parcel_write_bundle(rpc_port_parcel_h h, bundle* b);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_bundle")]
-            internal static extern ErrorCode WriteBundle(IntPtr parcelHandle, IntPtr b);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_bundle", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode WriteBundle(IntPtr parcelHandle, IntPtr b);
 
             //int rpc_port_parcel_write_array_count(rpc_port_parcel_h h, int count);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_array_count")]
-            internal static extern ErrorCode WriteArrayCount(IntPtr parcelHandle, int count);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_write_array_count", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode WriteArrayCount(IntPtr parcelHandle, int count);
 
             //int rpc_port_parcel_read_byte(rpc_port_parcel_h h, char* b);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_byte")]
-            internal static extern ErrorCode ReadByte(IntPtr parcelHandle, out byte b);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_byte", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode ReadByte(IntPtr parcelHandle, out byte b);
 
             //int rpc_port_parcel_read_int16(rpc_port_parcel_h h, short *i);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_int16")]
-            internal static extern ErrorCode ReadInt16(IntPtr parcelHandle, out short i);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_int16", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode ReadInt16(IntPtr parcelHandle, out short i);
 
             //int rpc_port_parcel_read_int32(rpc_port_parcel_h h, int* i);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_int32")]
-            internal static extern ErrorCode ReadInt32(IntPtr parcelHandle, out int i);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_int32", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode ReadInt32(IntPtr parcelHandle, out int i);
 
             //int rpc_port_parcel_read_int64(rpc_port_parcel_h h, long long* i);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_int64")]
-            internal static extern ErrorCode ReadInt64(IntPtr parcelHandle, out long i);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_int64", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode ReadInt64(IntPtr parcelHandle, out long i);
 
             //int rpc_port_parcel_read_float(rpc_port_parcel_h h, float *f);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_float")]
-            internal static extern ErrorCode ReadFloat(IntPtr parcelHandle, out float f);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_float", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode ReadFloat(IntPtr parcelHandle, out float f);
 
             //int rpc_port_parcel_read_double(rpc_port_parcel_h h, double *d);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_double")]
-            internal static extern ErrorCode ReadDouble(IntPtr parcelHandle, out double f);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_double", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode ReadDouble(IntPtr parcelHandle, out double f);
 
             //int rpc_port_parcel_read_string(rpc_port_parcel_h h, char** str);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_string")]
-            internal static extern ErrorCode ReadString(IntPtr parcelHandle, out string str);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_string", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode ReadString(IntPtr parcelHandle, out string str);
 
-            //int rpc_port_parcel_read_bool(rpc_port_parcel_h h, bool *b);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_bool")]
-            internal static extern ErrorCode ReadBool(IntPtr parcelHandle, out bool b);
+            //int rpc_port_parcel_read_bool(rpc_port_parcel_h h, [MarshalAs(UnmanagedType.U1)] bool *b);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_bool", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode ReadBool(IntPtr parcelHandle, [MarshalAs(UnmanagedType.U1)] out bool b);
 
             //int rpc_port_parcel_read_bundle(rpc_port_parcel_h h, bundle** b);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_bundle")]
-            internal static extern ErrorCode ReadBundle(IntPtr parcelHandle, out IntPtr b);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_bundle", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode ReadBundle(IntPtr parcelHandle, out IntPtr b);
 
             //int rpc_port_parcel_read_array_count(rpc_port_parcel_h h, int *count);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_array_count")]
-            internal static extern ErrorCode ReadArrayCount(IntPtr parcelHandle, out int count);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_read_array_count", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode ReadArrayCount(IntPtr parcelHandle, out int count);
 
             //int rpc_port_parcel_burst_read(rpc_port_parcel_h h, unsigned char *buf, unsigned int size);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_burst_read")]
-            internal static extern ErrorCode Read(IntPtr parcelHandle, [In, Out] byte[] buf, int size);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_burst_read", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode Read(IntPtr parcelHandle, [In, Out] byte[] buf, int size);
 
             //int rpc_port_parcel_burst_write(rpc_port_parcel_h h, const unsigned char *buf, unsigned int size);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_burst_write")]
-            internal static extern ErrorCode Write(IntPtr parcelHandle, byte[] buf, int size);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_burst_write", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode Write(IntPtr parcelHandle, byte[] buf, int size);
 
             //int rpc_port_parcel_get_header(rpc_port_parcel_h h, rpc_port_parcel_header_h *header);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_get_header")]
-            internal static extern ErrorCode GetHeader(IntPtr parcelHandle, out IntPtr ParcelHeaderHandle);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_get_header", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode GetHeader(IntPtr parcelHandle, out IntPtr ParcelHeaderHandle);
 
             //int rpc_port_parcel_header_set_tag(rpc_port_parcel_header_h header, const char *tag);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_header_set_tag")]
-            internal static extern ErrorCode SetTag(IntPtr parcelHeaderHandle, string tag);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_header_set_tag", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode SetTag(IntPtr parcelHeaderHandle, string tag);
 
             //int rpc_port_parcel_header_get_tag(rpc_port_parcel_header_h header, char **tag);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_header_get_tag")]
-            internal static extern ErrorCode GetTag(IntPtr parcelHeaderHandle, out string tag);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_header_get_tag", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode GetTag(IntPtr parcelHeaderHandle, out string tag);
 
             //int rpc_port_parcel_header_set_tag_ex(rpc_port_parcel_header_h header,
             //    unsigned char tidlc_version_major, unsigned char tidlc_version_minor,
             //    unsigned char tidlc_version_patch, unsigned char tidl_protocol_ver, unsigned char flags);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_header_set_tag_ex")]
-            internal static extern ErrorCode SetTagEx(IntPtr parcelHeaderHandle, byte major, byte minor, byte patch, byte protocol, byte flags);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_header_set_tag_ex", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode SetTagEx(IntPtr parcelHeaderHandle, byte major, byte minor, byte patch, byte protocol, byte flags);
 
             //int rpc_port_parcel_header_set_seq_num(rpc_port_parcel_header_h header, int seq_num);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_header_set_seq_num")]
-            internal static extern ErrorCode SetSeqNum(IntPtr parcelHeaderHandle, int seq_num);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_header_set_seq_num", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode SetSeqNum(IntPtr parcelHeaderHandle, int seq_num);
 
             //int rpc_port_parcel_header_get_seq_num(rpc_port_parcel_header_h header, int *seq_num);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_header_get_seq_num")]
-            internal static extern ErrorCode GetSeqNum(IntPtr parcelHeaderHandle, out int seq_num);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_header_get_seq_num", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode GetSeqNum(IntPtr parcelHeaderHandle, out int seq_num);
 
             //int rpc_port_parcel_header_get_timestamp(rpc_port_parcel_header_h header, struct timespec *timestamp);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_header_get_timestamp")]
-            internal static extern ErrorCode GetTimeStamp(IntPtr parcelHeaderHandle, ref Libc.TimeStamp time);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_header_get_timestamp", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode GetTimeStamp(IntPtr parcelHeaderHandle, ref Libc.TimeStamp time);
 
             //int rpc_port_parcel_get_raw(rpc_port_parcel_h h, void **raw, unsigned int *size);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_get_raw")]
-            internal static extern ErrorCode GetRaw(IntPtr parcelHandle, out IntPtr raw, out uint size);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_get_raw", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode GetRaw(IntPtr parcelHandle, out IntPtr raw, out uint size);
 
             //int rpc_port_parcel_create_from_raw(rpc_port_parcel_h *h, const void *raw, unsigned int size);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_create_from_raw")]
-            internal static extern ErrorCode CreateFromRaw(out IntPtr parcelHandle, byte[] raw, uint size);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_create_from_raw", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode CreateFromRaw(out IntPtr parcelHandle, byte[] raw, uint size);
 
             //int rpc_port_parcel_create_without_header(rpc_port_parcel_h *h);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_create_without_header")]
-            internal static extern ErrorCode CreateWithoutHeader(out IntPtr parcelHandle);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_create_without_header", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode CreateWithoutHeader(out IntPtr parcelHandle);
 
             //int rpc_port_parcel_reserve(rpc_port_parcel_h h, unsigned int size);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_reserve")]
-            internal static extern ErrorCode Reserve(IntPtr parcelHandle, uint size);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_reserve", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode Reserve(IntPtr parcelHandle, uint size);
 
             //int rpc_port_parcel_set_data_size(rpc_port_parcel_h h, unsigned int size);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_set_data_size")]
-            internal static extern ErrorCode SetDataSize(IntPtr parcelHandle, uint size);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_set_data_size", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode SetDataSize(IntPtr parcelHandle, uint size);
 
             //int rpc_port_parcel_get_data_size(rpc_port_parcel_h h, unsigned int* size);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_get_data_size")]
-            internal static extern ErrorCode GetDataSize(IntPtr parcelHandle, out uint size);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_get_data_size", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode GetDataSize(IntPtr parcelHandle, out uint size);
 
             //int rpc_port_parcel_pin(rpc_port_parcel_h h);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_pin")]
-            internal static extern ErrorCode Pin(IntPtr parcelHandle);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_pin", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode Pin(IntPtr parcelHandle);
 
             //int rpc_port_parcel_get_reader(rpc_port_parcel_h h, unsigned int* reader_pos);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_get_reader")]
-            internal static extern ErrorCode GetReader(IntPtr parcelHandle, out uint readerPos);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_get_reader", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode GetReader(IntPtr parcelHandle, out uint readerPos);
 
             //int rpc_port_parcel_set_reader(rpc_port_parcel_h h, unsigned int reader_pos);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_set_reader")]
-            internal static extern ErrorCode SetReader(IntPtr parcelHandle, uint readerPos);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_set_reader", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode SetReader(IntPtr parcelHandle, uint readerPos);
 
             //int rpc_port_parcel_create_from_parcel(rpc_port_parcel_h* h, rpc_port_parcel_h origin_parcel, unsigned int start_pos, unsigned int size);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_create_from_parcel")]
-            internal static extern ErrorCode CreateFromParcel(out IntPtr parcelHandle, IntPtr originParcel, uint startPos, uint size);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_create_from_parcel", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode CreateFromParcel(out IntPtr parcelHandle, IntPtr originParcel, uint startPos, uint size);
         }
 
         internal static partial class Proxy
@@ -236,40 +237,40 @@ internal static partial class Interop
             internal delegate void ReceivedEventCallback(string endPoint, string port_name, IntPtr data);
 
             //int rpc_port_proxy_create(rpc_port_proxy_h *h);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_create")]
-            internal static extern ErrorCode Create(out IntPtr handle);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode Create(out IntPtr handle);
 
             //int rpc_port_proxy_destroy(rpc_port_proxy_h h);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_destroy")]
-            internal static extern ErrorCode Destroy(IntPtr handle);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode Destroy(IntPtr handle);
 
             //int rpc_port_proxy_connect(rpc_port_proxy_h h, const char *appid, const char* port);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_connect")]
-            internal static extern ErrorCode Connect(IntPtr handle, string appId, string port);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_connect", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode Connect(IntPtr handle, string appId, string port);
 
             //int rpc_port_proxy_add_connected_event_cb(rpc_port_proxy_h h, rpc_port_proxy_connected_event_cb cb, void* data);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_add_connected_event_cb")]
-            internal static extern ErrorCode AddConnectedEventCb(IntPtr handle, ConnectedEventCallback cb, IntPtr data);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_add_connected_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode AddConnectedEventCb(IntPtr handle, ConnectedEventCallback cb, IntPtr data);
 
             //int rpc_port_proxy_add_disconnected_event_cb(rpc_port_proxy_h h, rpc_port_proxy_disconnected_event_cb cb, void* data);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_add_disconnected_event_cb")]
-            internal static extern ErrorCode AddDisconnectedEventCb(IntPtr handle, DisconnectedEventCallback cb, IntPtr data);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_add_disconnected_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode AddDisconnectedEventCb(IntPtr handle, DisconnectedEventCallback cb, IntPtr data);
 
             //int rpc_port_proxy_add_rejected_event_cb(rpc_port_proxy_h h, rpc_port_proxy_rejected_event_cb cb, void* data);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_add_rejected_event_cb")]
-            internal static extern ErrorCode AddRejectedEventCb(IntPtr handle, RejectedEventCallback cb, IntPtr data);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_add_rejected_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode AddRejectedEventCb(IntPtr handle, RejectedEventCallback cb, IntPtr data);
 
             //int rpc_port_proxy_add_received_event_cb(rpc_port_proxy_h h, rpc_port_proxy_received_event_cb cb, void* data);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_add_received_event_cb")]
-            internal static extern ErrorCode AddReceivedEventCb(IntPtr handle, ReceivedEventCallback cb, IntPtr data);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_add_received_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode AddReceivedEventCb(IntPtr handle, ReceivedEventCallback cb, IntPtr data);
 
             //int rpc_port_proxy_get_port(rpc_port_proxy_h h, rpc_port_port_type_e type, rpc_port_h* port);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_get_port")]
-            internal static extern ErrorCode GetPort(IntPtr handle, PortType t, out IntPtr port);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_get_port", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode GetPort(IntPtr handle, PortType t, out IntPtr port);
 
             //int rpc_port_proxy_connect_sync(rpc_port_proxy_h h, const char* appid, const char* port);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_connect_sync")]
-            internal static extern ErrorCode ConnectSync(IntPtr handle, string appId, string port);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_connect_sync", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode ConnectSync(IntPtr handle, string appId, string port);
         }
 
         internal static partial class Stub
@@ -287,59 +288,63 @@ internal static partial class Interop
             internal delegate int ReceivedEventCallback(string sender, string instance, IntPtr port, IntPtr data);
 
             //int rpc_port_stub_create(rpc_port_stub_h* h, const char* port_name);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_stub_create")]
-            internal static extern ErrorCode Create(out IntPtr handle, string portName);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_stub_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode Create(out IntPtr handle, string portName);
 
             //int rpc_port_stub_destroy(rpc_port_stub_h h);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_stub_destroy")]
-            internal static extern ErrorCode Destroy(IntPtr handle);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_stub_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode Destroy(IntPtr handle);
 
             //int rpc_port_stub_listen(rpc_port_stub_h h);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_stub_listen")]
-            internal static extern ErrorCode Listen(IntPtr handle);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_stub_listen", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode Listen(IntPtr handle);
 
             //int rpc_port_stub_add_connected_event_cb(rpc_port_stub_h h, rpc_port_stub_connected_event_cb cb, void* data);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_stub_add_connected_event_cb")]
-            internal static extern ErrorCode AddConnectedEventCb(IntPtr handle, ConnectedEventCallback cb, IntPtr data);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_stub_add_connected_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode AddConnectedEventCb(IntPtr handle, ConnectedEventCallback cb, IntPtr data);
 
             //int rpc_port_stub_add_disconnected_event_cb(rpc_port_stub_h h, rpc_port_stub_disconnected_event_cb cb, void* data);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_stub_add_disconnected_event_cb")]
-            internal static extern ErrorCode AddDisconnectedEventCb(IntPtr handle, DisconnectedEventCallback cb, IntPtr data);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_stub_add_disconnected_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode AddDisconnectedEventCb(IntPtr handle, DisconnectedEventCallback cb, IntPtr data);
 
             //int rpc_port_stub_add_received_event_cb(rpc_port_stub_h h, rpc_port_stub_received_event_cb cb, void* data);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_stub_add_received_event_cb")]
-            internal static extern ErrorCode AddReceivedEventCb(IntPtr handle, ReceivedEventCallback cb, IntPtr data);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_stub_add_received_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode AddReceivedEventCb(IntPtr handle, ReceivedEventCallback cb, IntPtr data);
 
             //int rpc_port_stub_add_privilege(rpc_port_stub_h h, const char *privilege);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_stub_add_privilege")]
-            internal static extern ErrorCode AddPrivilege(IntPtr handle, string privilege);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_stub_add_privilege", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode AddPrivilege(IntPtr handle, string privilege);
 
-            //int rpc_port_stub_set_trusted(rpc_port_stub_h h, const bool trusted);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_stub_set_trusted")]
-            internal static extern ErrorCode SetTrusted(IntPtr handle, bool trusted);
+            //int rpc_port_stub_set_trusted(rpc_port_stub_h h, const [MarshalAs(UnmanagedType.U1)] bool trusted);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_stub_set_trusted", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode SetTrusted(IntPtr handle, [MarshalAs(UnmanagedType.U1)] bool trusted);
 
             //int rpc_port_stub_get_port(rpc_port_stub_h h, rpc_port_port_type_e type, const char* instance, rpc_port_h *port);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_stub_get_port")]
-            internal static extern ErrorCode GetPort(IntPtr handle, PortType t, string instance, out IntPtr port);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_stub_get_port", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode GetPort(IntPtr handle, PortType t, string instance, out IntPtr port);
         }
 
         internal static partial class Port
         {
             //int rpc_port_set_private_sharing_array(rpc_port_h port, const char* paths[], unsigned int size);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_set_private_sharing_array")]
-            internal static extern ErrorCode SetPrivateSharingArray(IntPtr handle, string[] paths, uint size);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_set_private_sharing_array", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode SetPrivateSharingArray(IntPtr handle, string[] paths, uint size);
 
             //int rpc_port_set_private_sharing(rpc_port_h port, const char* path);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_set_private_sharing")]
-            internal static extern ErrorCode SetPrivateSharing(IntPtr handle, string path);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_set_private_sharing", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode SetPrivateSharing(IntPtr handle, string path);
 
             //int rpc_port_unset_private_sharing(rpc_port_h port);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_unset_private_sharing")]
-            internal static extern ErrorCode UnsetPrivateSharing(IntPtr handle);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_unset_private_sharing", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode UnsetPrivateSharing(IntPtr handle);
 
             //int rpc_port_disconnect(rpc_port_h h);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_disconnect")]
-            internal static extern ErrorCode Disconnect(IntPtr handle);
+            [LibraryImport(Libraries.RpcPort, EntryPoint = "rpc_port_disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ErrorCode Disconnect(IntPtr handle);
         }
     }
 }
+
+
+
+

--- a/src/Tizen.Applications.ComponentBased.ComponentManager/Interop/Interop.ComponentManager.cs
+++ b/src/Tizen.Applications.ComponentBased.ComponentManager/Interop/Interop.ComponentManager.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
@@ -42,123 +43,127 @@ internal static partial class Interop
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool ComponentManagerComponentContextCallback(IntPtr handle, IntPtr userData);
-        // bool (*component_manager_component_context_cb)(component_context_h handle, void *user_data);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool ComponentManagerComponentContextCallback(IntPtr handle, IntPtr userData);
+        // [MarshalAs(UnmanagedType.U1)] bool (*component_manager_component_context_cb)(component_context_h handle, void *user_data);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool ComponentManagerComponentInfoCallback(IntPtr handle, IntPtr userData);
-        // bool (*component_manager_component_info_cb)(component_info_h handle, void *user_data);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool ComponentManagerComponentInfoCallback(IntPtr handle, IntPtr userData);
+        // [MarshalAs(UnmanagedType.U1)] bool (*component_manager_component_info_cb)(component_info_h handle, void *user_data);
                
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_manager_foreach_component_context")]
-        internal static extern ErrorCode ComponentManagerForeachComponentContext(ComponentManagerComponentContextCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_manager_foreach_component_context", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentManagerForeachComponentContext(ComponentManagerComponentContextCallback callback, IntPtr userData);
         // int component_manager_foreach_component_context(component_manager_component_context_cb callback, void *user_data)
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_manager_foreach_component_info")]
-        internal static extern ErrorCode ComponentManagerForeachComponentInfo(ComponentManagerComponentInfoCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_manager_foreach_component_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentManagerForeachComponentInfo(ComponentManagerComponentInfoCallback callback, IntPtr userData);
         // int component_manager_foreach_component_info(component_manager_component_info_cb callback, void *user_data)
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_manager_get_component_context")]
-        internal static extern ErrorCode ComponentManagerGetComponentContext(string componentId, out IntPtr handle);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_manager_get_component_context", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentManagerGetComponentContext(string componentId, out IntPtr handle);
         // int component_manager_get_component_context(const char *comp_id, component_context_h *handle);
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_manager_get_component_info")]
-        internal static extern ErrorCode ComponentManagerGetComponentInfo(string componentId, out IntPtr handle);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_manager_get_component_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentManagerGetComponentInfo(string componentId, out IntPtr handle);
         // int component_manager_get_component_info(const char *comp_id, component_info_h *handle);
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_manager_is_running")]
-        internal static extern ErrorCode ComponentManagerIsRunning(string componentId, out bool running);
-        // int component_manager_is_running(const char *appid, bool *running);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_manager_is_running", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentManagerIsRunning(string componentId, [MarshalAs(UnmanagedType.U1)] out bool running);
+        // int component_manager_is_running(const char *appid, [MarshalAs(UnmanagedType.U1)] bool *running);
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_manager_resume_component")]
-        internal static extern ErrorCode ComponentManagerResumeComponent(IntPtr handle);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_manager_resume_component", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentManagerResumeComponent(IntPtr handle);
         // int component_manager_resume_component(component_context_h handle);
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_manager_terminate_bg_component")]
-        internal static extern ErrorCode ComponentManagerTerminateBgComponent(IntPtr handle);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_manager_terminate_bg_component", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentManagerTerminateBgComponent(IntPtr handle);
         // int component_manager_terminate_bg_component (component_context_h handle);
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_manager_pause_component")]
-        internal static extern ErrorCode ComponentManagerPauseComponent(IntPtr handle);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_manager_pause_component", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentManagerPauseComponent(IntPtr handle);
         // int component_manager_pause_component(component_context_h handle);
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_manager_terminate_component")]
-        internal static extern ErrorCode ComponentManagerTerminateComponent(IntPtr handle);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_manager_terminate_component", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentManagerTerminateComponent(IntPtr handle);
         // int component_manager_terminate_component(component_context_h handle);
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_context_destroy")]
-        internal static extern ErrorCode ComponentContextDestroy(IntPtr handle);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_context_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentContextDestroy(IntPtr handle);
         // int component_context_destroy(component_context_h handle)
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_context_get_app_id")]
-        internal static extern ErrorCode ComponentContextGetAppId(IntPtr handle, out string applicationId);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_context_get_app_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentContextGetAppId(IntPtr handle, out string applicationId);
         // int component_context_get_app_id(component_context_h handle, char **app_id)
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_context_get_component_id")]
-        internal static extern ErrorCode ComponentContextGetComponentId(IntPtr handle, out string componentId);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_context_get_component_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentContextGetComponentId(IntPtr handle, out string componentId);
         // int component_context_get_component_id(component_context_h handle, char **component_id)
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_context_get_instance_id")]
-        internal static extern ErrorCode ComponentContextGetInstanceId(IntPtr handle, out string instanceId);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_context_get_instance_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentContextGetInstanceId(IntPtr handle, out string instanceId);
         // int component_context_get_instance_id(component_context_h handle, char **instance_id)
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_context_get_component_state")]
-        internal static extern ErrorCode ComponentContextGetComponentState(IntPtr handle, out int state);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_context_get_component_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentContextGetComponentState(IntPtr handle, out int state);
         // int component_context_get_component_state(component_context_h handle, component_state_e *state)
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_context_is_terminated")]
-        internal static extern ErrorCode ComponentContextIsTerminated(IntPtr handle, out bool terminated);
-        // int component_context_is_terminated(component_context_h handle, bool *terminated);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_context_is_terminated", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentContextIsTerminated(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool terminated);
+        // int component_context_is_terminated(component_context_h handle, [MarshalAs(UnmanagedType.U1)] bool *terminated);
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_context_is_subcomponent")]
-        internal static extern ErrorCode ComponentContextIsSubComponent(IntPtr handle, out bool is_subcomponent);
-        // int component_context_is_subcomponent(component_context_h handle, bool *is_subcomponent);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_context_is_subcomponent", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentContextIsSubComponent(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool is_subcomponent);
+        // int component_context_is_subcomponent(component_context_h handle, [MarshalAs(UnmanagedType.U1)] bool *is_subcomponent);
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_context_clone")]
-        internal static extern ErrorCode ComponentContextClone(out IntPtr destination, IntPtr source);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_context_clone", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentContextClone(out IntPtr destination, IntPtr source);
         // int component_context_clone(component_context_h *clone, component_context_h handle);
         
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_info_create")]
-        internal static extern ErrorCode ComponentInfoCreate(string componentId, out IntPtr handle);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_info_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentInfoCreate(string componentId, out IntPtr handle);
         // int component_info_create(const char *component_id, component_info_h *handle);
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_info_destroy")]
-        internal static extern ErrorCode ComponentInfoDestroy(IntPtr handle);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_info_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentInfoDestroy(IntPtr handle);
         // int component_info_destroy(component_info_h handle);
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_info_get_app_id")]
-        internal static extern ErrorCode ComponentInfoGetAppId(IntPtr handle, out string applicationId);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_info_get_app_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentInfoGetAppId(IntPtr handle, out string applicationId);
         // int component_info_get_app_id(component_info_h handle, char **app_id);
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_info_get_component_id")]
-        internal static extern ErrorCode ComponentInfoGetComponentId(IntPtr handle, out string componentId);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_info_get_component_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentInfoGetComponentId(IntPtr handle, out string componentId);
         // int component_info_get_component_id(component_info_h handle, char **component_id);
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_info_get_component_type")]
-        internal static extern ErrorCode ComponentInfoGetComponentType(IntPtr handle, out ComponentInfoComponentType type);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_info_get_component_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentInfoGetComponentType(IntPtr handle, out ComponentInfoComponentType type);
         // int component_info_get_component_type(component_info_h handle, component_info_component_type_e *type);
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_info_is_icon_display")]
-        internal static extern ErrorCode ComponentInfoIsIconDisplay(IntPtr handle, out bool iconDisplay);
-        // int component_info_is_icon_display(component_info_h handle, bool *icon_display);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_info_is_icon_display", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentInfoIsIconDisplay(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool iconDisplay);
+        // int component_info_is_icon_display(component_info_h handle, [MarshalAs(UnmanagedType.U1)] bool *icon_display);
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_info_is_managed_by_task_manager")]
-        internal static extern ErrorCode ComponentInfoIsManagedByTaskManager(IntPtr handle, out bool managed);
-        // int component_info_is_managed_by_task_manager(component_info_h handle, bool *managed);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_info_is_managed_by_task_manager", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentInfoIsManagedByTaskManager(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool managed);
+        // int component_info_is_managed_by_task_manager(component_info_h handle, [MarshalAs(UnmanagedType.U1)] bool *managed);
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_info_get_icon")]
-        internal static extern ErrorCode ComponentInfoGetIcon(IntPtr handle, out string icon);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_info_get_icon", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentInfoGetIcon(IntPtr handle, out string icon);
         // int component_info_get_icon(component_info_h handle, char **icon);
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_info_get_label")]
-        internal static extern ErrorCode ComponentInfoGetLabel(IntPtr handle, out string label);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_info_get_label", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentInfoGetLabel(IntPtr handle, out string label);
         // int component_info_get_label(component_info_h handle, char **label);
 
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_info_get_localized_label")]
-        internal static extern ErrorCode ComponentInfoGetLocalizedLabel(IntPtr handle, string locale, out string label);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_info_get_localized_label", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentInfoGetLocalizedLabel(IntPtr handle, string locale, out string label);
         // int component_info_get_localized_label(component_info_h handle, const char *locale, char **label);
         
-        [DllImport(Libraries.ComponentManager, EntryPoint = "component_info_clone")]
-        internal static extern ErrorCode ComponentInfoClone(out IntPtr destination, IntPtr source);
+        [LibraryImport(Libraries.ComponentManager, EntryPoint = "component_info_clone", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentInfoClone(out IntPtr destination, IntPtr source);
         // int component_info_clone(component_info_h *clone, component_info_h handle);
     }
 }
+
+
+
+

--- a/src/Tizen.Applications.ComponentBased.ComponentManager/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.ComponentBased.ComponentManager/Interop/Interop.Libraries.cs
@@ -21,3 +21,5 @@ internal static partial class Interop
         public const string ComponentManager = "libcapi-appfw-component-manager.so.1";
     }
 }
+
+

--- a/src/Tizen.Applications.ComponentBased.Default/Interop/Interop.EflCbApplication.cs
+++ b/src/Tizen.Applications.ComponentBased.Default/Interop/Interop.EflCbApplication.cs
@@ -1,13 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using System.Text;
 
 internal static partial class Interop
 {
     internal static partial class EflCBApplication
     {
-        [DllImport(Libraries.CompApplication, EntryPoint = "frame_component_get_resource_id")]
-        internal static extern int GetResourceId(IntPtr win, out int resId);
+        [LibraryImport(Libraries.CompApplication, EntryPoint = "frame_component_get_resource_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetResourceId(IntPtr win, out int resId);
     }
 }
+
+
+

--- a/src/Tizen.Applications.ComponentBased.Default/Interop/Interop.Elementary.cs
+++ b/src/Tizen.Applications.ComponentBased.Default/Interop/Interop.Elementary.cs
@@ -1,25 +1,29 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using System.Text;
 
 internal static partial class Interop
 {
     internal static partial class Elementary
     {
-        [DllImport(Libraries.Elementary, EntryPoint = "elm_init")]
-        internal static extern void ElmInit(int argc, string[] argv);
+        [LibraryImport(Libraries.Elementary, EntryPoint = "elm_init", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void ElmInit(int argc, string[] argv);
 
-        [DllImport(Libraries.Elementary, EntryPoint = "elm_config_accel_preference_set")]
-        internal static extern IntPtr ElmConfigAccelPreferenceSet(string preference);
+        [LibraryImport(Libraries.Elementary, EntryPoint = "elm_config_accel_preference_set", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr ElmConfigAccelPreferenceSet(string preference);
 
-        [DllImport(Libraries.Elementary, EntryPoint = "elm_run")]
-        internal static extern void ElmRun();
+        [LibraryImport(Libraries.Elementary, EntryPoint = "elm_run", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void ElmRun();
 
-        [DllImport(Libraries.Elementary, EntryPoint = "elm_exit")]
-        internal static extern void ElmExit();
+        [LibraryImport(Libraries.Elementary, EntryPoint = "elm_exit", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void ElmExit();
 
-        [DllImport(Libraries.Elementary, EntryPoint = "elm_shutdown")]
-        internal static extern void ElmShutdown();
+        [LibraryImport(Libraries.Elementary, EntryPoint = "elm_shutdown", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void ElmShutdown();
     }
 }
+
+
+

--- a/src/Tizen.Applications.ComponentBased.Default/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.ComponentBased.Default/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -22,3 +22,6 @@ internal static partial class Interop
         public const string CompApplication = "libcomponent-based-application.so.1";
     }
 }
+
+
+

--- a/src/Tizen.Applications.ComponentBased.Port/Interop/Interop.ComponentPort.cs
+++ b/src/Tizen.Applications.ComponentBased.Port/Interop/Interop.ComponentPort.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 using Tizen.Applications.ComponentBased;
 
@@ -49,52 +50,55 @@ internal static partial class Interop
             PermissionDenied = Tizen.Internals.Errors.ErrorCode.PermissionDenied,
         }
 
-        [DllImport(Libraries.ComponentPort, EntryPoint = "component_port_create")]
-        internal static extern ErrorCode Create(string portName, out IntPtr handle);
+        [LibraryImport(Libraries.ComponentPort, EntryPoint = "component_port_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode Create(string portName, out IntPtr handle);
         // int component_port_create(const char *port_name, component_port_h *port);
 
-        [DllImport(Libraries.ComponentPort, EntryPoint = "component_port_destroy")]
-        internal static extern ErrorCode Destroy(IntPtr handle);
+        [LibraryImport(Libraries.ComponentPort, EntryPoint = "component_port_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode Destroy(IntPtr handle);
         // int component_port_destroy(component_port_h port);
 
-        [DllImport(Libraries.ComponentPort, EntryPoint = "component_port_set_request_cb")]
-        internal static extern ErrorCode SetRequestCb(IntPtr handle, ComponentPortRequestCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.ComponentPort, EntryPoint = "component_port_set_request_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetRequestCb(IntPtr handle, ComponentPortRequestCallback callback, IntPtr userData);
         // int component_port_set_request_cb(component_port_h port, component_port_request_cb callback, void *user_data);
 
-        [DllImport(Libraries.ComponentPort, EntryPoint = "component_port_set_sync_request_cb")]
-        internal static extern ErrorCode SetSyncRequestCb(IntPtr handle, ComponentPortSyncRequestCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.ComponentPort, EntryPoint = "component_port_set_sync_request_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetSyncRequestCb(IntPtr handle, ComponentPortSyncRequestCallback callback, IntPtr userData);
         // int component_port_set_sync_request_cb(component_port_h port, component_port_sync_request_cb callback, void *user_data);
 
-        [DllImport(Libraries.ComponentPort, EntryPoint = "component_port_add_privilege")]
-        internal static extern ErrorCode AddPrivilege(IntPtr handle, string privilege);
+        [LibraryImport(Libraries.ComponentPort, EntryPoint = "component_port_add_privilege", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AddPrivilege(IntPtr handle, string privilege);
         // int component_port_add_privilege(component_port_h port, const char *privilege);
 
-        [DllImport(Libraries.ComponentPort, EntryPoint = "component_port_wait_for_event")]
-        internal static extern void WaitForEvent(IntPtr handle);
+        [LibraryImport(Libraries.ComponentPort, EntryPoint = "component_port_wait_for_event", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void WaitForEvent(IntPtr handle);
         // void component_port_wait_for_event(component_port_h port);
 
-        [DllImport(Libraries.ComponentPort, EntryPoint = "component_port_cancel")]
-        internal static extern void Cancel(IntPtr handle);
+        [LibraryImport(Libraries.ComponentPort, EntryPoint = "component_port_cancel", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void Cancel(IntPtr handle);
         // void component_port_cancel(component_port_h port);
 
-        [DllImport(Libraries.ComponentPort, EntryPoint = "component_port_send")]
-        internal static extern ErrorCode Send(IntPtr handle, string endpoint, Int32 timeout, SafeParcelHandle request);
+        [LibraryImport(Libraries.ComponentPort, EntryPoint = "component_port_send", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode Send(IntPtr handle, string endpoint, Int32 timeout, SafeParcelHandle request);
         // int component_port_send(component_port_h port, const char *endpoint, int timeout, parcel_h request);
 
-        [DllImport(Libraries.ComponentPort, EntryPoint = "component_port_send_sync")]
-        internal static extern ErrorCode SendSync(IntPtr handle, string endpoint, Int32 timeout, SafeParcelHandle request, out SafeParcelHandle response);
+        [LibraryImport(Libraries.ComponentPort, EntryPoint = "component_port_send_sync", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SendSync(IntPtr handle, string endpoint, Int32 timeout, SafeParcelHandle request, out SafeParcelHandle response);
         // int component_port_send(component_port_h port, const char *endpoint, int timeout, parcel_h request, parcel_h *response);
 
-        [DllImport(Libraries.ComponentPort, EntryPoint = "component_port_is_running")]
-        internal static extern ErrorCode IsRunning(string endpoint, out bool isRunning);
-        // int component_port_is_running(const char *endpoint, bool *is_running);
+        [LibraryImport(Libraries.ComponentPort, EntryPoint = "component_port_is_running", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode IsRunning(string endpoint, [MarshalAs(UnmanagedType.U1)] out bool isRunning);
+        // int component_port_is_running(const char *endpoint, [MarshalAs(UnmanagedType.U1)] bool *is_running);
 
-        [DllImport(Libraries.ComponentPort, EntryPoint = "component_port_watch")]
-        internal static extern ErrorCode Watch(string endpoint, ComponentPortAppearedCallback appearedCallback, ComponentPortVanishedCallback vanishedCallback, IntPtr userData, out uint watcherId);
+        [LibraryImport(Libraries.ComponentPort, EntryPoint = "component_port_watch", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode Watch(string endpoint, ComponentPortAppearedCallback appearedCallback, ComponentPortVanishedCallback vanishedCallback, IntPtr userData, out uint watcherId);
         // int component_port_watch(const char *endpoint, component_port_appeared_cb appeared_cb, component_port_vanished_cb vanished_cb, void *user_data, unsigned int *watcher_id);
 
-        [DllImport(Libraries.ComponentPort, EntryPoint = "component_port_unwatch")]
-        internal static extern ErrorCode Unwatch(uint watcherId);
+        [LibraryImport(Libraries.ComponentPort, EntryPoint = "component_port_unwatch", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode Unwatch(uint watcherId);
         // int component_port_unwatch(unsigned int watcher_id);
     }
 }
+
+
+

--- a/src/Tizen.Applications.ComponentBased.Port/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.ComponentBased.Port/Interop/Interop.Libraries.cs
@@ -22,3 +22,5 @@ internal static partial class Interop
         public const string Parcel = "libparcel.so.0";
     }
 }
+
+

--- a/src/Tizen.Applications.ComponentBased.Port/Interop/Interop.Parcel.cs
+++ b/src/Tizen.Applications.ComponentBased.Port/Interop/Interop.Parcel.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Internals;
 using Tizen.Applications;
 
@@ -32,20 +33,22 @@ internal static partial class Interop
             OutOfMemory = Tizen.Internals.Errors.ErrorCode.OutOfMemory,
         }
 
-        [DllImport(Libraries.Parcel, EntryPoint = "parcel_create")]
-        internal static extern ErrorCode Create(out SafeParcelHandle handle);
+        [LibraryImport(Libraries.Parcel, EntryPoint = "parcel_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode Create(out SafeParcelHandle handle);
         // int parcel_create(parcel_h *parcel);
 
-        [DllImport(Libraries.Parcel, EntryPoint = "parcel_destroy")]
-        internal static extern ErrorCode DangerousDestroy(IntPtr handle);
+        [LibraryImport(Libraries.Parcel, EntryPoint = "parcel_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode DangerousDestroy(IntPtr handle);
         // int parcel_destroy(parcel_h parcel);
 
-        [DllImport(Libraries.Parcel, EntryPoint = "parcel_get_raw")]
-        internal static extern ErrorCode GetRaw(SafeParcelHandle handle, out IntPtr raw, out UInt32 size);
+        [LibraryImport(Libraries.Parcel, EntryPoint = "parcel_get_raw", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetRaw(SafeParcelHandle handle, out IntPtr raw, out UInt32 size);
         // int parcel_get_raw(parcel_h parcel, void **raw, uint32_t *size);
 
-        [DllImport(Libraries.Parcel, EntryPoint = "parcel_reset")]
-        internal static extern ErrorCode Reset(SafeParcelHandle handle, byte[] buf, UInt32 size);
+        [LibraryImport(Libraries.Parcel, EntryPoint = "parcel_reset", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode Reset(SafeParcelHandle handle, byte[] buf, UInt32 size);
         // int parcel_reset(parcel_h parcel, const void *buf, uint32_t size);
     }
 }
+
+

--- a/src/Tizen.Applications.ComponentBased/Interop/Interop.AppControl.cs
+++ b/src/Tizen.Applications.ComponentBased/Interop/Interop.AppControl.cs
@@ -16,13 +16,17 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 
 internal static partial class Interop
 {
     internal static partial class AppControl
     {
-        [DllImport(Libraries.AppControl, EntryPoint = "app_control_set_caller_instance_id")]
-        internal static extern int SetCallerInstanceId(SafeAppControlHandle appControl, string instanceId);
+        [LibraryImport(Libraries.AppControl, EntryPoint = "app_control_set_caller_instance_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetCallerInstanceId(SafeAppControlHandle appControl, string instanceId);
     }
 }
+
+
+

--- a/src/Tizen.Applications.ComponentBased/Interop/Interop.CBApplication.cs
+++ b/src/Tizen.Applications.ComponentBased/Interop/Interop.CBApplication.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Internals;
 using Tizen.Applications;
 
@@ -70,7 +71,7 @@ internal static partial class Interop
         }
 
         internal delegate IntPtr FrameCreateCallback(IntPtr context, IntPtr userData);
-        internal delegate void FrameStartCallback(IntPtr context, IntPtr appControl, bool restarted, IntPtr userData);
+        internal delegate void FrameStartCallback(IntPtr context, IntPtr appControl, [MarshalAs(UnmanagedType.U1)] bool restarted, IntPtr userData);
         internal delegate void FrameResumeCallback(IntPtr context, IntPtr userData);
         internal delegate void FramePauseCallback(IntPtr context, IntPtr userData);
         internal delegate void FrameStopCallback(IntPtr context, IntPtr userData);
@@ -106,8 +107,8 @@ internal static partial class Interop
             public FrameTimeZoneChangedCallback OnTimeZoneChanged;
         }
 
-        internal delegate bool ServiceCreateCallback(IntPtr context, IntPtr userData);
-        internal delegate void ServiceStartCommandCallback(IntPtr context, IntPtr appControl, bool restarted, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool ServiceCreateCallback(IntPtr context, IntPtr userData);
+        internal delegate void ServiceStartCommandCallback(IntPtr context, IntPtr appControl, [MarshalAs(UnmanagedType.U1)] bool restarted, IntPtr userData);
         internal delegate void ServiceDestroyCallback(IntPtr context, IntPtr userData);
         internal delegate void ServiceRestoreCallback(IntPtr context, IntPtr content, IntPtr userData);
         internal delegate void ServiceSaveCallback(IntPtr context, IntPtr content, IntPtr userData);
@@ -138,11 +139,11 @@ internal static partial class Interop
         }
 
         internal delegate IntPtr WidgetCreateCallback(IntPtr context, int width, int height, IntPtr userData);
-        internal delegate void WidgetStartCallback(IntPtr context, bool restarted, IntPtr userData);
+        internal delegate void WidgetStartCallback(IntPtr context, [MarshalAs(UnmanagedType.U1)] bool restarted, IntPtr userData);
         internal delegate void WidgetResumeCallback(IntPtr context, IntPtr userData);
         internal delegate void WidgetPauseCallback(IntPtr context, IntPtr userData);
         internal delegate void WidgetStopCallback(IntPtr context, IntPtr userData);
-        internal delegate void WidgetDestroyCallback(IntPtr context, bool permanent, IntPtr userData);
+        internal delegate void WidgetDestroyCallback(IntPtr context, [MarshalAs(UnmanagedType.U1)] bool permanent, IntPtr userData);
         internal delegate void WidgetRestoreCallback(IntPtr context, IntPtr content, IntPtr userData);
         internal delegate void WidgetSaveCallback(IntPtr context, IntPtr content, IntPtr userData);
         internal delegate void WidgetDeviceOrientationChangedCallback(IntPtr context, int orientation, IntPtr userData);
@@ -184,44 +185,44 @@ internal static partial class Interop
         internal delegate void BaseSuspendedStateCallback(IntPtr context, int state, IntPtr userData);
         internal delegate void BaseTimeZoneChangedCallback(IntPtr context, string timeZone, string timeZoneId, IntPtr userData);
 
-        [DllImport(Libraries.CompCoreBase, EntryPoint = "component_based_app_base_main")]
+        [DllImport(Libraries.CompCoreBase, EntryPoint = "component_based_app_base_main", CallingConvention = CallingConvention.Cdecl)]
         internal static extern ErrorCode BaseMain(int argc, string[] argv, ref CBAppLifecycleCallbacks callback, IntPtr userData);
 
-        [DllImport(Libraries.CompCoreBase, EntryPoint = "component_based_app_base_exit")]
-        internal static extern ErrorCode BaseExit();
+        [LibraryImport(Libraries.CompCoreBase, EntryPoint = "component_based_app_base_exit", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode BaseExit();
 
-        [DllImport(Libraries.CompCoreBase, EntryPoint = "component_based_app_base_add_frame_component")]
+        [DllImport(Libraries.CompCoreBase, EntryPoint = "component_based_app_base_add_frame_component", CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr BaseAddFrameComponent(IntPtr comp_class, string compId, ref FrameLifecycleCallbacks callback, IntPtr userData);
 
-        [DllImport(Libraries.CompCoreBase, EntryPoint = "component_based_app_base_add_service_component")]
+        [DllImport(Libraries.CompCoreBase, EntryPoint = "component_based_app_base_add_service_component", CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr BaseAddServiceComponent(IntPtr comp_class, string compId, ref ServiceLifecycleCallbacks callback, IntPtr userData);
 
-        [DllImport(Libraries.WidgetCompCoreBase, EntryPoint = "component_based_app_base_add_widget_component")]
+        [DllImport(Libraries.WidgetCompCoreBase, EntryPoint = "component_based_app_base_add_widget_component", CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr BaseAddWidgetComponent(IntPtr comp_class, string compId, ref WidgetLifecycleCallbacks callback, IntPtr userData);
 
-        [DllImport(Libraries.CompCoreBase, EntryPoint = "base_frame_create_window")]
-        internal static extern IntPtr BaseFrameCreateWindow(out IntPtr winHandle, int winId, IntPtr raw);
+        [LibraryImport(Libraries.CompCoreBase, EntryPoint = "base_frame_create_window", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr BaseFrameCreateWindow(out IntPtr winHandle, int winId, IntPtr raw);
 
-        [DllImport(Libraries.CompCoreBase, EntryPoint = "base_frame_window_get_compId")]
-        internal static extern IntPtr BaseFrameWindowGetId(IntPtr winHandle, out int winId);
+        [LibraryImport(Libraries.CompCoreBase, EntryPoint = "base_frame_window_get_compId", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr BaseFrameWindowGetId(IntPtr winHandle, out int winId);
 
-        [DllImport(Libraries.CompCoreBase, EntryPoint = "base_frame_window_get_raw")]
-        internal static extern IntPtr BaseFrameWindowGetRaw(IntPtr winHandle, out IntPtr raw);
+        [LibraryImport(Libraries.CompCoreBase, EntryPoint = "base_frame_window_get_raw", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr BaseFrameWindowGetRaw(IntPtr winHandle, out IntPtr raw);
 
-        [DllImport(Libraries.CompCoreBase, EntryPoint = "base_frame_get_display_status")]
-        internal static extern ErrorCode BaseFrameGetDisplayStatus(IntPtr context, out NativeDisplayStatus status);
+        [LibraryImport(Libraries.CompCoreBase, EntryPoint = "base_frame_get_display_status", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode BaseFrameGetDisplayStatus(IntPtr context, out NativeDisplayStatus status);
 
-        [DllImport(Libraries.WidgetCompCoreBase, EntryPoint = "base_widget_create_window")]
-        internal static extern IntPtr BaseWidgetCreateWindow(out IntPtr winHandle, int winId, IntPtr raw);
+        [LibraryImport(Libraries.WidgetCompCoreBase, EntryPoint = "base_widget_create_window", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr BaseWidgetCreateWindow(out IntPtr winHandle, int winId, IntPtr raw);
 
-        [DllImport(Libraries.WidgetCompCoreBase, EntryPoint = "base_widget_window_get_id")]
-        internal static extern IntPtr BaseWidgetWindowGetId(IntPtr winHandle, out int winId);
+        [LibraryImport(Libraries.WidgetCompCoreBase, EntryPoint = "base_widget_window_get_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr BaseWidgetWindowGetId(IntPtr winHandle, out int winId);
 
-        [DllImport(Libraries.WidgetCompCoreBase, EntryPoint = "base_widget_window_get_raw")]
-        internal static extern IntPtr BaseWidgetWindowGetRaw(IntPtr winHandle, out IntPtr raw);
+        [LibraryImport(Libraries.WidgetCompCoreBase, EntryPoint = "base_widget_window_get_raw", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr BaseWidgetWindowGetRaw(IntPtr winHandle, out IntPtr raw);
 
-        [DllImport(Libraries.CompCoreBase, EntryPoint = "component_get_instance_id")]
-        internal static extern ErrorCode GetInstanceId(IntPtr context, out string instanceId);
+        [LibraryImport(Libraries.CompCoreBase, EntryPoint = "component_get_instance_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetInstanceId(IntPtr context, out string instanceId);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void ReplyCallback(IntPtr request, IntPtr reply, int result, IntPtr userData);
@@ -229,15 +230,19 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void ResultCallback(IntPtr request, int result, IntPtr userData);
 
-        [DllImport(Libraries.CompCoreBase, EntryPoint = "component_send_launch_request_async")]
-        internal static extern ErrorCode SendLaunchRequestAsync(IntPtr context, SafeAppControlHandle appControl,
+        [LibraryImport(Libraries.CompCoreBase, EntryPoint = "component_send_launch_request_async", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SendLaunchRequestAsync(IntPtr context, SafeAppControlHandle appControl,
             ResultCallback resultCallback, ReplyCallback replyCallback, IntPtr userData);
 
-        [DllImport(Libraries.CompCoreBase, EntryPoint = "component_send_launch_request_sync")]
-        internal static extern ErrorCode SendLaunchRequestSync(IntPtr context, SafeAppControlHandle appControl,
+        [LibraryImport(Libraries.CompCoreBase, EntryPoint = "component_send_launch_request_sync", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SendLaunchRequestSync(IntPtr context, SafeAppControlHandle appControl,
             SafeAppControlHandle replyControl, out int result);
 
-        [DllImport(Libraries.CompCoreBase, EntryPoint = "component_finish")]
-        internal static extern ErrorCode ComponentFinish(IntPtr context);
+        [LibraryImport(Libraries.CompCoreBase, EntryPoint = "component_finish", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ComponentFinish(IntPtr context);
     }
 }
+
+
+
+

--- a/src/Tizen.Applications.ComponentBased/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.ComponentBased/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -27,3 +27,6 @@ internal static partial class Interop
         public const string AppControl = "libcapi-appfw-app-control.so.0";
     }
 }
+
+
+

--- a/src/Tizen.Applications.DataControl/Interop/Interop.DataControl.cs
+++ b/src/Tizen.Applications.DataControl/Interop/Interop.DataControl.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using System.Text;
 using Tizen.Applications;
 using Tizen.Internals;
@@ -43,17 +44,15 @@ internal static partial class Interop
             {
             }
 
-            internal SafeBulkDataHandle(IntPtr existingHandle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+            internal SafeBulkDataHandle(IntPtr existingHandle, [MarshalAs(UnmanagedType.U1)] bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
             {
                 SetHandle(existingHandle);
             }
-
-            public override bool IsInvalid
+        public override bool IsInvalid
             {
                 get { return this.handle == IntPtr.Zero; }
             }
-
-            protected override bool ReleaseHandle()
+        protected override bool ReleaseHandle()
             {
                 DataControl.BulkFree(this.handle);
                 this.SetHandle(IntPtr.Zero);
@@ -68,17 +67,15 @@ internal static partial class Interop
             {
             }
 
-            internal SafeBulkResultDataHandle(IntPtr existingHandle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+            internal SafeBulkResultDataHandle(IntPtr existingHandle, [MarshalAs(UnmanagedType.U1)] bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
             {
                 SetHandle(existingHandle);
             }
-
-            public override bool IsInvalid
+        public override bool IsInvalid
             {
                 get { return this.handle == IntPtr.Zero; }
             }
-
-            protected override bool ReleaseHandle()
+        protected override bool ReleaseHandle()
             {
                 DataControl.BulkResultFree(this.handle);
                 this.SetHandle(IntPtr.Zero);
@@ -93,17 +90,15 @@ internal static partial class Interop
             {
             }
 
-            internal SafeCursorHandle(IntPtr existingHandle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+            internal SafeCursorHandle(IntPtr existingHandle, [MarshalAs(UnmanagedType.U1)] bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
             {
                 SetHandle(existingHandle);
             }
-
-            public override bool IsInvalid
+        public override bool IsInvalid
             {
                 get { return this.handle == IntPtr.Zero; }
             }
-
-            protected override bool ReleaseHandle()
+        protected override bool ReleaseHandle()
             {
                 this.SetHandle(IntPtr.Zero);
                 return true;
@@ -117,17 +112,15 @@ internal static partial class Interop
             {
             }
 
-            internal SafeDataControlHandle(IntPtr existingHandle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+            internal SafeDataControlHandle(IntPtr existingHandle, [MarshalAs(UnmanagedType.U1)] bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
             {
                 SetHandle(existingHandle);
             }
-
-            public override bool IsInvalid
+        public override bool IsInvalid
             {
                 get { return this.handle == IntPtr.Zero; }
             }
-
-            protected override bool ReleaseHandle()
+        protected override bool ReleaseHandle()
             {
                 DataControl.Destroy(this.handle);
                 this.SetHandle(IntPtr.Zero);
@@ -154,15 +147,15 @@ internal static partial class Interop
         internal static extern ResultType DataControlGetDataId(SafeDataControlHandle handle, out string dataId);
 
         internal delegate void MapGetResponseCallback(int requestID,
-            IntPtr provider, IntPtr resultValueList, int resultValueCount, bool providerResult, string error, IntPtr userData);
+            IntPtr provider, IntPtr resultValueList, int resultValueCount, [MarshalAs(UnmanagedType.U1)] bool providerResult, string error, IntPtr userData);
         internal delegate void MapSetResponseCallback(int requestID,
-            IntPtr provider, bool providerResult, string error, IntPtr userData);
+            IntPtr provider, [MarshalAs(UnmanagedType.U1)] bool providerResult, string error, IntPtr userData);
         internal delegate void MapAddResponseCallback(int requestID,
-            IntPtr provider, bool providerResult, string error, IntPtr userData);
+            IntPtr provider, [MarshalAs(UnmanagedType.U1)] bool providerResult, string error, IntPtr userData);
         internal delegate void MapRemoveResponseCallback(int requestID,
-            IntPtr provider, bool providerResult, string error, IntPtr userData);
+            IntPtr provider, [MarshalAs(UnmanagedType.U1)] bool providerResult, string error, IntPtr userData);
         internal delegate void MapBulkAddResponseCallback(int requestID,
-            IntPtr provider, IntPtr bulkResults, bool providerResult, string error, IntPtr userData);
+            IntPtr provider, IntPtr bulkResults, [MarshalAs(UnmanagedType.U1)] bool providerResult, string error, IntPtr userData);
 
         [NativeStruct("data_control_map_response_cb", Include="data_control.h", PkgConfig="data-control")]
         [StructLayoutAttribute(LayoutKind.Sequential)]
@@ -175,15 +168,15 @@ internal static partial class Interop
         }
 
         internal delegate void SqlSelectResponseCallback(int requestID,
-            IntPtr provider, IntPtr cursor, bool providerResult, string error, IntPtr userData);
+            IntPtr provider, IntPtr cursor, [MarshalAs(UnmanagedType.U1)] bool providerResult, string error, IntPtr userData);
         internal delegate void SqlInsertResponseCallback(int requestID,
-            IntPtr provider, long inserted_row_id, bool providerResult, string error, IntPtr userData);
+            IntPtr provider, long inserted_row_id, [MarshalAs(UnmanagedType.U1)] bool providerResult, string error, IntPtr userData);
         internal delegate void SqlUpdateResponseCallback(int requestID,
-            IntPtr provider, bool providerResult, string error, IntPtr userData);
+            IntPtr provider, [MarshalAs(UnmanagedType.U1)] bool providerResult, string error, IntPtr userData);
         internal delegate void SqlDeleteResponseCallback(int requestID,
-            IntPtr provider, bool providerResult, string error, IntPtr userData);
+            IntPtr provider, [MarshalAs(UnmanagedType.U1)] bool providerResult, string error, IntPtr userData);
         internal delegate void SqlBulkInsertResponseCallback(int requestID,
-            IntPtr provider, IntPtr bulk_results, bool providerResult, string error, IntPtr userData);
+            IntPtr provider, IntPtr bulk_results, [MarshalAs(UnmanagedType.U1)] bool providerResult, string error, IntPtr userData);
 
         [NativeStruct("data_control_sql_response_cb", Include="data_control.h", PkgConfig="data-control")]
         [StructLayoutAttribute(LayoutKind.Sequential)]
@@ -434,17 +427,17 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void DataChangeCallback(IntPtr handle, ChangeType type, IntPtr data, IntPtr userData);
 
-        [DllImport(Libraries.DataControl, EntryPoint = "data_control_add_data_change_cb", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.DataControl, EntryPoint = "data_control_add_data_change_cb")]
         internal static extern ResultType AddDataChangeCallback(SafeDataControlHandle provider, DataChangeCallback callback,
             IntPtr userData, AddCallbackResultCallback resultCallback, IntPtr resultCbUserData, out int callbackID);
 
-        [DllImport(Libraries.DataControl, EntryPoint = "data_control_remove_data_change_cb", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.DataControl, EntryPoint = "data_control_remove_data_change_cb")]
         internal static extern ResultType RemoveDataChangeCallback(SafeDataControlHandle provider, int callbackID);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool DataChangeConsumerFilterCb(IntPtr handle, string consumerAppid, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool DataChangeConsumerFilterCb(IntPtr handle, string consumerAppid, IntPtr userData);
 
-        [DllImport(Libraries.DataControl, EntryPoint = "data_control_provider_add_data_change_consumer_filter_cb", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.DataControl, EntryPoint = "data_control_provider_add_data_change_consumer_filter_cb")]
         internal static extern ResultType AddDataChangeConsumerFilterCallback(DataChangeConsumerFilterCb callback,
             IntPtr userData,
             out int callbackID);
@@ -458,7 +451,7 @@ internal static partial class Interop
         [DllImport(Libraries.DataControl, EntryPoint = "data_control_provider_send_map_bulk_add_result")]
         internal static extern ResultType SendMapBulkAddResult(int requestId, SafeBulkResultDataHandle result);
 
-        internal static class UnsafeCode
+        internal static partial class UnsafeCode
         {
             internal static unsafe ResultType WriteResult(int socketFd, byte[] value, int nbytes, out uint bytesWrite)
             {
@@ -471,3 +464,10 @@ internal static partial class Interop
 
     }
 }
+
+
+
+
+
+
+

--- a/src/Tizen.Applications.DataControl/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.DataControl/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string DataControl = "libdata-control.so.0";
     }
 }
+
+
+

--- a/src/Tizen.Applications.EventManager/Interop/Interop.AppEvent.cs
+++ b/src/Tizen.Applications.EventManager/Interop/Interop.AppEvent.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Tizen.Applications;
 
@@ -36,19 +37,22 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void EventCallback(string eventName, IntPtr eventData, IntPtr userData);
 
-        [DllImport(Libraries.AppEvent, EntryPoint = "event_add_event_handler")]
-        internal static extern ErrorCode EventAddHandler(string eventName, EventCallback cb, IntPtr userData, out IntPtr handle);
+        [LibraryImport(Libraries.AppEvent, EntryPoint = "event_add_event_handler", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode EventAddHandler(string eventName, EventCallback cb, IntPtr userData, out IntPtr handle);
 
-        [DllImport(Libraries.AppEvent, EntryPoint = "event_remove_event_handler")]
-        internal static extern ErrorCode EventRemoveHandler(IntPtr handle);
+        [LibraryImport(Libraries.AppEvent, EntryPoint = "event_remove_event_handler", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode EventRemoveHandler(IntPtr handle);
 
-        [DllImport(Libraries.AppEvent, EntryPoint = "event_publish_app_event")]
-        internal static extern ErrorCode EventPublishAppEvent(string eventName, SafeBundleHandle eventData);
+        [LibraryImport(Libraries.AppEvent, EntryPoint = "event_publish_app_event", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode EventPublishAppEvent(string eventName, SafeBundleHandle eventData);
 
-        [DllImport(Libraries.AppEvent, EntryPoint = "event_publish_trusted_app_event")]
-        internal static extern ErrorCode EventPublishTrustedAppEvent(string eventName, SafeBundleHandle eventData);
+        [LibraryImport(Libraries.AppEvent, EntryPoint = "event_publish_trusted_app_event", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode EventPublishTrustedAppEvent(string eventName, SafeBundleHandle eventData);
 
-        [DllImport(Libraries.AppEvent, EntryPoint = "event_keep_last_event_data")]
-        internal static extern ErrorCode EventKeepLastEventData(string eventName);
+        [LibraryImport(Libraries.AppEvent, EntryPoint = "event_keep_last_event_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode EventKeepLastEventData(string eventName);
     }
 }
+
+
+

--- a/src/Tizen.Applications.EventManager/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.EventManager/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string AppEvent = "libcapi-appfw-event.so.0";
     }
 }
+
+
+

--- a/src/Tizen.Applications.MessagePort/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.MessagePort/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string MessagePort = "libmessage-port.so.1";
     }
 }
+
+
+

--- a/src/Tizen.Applications.MessagePort/Interop/Interop.MessagePort.cs
+++ b/src/Tizen.Applications.MessagePort/Interop/Interop.MessagePort.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Tizen.Applications;
 
@@ -23,43 +24,47 @@ internal static partial class Interop
 {
     internal static partial class MessagePort
     {
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_register_local_port", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int RegisterPort(string local_port, message_port_message_cb callback, IntPtr userData);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_register_local_port", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RegisterPort(string local_port, message_port_message_cb callback, IntPtr userData);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_register_trusted_local_port", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int RegisterTrustedPort(string trusted_local_port, message_port_message_cb callback, IntPtr userData);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_register_trusted_local_port", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RegisterTrustedPort(string trusted_local_port, message_port_message_cb callback, IntPtr userData);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_unregister_local_port", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int UnregisterPort(int local_port_id);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_unregister_local_port", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UnregisterPort(int local_port_id);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_unregister_trusted_local_port", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int UnregisterTrustedPort(int trusted_local_port_id);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_unregister_trusted_local_port", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UnregisterTrustedPort(int trusted_local_port_id);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_send_message_with_local_port", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int SendMessageWithLocalPort(string remote_app_id, string remote_port, SafeBundleHandle message, int local_port_id);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_send_message_with_local_port", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SendMessageWithLocalPort(string remote_app_id, string remote_port, SafeBundleHandle message, int local_port_id);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_send_trusted_message_with_local_port", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int SendTrustedMessageWithLocalPort(string remote_app_id, string remote_port, SafeBundleHandle message, int local_port_id);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_send_trusted_message_with_local_port", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SendTrustedMessageWithLocalPort(string remote_app_id, string remote_port, SafeBundleHandle message, int local_port_id);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_check_remote_port", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int CheckRemotePort(string remote_app_id, string remote_port, out bool exist);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_check_remote_port", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CheckRemotePort(string remote_app_id, string remote_port, [MarshalAs(UnmanagedType.U1)] out bool exist);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_check_trusted_remote_port", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int CheckTrustedRemotePort(string remote_app_id, string remote_port, out bool exist);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_check_trusted_remote_port", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CheckTrustedRemotePort(string remote_app_id, string remote_port, [MarshalAs(UnmanagedType.U1)] out bool exist);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_add_registered_cb", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int AddRegisteredCallback(string remote_app_id, string remote_port, bool trusted_remote_port, message_port_registration_event_cb callback, IntPtr userData, out int watcher_id);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_add_registered_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int AddRegisteredCallback(string remote_app_id, string remote_port, [MarshalAs(UnmanagedType.U1)] bool trusted_remote_port, message_port_registration_event_cb callback, IntPtr userData, out int watcher_id);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_add_unregistered_cb", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int AddUnregisteredCallback(string remote_app_id, string remote_port, bool trusted_remote_port, message_port_registration_event_cb callback, IntPtr userData, out int watcher_id);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_add_unregistered_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int AddUnregisteredCallback(string remote_app_id, string remote_port, [MarshalAs(UnmanagedType.U1)] bool trusted_remote_port, message_port_registration_event_cb callback, IntPtr userData, out int watcher_id);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_remove_registration_event_cb", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int RemoveRegistrationCallback(int watcher_id);
-
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void message_port_message_cb(int local_port_id, string remote_app_id, string remote_port, bool trusted_remote_port, IntPtr message, IntPtr userData);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_remove_registration_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RemoveRegistrationCallback(int watcher_id);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void message_port_registration_event_cb(string remote_app_id, string remote_port, bool trusted_remote_port, IntPtr userData);
+        internal delegate void message_port_message_cb(int local_port_id, string remote_app_id, string remote_port, [MarshalAs(UnmanagedType.U1)] bool trusted_remote_port, IntPtr message, IntPtr userData);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void message_port_registration_event_cb(string remote_app_id, string remote_port, [MarshalAs(UnmanagedType.U1)] bool trusted_remote_port, IntPtr userData);
     }
 }
+
+
+
+

--- a/src/Tizen.Applications.Notification/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.Notification/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string Notification = "libnotification.so.0";
     }
 }
+
+
+

--- a/src/Tizen.Applications.Notification/Interop/Interop.Notification.cs
+++ b/src/Tizen.Applications.Notification/Interop/Interop.Notification.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,249 +16,250 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 using Tizen.Applications.Notifications;
 
 internal static partial class Interop
 {
-    internal static class Notification
+    internal static partial class Notification
     {
         internal delegate void ResponseEventCallback(IntPtr ptr, int type, IntPtr userData);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_create")]
-        internal static extern IntPtr Create(NotificationType type);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr Create(NotificationType type);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_free")]
-        internal static extern NotificationError Destroy(IntPtr handle);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_free", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError Destroy(IntPtr handle);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_text")]
-        internal static extern NotificationError GetTextReferenceType(NotificationSafeHandle handle, NotificationText type, out IntPtr text);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_text", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetTextReferenceType(NotificationSafeHandle handle, NotificationText type, out IntPtr text);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_text")]
-        internal static extern NotificationError SetText(NotificationSafeHandle handle, NotificationText type, string text, string key, int args);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_text", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetText(NotificationSafeHandle handle, NotificationText type, string text, string key, int args);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_image")]
-        internal static extern NotificationError GetImageReferenceType(NotificationSafeHandle handle, NotificationImage type, out IntPtr path);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_image", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetImageReferenceType(NotificationSafeHandle handle, NotificationImage type, out IntPtr path);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_image")]
-        internal static extern NotificationError SetImage(NotificationSafeHandle handle, NotificationImage type, string path);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_image", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetImage(NotificationSafeHandle handle, NotificationImage type, string path);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_time")]
-        internal static extern NotificationError GetTime(NotificationSafeHandle handle, out int time);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_time", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetTime(NotificationSafeHandle handle, out int time);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_time")]
-        internal static extern NotificationError SetTime(NotificationSafeHandle handle, int time);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_time", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetTime(NotificationSafeHandle handle, int time);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_insert_time")]
-        internal static extern NotificationError GetInsertTime(NotificationSafeHandle handle, out long time);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_insert_time", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetInsertTime(NotificationSafeHandle handle, out long time);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_sound")]
-        internal static extern NotificationError GetSoundReferenceType(NotificationSafeHandle handle, out AccessoryOption type, out IntPtr path);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_sound", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetSoundReferenceType(NotificationSafeHandle handle, out AccessoryOption type, out IntPtr path);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_sound")]
-        internal static extern NotificationError SetSound(NotificationSafeHandle handle, AccessoryOption type, string path);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_sound", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetSound(NotificationSafeHandle handle, AccessoryOption type, string path);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_vibration")]
-        internal static extern NotificationError GetVibrationReferenceType(NotificationSafeHandle handle, out AccessoryOption type, out IntPtr path);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_vibration", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetVibrationReferenceType(NotificationSafeHandle handle, out AccessoryOption type, out IntPtr path);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_vibration")]
-        internal static extern NotificationError SetVibration(NotificationSafeHandle handle, AccessoryOption type, string path);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_vibration", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetVibration(NotificationSafeHandle handle, AccessoryOption type, string path);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_led")]
-        internal static extern NotificationError GetLed(NotificationSafeHandle handle, out AccessoryOption type, out int color);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_led", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetLed(NotificationSafeHandle handle, out AccessoryOption type, out int color);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_led")]
-        internal static extern NotificationError SetLed(NotificationSafeHandle handle, AccessoryOption type, int color);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_led", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetLed(NotificationSafeHandle handle, AccessoryOption type, int color);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_led_time_period")]
-        internal static extern NotificationError GetLedTimePeriod(NotificationSafeHandle handle, out int onMillisecond, out int offMillisecond);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_led_time_period", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetLedTimePeriod(NotificationSafeHandle handle, out int onMillisecond, out int offMillisecond);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_led_time_period")]
-        internal static extern NotificationError SetLedTimePeriod(NotificationSafeHandle handle, int onMillisecond, int offMillisecond);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_led_time_period", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetLedTimePeriod(NotificationSafeHandle handle, int onMillisecond, int offMillisecond);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_launch_option")]
-        internal static extern NotificationError GetAppControl(NotificationSafeHandle handle, LaunchOption type, out SafeAppControlHandle apphandle);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_launch_option", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetAppControl(NotificationSafeHandle handle, LaunchOption type, out SafeAppControlHandle apphandle);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_launch_option")]
-        internal static extern NotificationError SetAppControl(NotificationSafeHandle handle, LaunchOption type, SafeAppControlHandle appHandle);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_launch_option", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetAppControl(NotificationSafeHandle handle, LaunchOption type, SafeAppControlHandle appHandle);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_event_handler")]
-        internal static extern NotificationError GetEventHandler(NotificationSafeHandle handle, int type, out SafeAppControlHandle appHandle);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_event_handler", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetEventHandler(NotificationSafeHandle handle, int type, out SafeAppControlHandle appHandle);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_event_handler")]
-        internal static extern NotificationError SetEventHandler(NotificationSafeHandle handle, int type, SafeAppControlHandle appHandle);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_event_handler", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetEventHandler(NotificationSafeHandle handle, int type, SafeAppControlHandle appHandle);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_property")]
-        internal static extern NotificationError GetProperties(NotificationSafeHandle handle, out int flags);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_property", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetProperties(NotificationSafeHandle handle, out int flags);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_property")]
-        internal static extern NotificationError SetProperties(NotificationSafeHandle handle, int flags);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_property", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetProperties(NotificationSafeHandle handle, int flags);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_display_applist")]
-        internal static extern NotificationError GetApplist(NotificationSafeHandle handle, out int flags);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_display_applist", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetApplist(NotificationSafeHandle handle, out int flags);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_display_applist")]
-        internal static extern NotificationError SetApplist(NotificationSafeHandle handle, int flags);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_display_applist", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetApplist(NotificationSafeHandle handle, int flags);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_size")]
-        internal static extern NotificationError GetProgressSize(NotificationSafeHandle handle, out double size);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_size", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetProgressSize(NotificationSafeHandle handle, out double size);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_size")]
-        internal static extern NotificationError SetProgressSize(NotificationSafeHandle handle, double size);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_size", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetProgressSize(NotificationSafeHandle handle, double size);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_progress")]
-        internal static extern NotificationError GetProgress(NotificationSafeHandle handle, out double progress);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_progress", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetProgress(NotificationSafeHandle handle, out double progress);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_progress")]
-        internal static extern NotificationError SetProgress(NotificationSafeHandle handle, double progress);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_progress", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetProgress(NotificationSafeHandle handle, double progress);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_layout")]
-        internal static extern NotificationError GetLayout(NotificationSafeHandle handle, out NotificationLayout layout);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_layout", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetLayout(NotificationSafeHandle handle, out NotificationLayout layout);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_layout")]
-        internal static extern NotificationError SetLayout(NotificationSafeHandle handle, NotificationLayout layout);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_layout", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetLayout(NotificationSafeHandle handle, NotificationLayout layout);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_type")]
-        internal static extern NotificationError GetType(NotificationSafeHandle handle, out NotificationType type);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetType(NotificationSafeHandle handle, out NotificationType type);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_update")]
-        internal static extern NotificationError Update(NotificationSafeHandle handle);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_update", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError Update(NotificationSafeHandle handle);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_delete")]
-        internal static extern NotificationError Delete(NotificationSafeHandle handle);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_delete", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError Delete(NotificationSafeHandle handle);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_delete_all")]
-        internal static extern NotificationError DeleteAll(int type);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_delete_all", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError DeleteAll(int type);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_post")]
-        internal static extern NotificationError Post(NotificationSafeHandle handle);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_post", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError Post(NotificationSafeHandle handle);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_post_with_event_cb")]
-        internal static extern NotificationError PostWithEventCallback(NotificationSafeHandle handle, ResponseEventCallback cb, IntPtr userdata);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_post_with_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError PostWithEventCallback(NotificationSafeHandle handle, ResponseEventCallback cb, IntPtr userdata);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_pkgname")]
-        internal static extern NotificationError GetPackageName(NotificationSafeHandle handle, out IntPtr name);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_pkgname", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetPackageName(NotificationSafeHandle handle, out IntPtr name);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_event_handler")]
-        internal static extern NotificationError AddButtonAction(NotificationSafeHandle handle, ButtonIndex type, SafeAppControlHandle appcontrol);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_event_handler", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError AddButtonAction(NotificationSafeHandle handle, ButtonIndex type, SafeAppControlHandle appcontrol);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_remove_button")]
-        internal static extern NotificationError RemoveButton(NotificationSafeHandle handle, ButtonIndex index);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_remove_button", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError RemoveButton(NotificationSafeHandle handle, ButtonIndex index);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_tag")]
-        internal static extern NotificationError SetTag(NotificationSafeHandle handle, string tag);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_tag", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetTag(NotificationSafeHandle handle, string tag);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_tag")]
-        internal static extern NotificationError GetTagReferenceType(NotificationSafeHandle handle, out IntPtr tag);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_tag", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetTagReferenceType(NotificationSafeHandle handle, out IntPtr tag);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_load_by_tag")]
-        internal static extern IntPtr Load(string text);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_load_by_tag", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr Load(string text);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_id")]
-        internal static extern NotificationError GetID(NotificationSafeHandle handle, out int groupID, out int privID);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetID(NotificationSafeHandle handle, out int groupID, out int privID);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_priv_id")]
-        internal static extern NotificationError SetID(NotificationSafeHandle handle, int privID);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_priv_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetID(NotificationSafeHandle handle, int privID);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_save_as_template")]
-        internal static extern NotificationError SaveTemplate(NotificationSafeHandle handle, string name);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_save_as_template", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SaveTemplate(NotificationSafeHandle handle, string name);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_create_from_template")]
-        internal static extern IntPtr LoadTemplate(string name);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_create_from_template", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr LoadTemplate(string name);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_noti_block_state")]
-        internal static extern NotificationError GetBlockState(out NotificationBlockState status);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_noti_block_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetBlockState(out NotificationBlockState status);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_auto_remove")]
-        internal static extern NotificationError SetAutoRemove(NotificationSafeHandle handle, bool autoRemove);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_auto_remove", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetAutoRemove(NotificationSafeHandle handle, [MarshalAs(UnmanagedType.U1)] bool autoRemove);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_auto_remove")]
-        internal static extern NotificationError GetAutoRemove(NotificationSafeHandle handle, out bool autoRemove);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_auto_remove", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetAutoRemove(NotificationSafeHandle handle, [MarshalAs(UnmanagedType.U1)] out bool autoRemove);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_ongoing_value_type")]
-        internal static extern NotificationError SetProgressType(NotificationSafeHandle handle, ProgressCategory category);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_ongoing_value_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetProgressType(NotificationSafeHandle handle, ProgressCategory category);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_ongoing_value_type")]
-        internal static extern NotificationError GetProgressType(NotificationSafeHandle handle, out ProgressCategory category);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_ongoing_value_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetProgressType(NotificationSafeHandle handle, out ProgressCategory category);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_ongoing_flag")]
-        internal static extern NotificationError SetOngoingFlag(NotificationSafeHandle handle, bool flag);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_ongoing_flag", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetOngoingFlag(NotificationSafeHandle handle, [MarshalAs(UnmanagedType.U1)] bool flag);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_ongoing_flag")]
-        internal static extern NotificationError GetProgressFlag(NotificationSafeHandle handle, bool flag);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_ongoing_flag", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetProgressFlag(NotificationSafeHandle handle, [MarshalAs(UnmanagedType.U1)] bool flag);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_ongoing_flag")]
-        internal static extern NotificationError GetProgressFlag(NotificationSafeHandle handle, out bool flag);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_ongoing_flag", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetProgressFlag(NotificationSafeHandle handle, [MarshalAs(UnmanagedType.U1)] out bool flag);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_text_input")]
-        internal static extern NotificationError SetPlaceHolderLength(NotificationSafeHandle handle, int length);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_text_input", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetPlaceHolderLength(NotificationSafeHandle handle, int length);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_text_input_max_length")]
-        internal static extern NotificationError GetPlaceHolderLength(NotificationSafeHandle handle, out int length);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_text_input_max_length", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetPlaceHolderLength(NotificationSafeHandle handle, out int length);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_hide_timeout")]
-        internal static extern NotificationError GetHideTime(NotificationSafeHandle handle, out int timeout);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_hide_timeout", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetHideTime(NotificationSafeHandle handle, out int timeout);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_hide_timeout")]
-        internal static extern NotificationError SetHideTime(NotificationSafeHandle handle, int timeout);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_hide_timeout", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetHideTime(NotificationSafeHandle handle, int timeout);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_delete_timeout")]
-        internal static extern NotificationError GetDeleteTime(NotificationSafeHandle handle, out int timeout);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_delete_timeout", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetDeleteTime(NotificationSafeHandle handle, out int timeout);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_delete_timeout")]
-        internal static extern NotificationError SetDeleteTime(NotificationSafeHandle handle, int timeout);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_delete_timeout", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetDeleteTime(NotificationSafeHandle handle, int timeout);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_extension_data")]
-        internal static extern NotificationError SetExtensionData(NotificationSafeHandle handle, string key, SafeBundleHandle bundleHandle);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_extension_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetExtensionData(NotificationSafeHandle handle, string key, SafeBundleHandle bundleHandle);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_extension_data")]
-        internal static extern NotificationError GetExtensionData(NotificationSafeHandle handle, string key, out SafeBundleHandle bundleHandle);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_extension_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetExtensionData(NotificationSafeHandle handle, string key, out SafeBundleHandle bundleHandle);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_args")]
-        internal static extern NotificationError GetExtensionBundle(NotificationSafeHandle handle, out IntPtr args, out IntPtr group_args);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_args", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetExtensionBundle(NotificationSafeHandle handle, out IntPtr args, out IntPtr group_args);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_default_button")]
-        internal static extern NotificationError GetDefaultButton(NotificationSafeHandle handle, out int index);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_default_button", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetDefaultButton(NotificationSafeHandle handle, out int index);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_default_button")]
-        internal static extern NotificationError SetDefaultButton(NotificationSafeHandle handle, int index);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_default_button", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetDefaultButton(NotificationSafeHandle handle, int index);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_extension_event_handler")]
-        internal static extern NotificationError SetExtensionAction(NotificationSafeHandle handle, NotificationEventType type, SafeAppControlHandle appcontrol);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_extension_event_handler", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetExtensionAction(NotificationSafeHandle handle, NotificationEventType type, SafeAppControlHandle appcontrol);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_extension_event_handler")]
-        internal static extern NotificationError GetExtensionAction(NotificationSafeHandle handle, NotificationEventType type, out SafeAppControlHandle appcontrol);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_extension_event_handler", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetExtensionAction(NotificationSafeHandle handle, NotificationEventType type, out SafeAppControlHandle appcontrol);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_clone")]
-        internal static extern NotificationError Clone(IntPtr handle, out IntPtr cloned);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_clone", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError Clone(IntPtr handle, out IntPtr cloned);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_check_box")]
-        internal static extern NotificationError SetCheckBox(NotificationSafeHandle handle, bool flag, bool checkedValue);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_check_box", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetCheckBox(NotificationSafeHandle handle, [MarshalAs(UnmanagedType.U1)] bool flag, [MarshalAs(UnmanagedType.U1)] bool checkedValue);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_check_box")]
-        internal static extern NotificationError GetCheckBox(NotificationSafeHandle handle, out bool flag, out bool checkedValue);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_check_box", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetCheckBox(NotificationSafeHandle handle, [MarshalAs(UnmanagedType.U1)] out bool flag, [MarshalAs(UnmanagedType.U1)] out bool checkedValue);
 
         /* apis for do not disturb app */
         internal delegate void DisturbCallback(IntPtr userData);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_register_do_not_disturb_app")]
-        internal static extern NotificationError RegisterDndApp(DisturbCallback cb, IntPtr userData);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_register_do_not_disturb_app", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError RegisterDndApp(DisturbCallback cb, IntPtr userData);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_unregister_do_not_disturb_app")]
-        internal static extern NotificationError UnRegisterDndApp();
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_unregister_do_not_disturb_app", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError UnRegisterDndApp();
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_pairing_type")]
-        internal static extern NotificationError SetPairingType(NotificationSafeHandle handle, bool pairing);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_pairing_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetPairingType(NotificationSafeHandle handle, [MarshalAs(UnmanagedType.U1)] bool pairing);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_pairing_type")]
-        internal static extern NotificationError GetPairingType(NotificationSafeHandle handle, out bool pairing);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_pairing_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetPairingType(NotificationSafeHandle handle, [MarshalAs(UnmanagedType.U1)] out bool pairing);
 
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_set_extension_image_size")]
-        internal static extern NotificationError SetExtensionImageSize(NotificationSafeHandle handle, int height);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_set_extension_image_size", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError SetExtensionImageSize(NotificationSafeHandle handle, int height);
 
-        [DllImport(Libraries.Notification, EntryPoint = "notification_get_extension_image_size")]
-        internal static extern NotificationError GetExtensionImageSize(NotificationSafeHandle handle, out int height);
+        [LibraryImport(Libraries.Notification, EntryPoint = "notification_get_extension_image_size", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial NotificationError GetExtensionImageSize(NotificationSafeHandle handle, out int height);
 
         internal static NotificationError GetText(NotificationSafeHandle handle, NotificationText type, out string text)
         {
@@ -351,3 +352,7 @@ internal static partial class Interop
         }
     }
 }
+
+
+
+

--- a/src/Tizen.Applications.NotificationEventListener/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.NotificationEventListener/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string NotificationEventListener = "libnotification.so.0";
     }
 }
+
+
+

--- a/src/Tizen.Applications.NotificationEventListener/Interop/Interop.NotificationEventListener.cs
+++ b/src/Tizen.Applications.NotificationEventListener/Interop/Interop.NotificationEventListener.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -17,13 +17,14 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Tizen.Applications;
 using Tizen.Applications.NotificationEventListener;
 
 internal static partial class Interop
 {
-    internal static class NotificationEventListener
+    internal static partial class NotificationEventListener
     {
         internal delegate void ChangedCallback(IntPtr userData, NotificationType type, IntPtr operationList, int num);
 
@@ -42,146 +43,146 @@ internal static partial class Interop
             InvalidOperation = Tizen.Internals.Errors.ErrorCode.InvalidOperation
         }
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_free")]
-        internal static extern ErrorCode Destroy(IntPtr handle);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_free", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode Destroy(IntPtr handle);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_id")]
-        internal static extern ErrorCode GetID(NotificationSafeHandle handle, out int groupId, out int privateId);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetID(NotificationSafeHandle handle, out int groupId, out int privateId);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_pkgname")]
-        internal static extern ErrorCode GetAppIdReferenceType(NotificationSafeHandle handle, out IntPtr appid);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_pkgname", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetAppIdReferenceType(NotificationSafeHandle handle, out IntPtr appid);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_text")]
-        internal static extern ErrorCode GetTextReferenceType(NotificationSafeHandle handle, NotificationText type, out IntPtr text);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_text", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetTextReferenceType(NotificationSafeHandle handle, NotificationText type, out IntPtr text);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_image")]
-        internal static extern ErrorCode GetImageReferenceType(NotificationSafeHandle handle, NotificationImage type, out IntPtr text);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_image", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetImageReferenceType(NotificationSafeHandle handle, NotificationImage type, out IntPtr text);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_insert_time")]
-        internal static extern ErrorCode GetInsertTime(NotificationSafeHandle handle, out int time);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_insert_time", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetInsertTime(NotificationSafeHandle handle, out int time);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_time")]
-        internal static extern ErrorCode GetTime(NotificationSafeHandle handle, out int time);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_time", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetTime(NotificationSafeHandle handle, out int time);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_sound")]
-        internal static extern ErrorCode GetSoundReferenceType(NotificationSafeHandle handle, out AccessoryOption type, out IntPtr path);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_sound", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetSoundReferenceType(NotificationSafeHandle handle, out AccessoryOption type, out IntPtr path);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_vibration")]
-        internal static extern ErrorCode GetVibrationReferenceType(NotificationSafeHandle handle, out AccessoryOption type, out IntPtr path);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_vibration", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetVibrationReferenceType(NotificationSafeHandle handle, out AccessoryOption type, out IntPtr path);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_led")]
-        internal static extern ErrorCode GetLed(NotificationSafeHandle handle, out AccessoryOption type, out int color);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_led", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetLed(NotificationSafeHandle handle, out AccessoryOption type, out int color);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_led_time_period")]
-        internal static extern ErrorCode GetLedTime(NotificationSafeHandle handle, out int onMilliSeconds, out int offMilliSeconds);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_led_time_period", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetLedTime(NotificationSafeHandle handle, out int onMilliSeconds, out int offMilliSeconds);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_tag")]
-        internal static extern ErrorCode GetTagReferenceType(NotificationSafeHandle handle, out IntPtr tag);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_tag", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetTagReferenceType(NotificationSafeHandle handle, out IntPtr tag);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_display_applist")]
-        internal static extern ErrorCode GetStyleList(NotificationSafeHandle handle, out int styleList);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_display_applist", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetStyleList(NotificationSafeHandle handle, out int styleList);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_auto_remove")]
-        internal static extern ErrorCode GetAutoRemove(NotificationSafeHandle handle, out bool autoRemove);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_auto_remove", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetAutoRemove(NotificationSafeHandle handle, [MarshalAs(UnmanagedType.U1)] out bool autoRemove);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_text_input_max_length")]
-        internal static extern ErrorCode GetPlaceHolderLength(NotificationSafeHandle handle, out int max);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_text_input_max_length", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetPlaceHolderLength(NotificationSafeHandle handle, out int max);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_launch_option")]
-        internal static extern ErrorCode GetAppControl(NotificationSafeHandle handle, LaunchOption type, out SafeAppControlHandle appControlHandle);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_launch_option", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetAppControl(NotificationSafeHandle handle, LaunchOption type, out SafeAppControlHandle appControlHandle);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_event_handler")]
-        internal static extern ErrorCode GetEventHandler(NotificationSafeHandle handle, int type, out SafeAppControlHandle appControlHandle);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_event_handler", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetEventHandler(NotificationSafeHandle handle, int type, out SafeAppControlHandle appControlHandle);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_register_detailed_changed_cb")]
-        internal static extern ErrorCode SetChangedCallback(ChangedCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_register_detailed_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetChangedCallback(ChangedCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_unregister_detailed_changed_cb")]
-        internal static extern ErrorCode UnsetChangedCallback(ChangedCallback callback);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_unregister_detailed_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode UnsetChangedCallback(ChangedCallback callback);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_op_get_data")]
-        internal static extern ErrorCode GetOperationData(IntPtr operationList, NotificationOperationDataType type, out IntPtr userData);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_op_get_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetOperationData(IntPtr operationList, NotificationOperationDataType type, out IntPtr userData);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_list_get_data")]
-        internal static extern IntPtr GetData(IntPtr notificationList);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_list_get_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr GetData(IntPtr notificationList);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_list_get_next")]
-        internal static extern IntPtr GetNext(IntPtr notificationList);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_list_get_next", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr GetNext(IntPtr notificationList);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_delete_by_priv_id")]
-        internal static extern ErrorCode Delete(string appId, NotificationType type, int uniqueNumber);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_delete_by_priv_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode Delete(string appId, NotificationType type, int uniqueNumber);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_clear")]
-        internal static extern ErrorCode DeleteAll(int type);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_clear", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode DeleteAll(int type);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_list")]
-        internal static extern ErrorCode GetList(NotificationType type, int count, out IntPtr notification);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_list", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetList(NotificationType type, int count, out IntPtr notification);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_send_event_by_priv_id")]
-        internal static extern ErrorCode SendEvent(int uniqueNumber, int evnetType);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_send_event_by_priv_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SendEvent(int uniqueNumber, int evnetType);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_layout")]
-        internal static extern ErrorCode GetLayout(NotificationSafeHandle handle, out NotificationLayout type);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_layout", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetLayout(NotificationSafeHandle handle, out NotificationLayout type);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_type")]
-        internal static extern ErrorCode GetType(NotificationSafeHandle handle, out NotificationType type);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetType(NotificationSafeHandle handle, out NotificationType type);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_ongoing_value_type")]
-        internal static extern ErrorCode GetOngoingType(NotificationSafeHandle handle, out ProgressCategory category);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_ongoing_value_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetOngoingType(NotificationSafeHandle handle, out ProgressCategory category);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_size")]
-        internal static extern ErrorCode GetProgressSize(NotificationSafeHandle handle, out double value);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_size", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetProgressSize(NotificationSafeHandle handle, out double value);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_progress")]
-        internal static extern ErrorCode GetProgress(NotificationSafeHandle handle, out double value);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_progress", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetProgress(NotificationSafeHandle handle, out double value);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_property")]
-        internal static extern ErrorCode GetProperties(NotificationSafeHandle handle, out int flags);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_property", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetProperties(NotificationSafeHandle handle, out int flags);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_extension_data")]
-        internal static extern ErrorCode GetExtender(NotificationSafeHandle handle, string key, out SafeBundleHandle value);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_extension_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetExtender(NotificationSafeHandle handle, string key, out SafeBundleHandle value);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_clone")]
-        internal static extern ErrorCode GetClone(IntPtr handle, out IntPtr value);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_clone", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetClone(IntPtr handle, out IntPtr value);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_free_list")]
-        internal static extern ErrorCode NotificationListFree(IntPtr list);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_free_list", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode NotificationListFree(IntPtr list);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_args")]
-        internal static extern ErrorCode GetExtensionBundle(NotificationSafeHandle handle, out IntPtr args, out IntPtr groupArgs);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_args", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetExtensionBundle(NotificationSafeHandle handle, out IntPtr args, out IntPtr groupArgs);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_hide_timeout")]
-        internal static extern ErrorCode GetHideTimeout(NotificationSafeHandle handle, out int timeout);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_hide_timeout", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetHideTimeout(NotificationSafeHandle handle, out int timeout);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_delete_timeout")]
-        internal static extern ErrorCode GetDeleteTimeout(NotificationSafeHandle handle, out int timeout);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_delete_timeout", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetDeleteTimeout(NotificationSafeHandle handle, out int timeout);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_event_flag")]
-        internal static extern ErrorCode GetEventFlag(NotificationSafeHandle handle, out bool eventFlag);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_event_flag", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetEventFlag(NotificationSafeHandle handle, [MarshalAs(UnmanagedType.U1)] out bool eventFlag);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_default_button")]
-        internal static extern ErrorCode GetDefaultButton(NotificationSafeHandle handle, out int index);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_default_button", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetDefaultButton(NotificationSafeHandle handle, out int index);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_extension_event_handler")]
-        internal static extern ErrorCode GetExtensionAction(NotificationSafeHandle handle, UserEventType type, out SafeAppControlHandle appcontrol);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_extension_event_handler", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetExtensionAction(NotificationSafeHandle handle, UserEventType type, out SafeAppControlHandle appcontrol);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_load")]
-        internal static extern IntPtr LoadNotification(string appID, int uniqueID);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_load", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr LoadNotification(string appID, int uniqueID);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_all_count")]
-        internal static extern ErrorCode GetAllCount(NotificationType type, out int count);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_all_count", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetAllCount(NotificationType type, out int count);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_set_check_box_checked")]
-        internal static extern ErrorCode SetCheckedValue(NotificationSafeHandle handle, bool checkedValue);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_set_check_box_checked", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetCheckedValue(NotificationSafeHandle handle, [MarshalAs(UnmanagedType.U1)] bool checkedValue);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_check_box")]
-        internal static extern ErrorCode GetCheckBox(NotificationSafeHandle handle, out bool flag, out bool checkedValue);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_check_box", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetCheckBox(NotificationSafeHandle handle, [MarshalAs(UnmanagedType.U1)] out bool flag, [MarshalAs(UnmanagedType.U1)] out bool checkedValue);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_send_event")]
-        internal static extern ErrorCode SendEventWithNotification(NotificationSafeHandle handle, int evnetType);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_send_event", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SendEventWithNotification(NotificationSafeHandle handle, int evnetType);
 
-        [DllImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_extension_image_size")]
-        internal static extern ErrorCode GetExtensionImageSize(NotificationSafeHandle handle, out int height);
+        [LibraryImport(Libraries.NotificationEventListener, EntryPoint = "notification_get_extension_image_size", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetExtensionImageSize(NotificationSafeHandle handle, out int height);
 
         internal static ErrorCode GetAppId(NotificationSafeHandle handle, out string appid)
         {
@@ -298,17 +299,15 @@ internal static partial class Interop
             {
             }
 
-            internal NotificationSafeHandle(IntPtr existingHandle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+            internal NotificationSafeHandle(IntPtr existingHandle, [MarshalAs(UnmanagedType.U1)] bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
             {
                 SetHandle(existingHandle);
             }
-
-            public override bool IsInvalid
+        public override bool IsInvalid
             {
                 get { return this.handle == IntPtr.Zero; }
             }
-
-            protected override bool ReleaseHandle()
+        protected override bool ReleaseHandle()
             {
                 NotificationEventListener.Destroy(this.handle);
                 this.SetHandle(IntPtr.Zero);
@@ -317,3 +316,9 @@ internal static partial class Interop
         }
     }
 }
+
+
+
+
+
+

--- a/src/Tizen.Applications.PackageManager/Interop/Interop.AulInternal.cs
+++ b/src/Tizen.Applications.PackageManager/Interop/Interop.AulInternal.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2026 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
@@ -89,7 +90,10 @@ internal static partial class Interop
             ENoMem = -16
         }
 
-        [DllImport(Libraries.Aul, EntryPoint = "aul_package_get_install_status")]
-        internal static extern AulErrorCode AulPackageGetInstallStatus(string pkgid, out int status);
+        [LibraryImport(Libraries.Aul, EntryPoint = "aul_package_get_install_status", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial AulErrorCode AulPackageGetInstallStatus(string pkgid, out int status);
     }
 }
+
+
+

--- a/src/Tizen.Applications.PackageManager/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.PackageManager/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -25,3 +25,6 @@ internal static partial class Interop
         public const string Aul = "libaul.so.0";
     }
 }
+
+
+

--- a/src/Tizen.Applications.PackageManager/Interop/Interop.Package.cs
+++ b/src/Tizen.Applications.PackageManager/Interop/Interop.Package.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using ErrorCode = Interop.PackageManager.ErrorCode;
 using StorageType = Interop.PackageManager.StorageType;
@@ -26,19 +27,19 @@ internal static partial class Interop
     internal static partial class Package
     {
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
-        internal delegate bool PackageInfoAppInfoCallback(AppType appType, string appId, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool PackageInfoAppInfoCallback(AppType appType, string appId, IntPtr userData);
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
-        internal delegate bool PackageInfoCertificateInfoCallback(IntPtr handle, CertificateType certType, string certValue, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool PackageInfoCertificateInfoCallback(IntPtr handle, CertificateType certType, string certValue, IntPtr userData);
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
-        internal delegate bool PackageInfoPrivilegeInfoCallback(string privilege, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool PackageInfoPrivilegeInfoCallback(string privilege, IntPtr userData);
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
-        internal delegate bool PackageInfoDependencyInfoCallback(string from, string to, string type, string requiredVersion, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool PackageInfoDependencyInfoCallback(string from, string to, string type, string requiredVersion, IntPtr userData);
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
-        internal delegate bool PackageInfoResAllowedPackageCallback(string allowedPackage, IntPtr requiredPrivileges, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool PackageInfoResAllowedPackageCallback(string allowedPackage, IntPtr requiredPrivileges, IntPtr userData);
 
         // Any change here might require changes in Tizen.Applications.AppType enum
         internal enum AppType
@@ -61,79 +62,83 @@ internal static partial class Interop
             Distributor2SignerCertificate = 8
         }
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_foreach_app_from_package")]
-        internal static extern ErrorCode PackageInfoForeachAppInfo(IntPtr handle, AppType appType, PackageInfoAppInfoCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_foreach_app_from_package", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoForeachAppInfo(IntPtr handle, AppType appType, PackageInfoAppInfoCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_foreach_privilege_info")]
-        internal static extern ErrorCode PackageInfoForeachPrivilegeInfo(IntPtr handle, PackageInfoPrivilegeInfoCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_foreach_privilege_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoForeachPrivilegeInfo(IntPtr handle, PackageInfoPrivilegeInfoCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_create")]
-        internal static extern ErrorCode PackageInfoCreate(string packageId, out IntPtr handle);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoCreate(string packageId, out IntPtr handle);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_destroy")]
-        internal static extern ErrorCode PackageInfoDestroy(IntPtr handle);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoDestroy(IntPtr handle);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_get_package")]
-        internal static extern ErrorCode PackageInfoGetPackage(IntPtr handle, out string packageId);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_get_package", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoGetPackage(IntPtr handle, out string packageId);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_get_main_app_id")]
-        internal static extern ErrorCode PackageInfoGetMainAppId(IntPtr handle, out string mainAppId);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_get_main_app_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoGetMainAppId(IntPtr handle, out string mainAppId);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_get_label")]
-        internal static extern ErrorCode PackageInfoGetLabel(IntPtr handle, out string label);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_get_label", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoGetLabel(IntPtr handle, out string label);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_get_icon")]
-        internal static extern ErrorCode PackageInfoGetIconPath(IntPtr handle, out string path);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_get_icon", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoGetIconPath(IntPtr handle, out string path);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_get_version")]
-        internal static extern ErrorCode PackageInfoGetVersion(IntPtr handle, out string version);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_get_version", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoGetVersion(IntPtr handle, out string version);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_get_type")]
-        internal static extern ErrorCode PackageInfoGetType(IntPtr handle, out string type);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_get_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoGetType(IntPtr handle, out string type);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_get_installed_storage")]
-        internal static extern ErrorCode PackageInfoGetInstalledStorage(IntPtr handle, out StorageType storage);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_get_installed_storage", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoGetInstalledStorage(IntPtr handle, out StorageType storage);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_get_root_path")]
-        internal static extern ErrorCode PackageInfoGetRootPath(IntPtr handle, out string path);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_get_root_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoGetRootPath(IntPtr handle, out string path);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_get_tep_name")]
-        internal static extern ErrorCode PackageInfoGetTepName(IntPtr handle, out string name);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_get_tep_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoGetTepName(IntPtr handle, out string name);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_is_system_package")]
-        internal static extern ErrorCode PackageInfoIsSystemPackage(IntPtr handle, out bool system);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_is_system_package", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoIsSystemPackage(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool system);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_is_removable_package")]
-        internal static extern ErrorCode PackageInfoIsRemovablePackage(IntPtr handle, out bool removable);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_is_removable_package", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoIsRemovablePackage(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool removable);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_is_preload_package")]
-        internal static extern ErrorCode PackageInfoIsPreloadPackage(IntPtr handle, out bool preload);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_is_preload_package", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoIsPreloadPackage(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool preload);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_is_update_package")]
-        internal static extern ErrorCode PackageInfoIsUpdatePackage(IntPtr handle, out bool update);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_is_update_package", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoIsUpdatePackage(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool update);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_is_accessible")]
-        internal static extern ErrorCode PackageInfoIsAccessible(IntPtr handle, out bool accessible);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_is_accessible", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoIsAccessible(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool accessible);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_get_first_installed_time")]
-        internal static extern ErrorCode PackageInfoGetFirstInstalledTime(IntPtr handle, out long firstinstalledTime);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_get_first_installed_time", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoGetFirstInstalledTime(IntPtr handle, out long firstinstalledTime);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_get_installed_time")]
-        internal static extern ErrorCode PackageInfoGetInstalledTime(IntPtr handle, out int installedTime);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_get_installed_time", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoGetInstalledTime(IntPtr handle, out int installedTime);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_compare_package_cert_info")]
-        internal static extern ErrorCode PackageCompareCertInfo(string lhsPackageId, string rhsPackageId, out CertCompareResultType result);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_compare_package_cert_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageCompareCertInfo(string lhsPackageId, string rhsPackageId, out CertCompareResultType result);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_foreach_dependency_info")]
-        internal static extern ErrorCode PackageInfoForeachDependencyInfo(IntPtr handle, PackageInfoDependencyInfoCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_foreach_dependency_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoForeachDependencyInfo(IntPtr handle, PackageInfoDependencyInfoCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_foreach_dependency_info_depends_on")]
-        internal static extern ErrorCode PackageInfoForeachDependencyInfoDependsOn(IntPtr handle, PackageInfoDependencyInfoCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_foreach_dependency_info_depends_on", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoForeachDependencyInfoDependsOn(IntPtr handle, PackageInfoDependencyInfoCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_foreach_res_allowed_package")]
-        internal static extern ErrorCode PackageInfoForeachResAllowedPackage(IntPtr handle, PackageInfoResAllowedPackageCallback callback, IntPtr user_data);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_foreach_res_allowed_package", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoForeachResAllowedPackage(IntPtr handle, PackageInfoResAllowedPackageCallback callback, IntPtr user_data);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_foreach_required_privilege")]
-        internal static extern ErrorCode PackageInfoForeachRequiredPrivilege(IntPtr privilegeHandle, PackageInfoPrivilegeInfoCallback callback, IntPtr user_data);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_info_foreach_required_privilege", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoForeachRequiredPrivilege(IntPtr privilegeHandle, PackageInfoPrivilegeInfoCallback callback, IntPtr user_data);
     }
 }
+
+
+
+

--- a/src/Tizen.Applications.PackageManager/Interop/Interop.PackageArchive.cs
+++ b/src/Tizen.Applications.PackageManager/Interop/Interop.PackageArchive.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using ErrorCode = Interop.PackageManager.ErrorCode;
 
@@ -24,37 +25,40 @@ internal static partial class Interop
     internal static partial class PackageArchive
     {
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_archive_info_create")]
-        internal static extern ErrorCode PackageArchiveInfoCreate(string path, out IntPtr handle);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_archive_info_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageArchiveInfoCreate(string path, out IntPtr handle);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_archive_info_destroy")]
-        internal static extern ErrorCode PackageArchiveInfoDestroy(IntPtr handle);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_archive_info_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageArchiveInfoDestroy(IntPtr handle);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_archive_info_get_package")]
-        internal static extern ErrorCode PackageArchiveInfoGetPackage(IntPtr handle, out string package);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_archive_info_get_package", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageArchiveInfoGetPackage(IntPtr handle, out string package);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_archive_info_get_type")]
-        internal static extern ErrorCode PackageArchiveInfoGetType(IntPtr handle, out string type);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_archive_info_get_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageArchiveInfoGetType(IntPtr handle, out string type);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_archive_info_get_version")]
-        internal static extern ErrorCode PackageArchiveInfoGetVersion(IntPtr handle, out string version);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_archive_info_get_version", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageArchiveInfoGetVersion(IntPtr handle, out string version);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_archive_info_get_api_version")]
-        internal static extern ErrorCode PackageArchiveInfoGetApiVersion(IntPtr handle, out string apiVersion);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_archive_info_get_api_version", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageArchiveInfoGetApiVersion(IntPtr handle, out string apiVersion);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_archive_info_get_description")]
-        internal static extern ErrorCode PackageArchiveInfoGetDescription(IntPtr handle, out string description);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_archive_info_get_description", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageArchiveInfoGetDescription(IntPtr handle, out string description);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_archive_info_get_label")]
-        internal static extern ErrorCode PackageArchiveInfoGetLabel(IntPtr handle, out string label);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_archive_info_get_label", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageArchiveInfoGetLabel(IntPtr handle, out string label);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_archive_info_get_author")]
-        internal static extern ErrorCode PackageArchiveInfoGetAuthor(IntPtr handle, out string author);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_archive_info_get_author", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageArchiveInfoGetAuthor(IntPtr handle, out string author);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_archive_info_get_icon")]
-        internal static extern ErrorCode PackageArchiveInfoGetIcon(IntPtr handle, out IntPtr icon, out int iconSize);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_archive_info_get_icon", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageArchiveInfoGetIcon(IntPtr handle, out IntPtr icon, out int iconSize);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_archive_info_foreach_direct_dependency")]
-        internal static extern ErrorCode PackageArchiveInfoForeachDirectDependency(IntPtr handle, Package.PackageInfoDependencyInfoCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_archive_info_foreach_direct_dependency", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageArchiveInfoForeachDirectDependency(IntPtr handle, Package.PackageInfoDependencyInfoCallback callback, IntPtr userData);
     }
 }
+
+
+

--- a/src/Tizen.Applications.PackageManager/Interop/Interop.PackageManager.cs
+++ b/src/Tizen.Applications.PackageManager/Interop/Interop.PackageManager.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 
 internal static partial class Interop
@@ -26,7 +27,7 @@ internal static partial class Interop
         internal delegate void PackageManagerEventCallback(string type, string packageId, EventType eventType, PackageEventState eventState, int progress, ErrorCode error, IntPtr userData);
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
-        internal delegate bool PackageManagerPackageInfoCallback(IntPtr handle, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool PackageManagerPackageInfoCallback(IntPtr handle, IntPtr userData);
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
         internal delegate void PackageManagerSizeInfoCallback(string packageId, IntPtr sizeInfoHandle, IntPtr userData);
@@ -104,149 +105,153 @@ internal static partial class Interop
             External = 1
         }
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_create")]
-        internal static extern ErrorCode PackageManagerCreate(out SafePackageManagerHandle managerHandle);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerCreate(out SafePackageManagerHandle managerHandle);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_destroy")]
-        internal static extern ErrorCode PackageManagerDestroy(IntPtr managerHandle);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerDestroy(IntPtr managerHandle);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_set_event_status")]
-        internal static extern ErrorCode PackageManagerSetEventStatus(SafePackageManagerHandle managerHandle, EventStatus eventStatus);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_set_event_status", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerSetEventStatus(SafePackageManagerHandle managerHandle, EventStatus eventStatus);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_set_event_cb")]
-        internal static extern ErrorCode PackageManagerSetEvent(SafePackageManagerHandle managerHandle, PackageManagerEventCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_set_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerSetEvent(SafePackageManagerHandle managerHandle, PackageManagerEventCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_unset_event_cb")]
-        internal static extern ErrorCode PackageManagerUnsetEvent(SafePackageManagerHandle managerHandle);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_unset_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerUnsetEvent(SafePackageManagerHandle managerHandle);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_foreach_package_info")]
-        internal static extern ErrorCode PackageManagerForeachPackageInfo(PackageManagerPackageInfoCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_foreach_package_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerForeachPackageInfo(PackageManagerPackageInfoCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_get_package_size_info")]
-        internal static extern ErrorCode PackageManagerGetSizeInfo(string packageId, PackageManagerSizeInfoCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_get_package_size_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerGetSizeInfo(string packageId, PackageManagerSizeInfoCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_get_total_package_size_info")]
-        internal static extern ErrorCode PackageManagerGetTotalSizeInfo(PackageManagerTotalSizeInfoCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_get_total_package_size_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerGetTotalSizeInfo(PackageManagerTotalSizeInfoCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_get_package_id_by_app_id")]
-        internal static extern ErrorCode PackageManagerGetPackageIdByAppId(string app_id, out string package_id);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_get_package_id_by_app_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerGetPackageIdByAppId(string app_id, out string package_id);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_get_package_info")]
-        internal static extern ErrorCode PackageManagerGetPackageInfo(string packageId, out IntPtr packageInfoHandle);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_get_package_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerGetPackageInfo(string packageId, out IntPtr packageInfoHandle);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_clear_cache_dir")]
-        internal static extern ErrorCode PackageManagerClearCacheDir(string packageId);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_clear_cache_dir", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerClearCacheDir(string packageId);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_clear_all_cache_dir")]
-        internal static extern ErrorCode PackageManagerClearAllCacheDir();
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_clear_all_cache_dir", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerClearAllCacheDir();
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_clear_data_dir")]
-        internal static extern ErrorCode PackageManagerClearDataDir(string packageId);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_clear_data_dir", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerClearDataDir(string packageId);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_clear_user_data_with_path")]
-        internal static extern ErrorCode PackageManagerClearUserDataWithPath(string packageId, String filePath);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_clear_user_data_with_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerClearUserDataWithPath(string packageId, String filePath);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_filter_create")]
-        internal static extern ErrorCode PackageManagerFilterCreate(out IntPtr handle);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_filter_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerFilterCreate(out IntPtr handle);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_filter_destroy")]
-        internal static extern ErrorCode PackageManagerFilterDestroy(IntPtr handle);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_filter_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerFilterDestroy(IntPtr handle);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_filter_add_bool")]
-        internal static extern ErrorCode PackageManagerFilterAdd(IntPtr handle, string property, bool value);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_filter_add_bool", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerFilterAdd(IntPtr handle, string property, [MarshalAs(UnmanagedType.U1)] bool value);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_filter_add_string")]
-        internal static extern ErrorCode PackageManagerFilterAdd(IntPtr handle, string property, string value);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_filter_add_string", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerFilterAdd(IntPtr handle, string property, string value);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_filter_foreach_package_info")]
-        internal static extern ErrorCode PackageManagerFilterForeachPackageInfo(IntPtr handle, PackageManagerPackageInfoCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_filter_foreach_package_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerFilterForeachPackageInfo(IntPtr handle, PackageManagerPackageInfoCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_size_info_get_data_size")]
-        internal static extern ErrorCode PackageSizeInfoGetDataSize(IntPtr handle, out long dataSize);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_size_info_get_data_size", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageSizeInfoGetDataSize(IntPtr handle, out long dataSize);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_size_info_get_cache_size")]
-        internal static extern ErrorCode PackageSizeInfoGetCacheSize(IntPtr handle, out long cacheSize);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_size_info_get_cache_size", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageSizeInfoGetCacheSize(IntPtr handle, out long cacheSize);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_size_info_get_app_size")]
-        internal static extern ErrorCode PackageSizeInfoGetAppSize(IntPtr handle, out long appSize);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_size_info_get_app_size", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageSizeInfoGetAppSize(IntPtr handle, out long appSize);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_size_info_get_external_data_size")]
-        internal static extern ErrorCode PackageSizeInfoGetExtDataSize(IntPtr handle, out long extDataSize);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_size_info_get_external_data_size", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageSizeInfoGetExtDataSize(IntPtr handle, out long extDataSize);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_size_info_get_external_cache_size")]
-        internal static extern ErrorCode PackageSizeInfoGetExtCacheSize(IntPtr handle, out long extCacheSize);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_size_info_get_external_cache_size", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageSizeInfoGetExtCacheSize(IntPtr handle, out long extCacheSize);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_size_info_get_external_app_size")]
-        internal static extern ErrorCode PackageSizeInfoGetExtAppSize(IntPtr handle, out long extAppSize);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_size_info_get_external_app_size", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageSizeInfoGetExtAppSize(IntPtr handle, out long extAppSize);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_request_create")]
-        internal static extern ErrorCode PackageManagerRequestCreate(out SafePackageManagerRequestHandle requestHandle);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_request_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerRequestCreate(out SafePackageManagerRequestHandle requestHandle);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_request_destroy")]
-        internal static extern ErrorCode PackageManagerRequestDestroy(IntPtr requestHandle);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_request_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerRequestDestroy(IntPtr requestHandle);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_request_set_type")]
-        internal static extern ErrorCode PackageManagerRequestSetType(SafePackageManagerRequestHandle requestHandle, string type);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_request_set_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerRequestSetType(SafePackageManagerRequestHandle requestHandle, string type);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_request_set_tep")]
-        internal static extern ErrorCode PackageManagerRequestSetTepPath(SafePackageManagerRequestHandle requestHandle, string tepPath);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_request_set_tep", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerRequestSetTepPath(SafePackageManagerRequestHandle requestHandle, string tepPath);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_request_install")]
-        internal static extern ErrorCode PackageManagerRequestInstall(SafePackageManagerRequestHandle requestHandle, string path, out int id);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_request_install", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerRequestInstall(SafePackageManagerRequestHandle requestHandle, string path, out int id);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_request_mount_install")]
-        internal static extern ErrorCode PackageManagerRequestMountInstall(SafePackageManagerRequestHandle requestHandle, string path, out int id);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_request_mount_install", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerRequestMountInstall(SafePackageManagerRequestHandle requestHandle, string path, out int id);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_request_uninstall")]
-        internal static extern ErrorCode PackageManagerRequestUninstall(SafePackageManagerRequestHandle requestHandle, string name, out int id);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_request_uninstall", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerRequestUninstall(SafePackageManagerRequestHandle requestHandle, string name, out int id);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_request_move")]
-        internal static extern ErrorCode PackageManagerRequestMove(SafePackageManagerRequestHandle requestHandle, string name, StorageType moveToStorageType);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_request_move", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerRequestMove(SafePackageManagerRequestHandle requestHandle, string name, StorageType moveToStorageType);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_compare_package_cert_info")]
-        internal static extern ErrorCode PackageManagerCompareCertInfo(string lhsPackageId, string rhsPackageId, out CertCompareResultType CompareResult);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_compare_package_cert_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerCompareCertInfo(string lhsPackageId, string rhsPackageId, out CertCompareResultType CompareResult);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_compare_app_cert_info")]
-        internal static extern ErrorCode PackageManagerCompareCertInfoByApplicationId(string lhsPackageId, string rhsPackageId, out CertCompareResultType CompareResult);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_compare_app_cert_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerCompareCertInfoByApplicationId(string lhsPackageId, string rhsPackageId, out CertCompareResultType CompareResult);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_is_preload_package_by_app_id")]
-        internal static extern ErrorCode PackageManagerIsPreloadPackageByApplicationId(string ApplicationId, out bool IsPreload);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_is_preload_package_by_app_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerIsPreloadPackageByApplicationId(string ApplicationId, [MarshalAs(UnmanagedType.U1)] out bool IsPreload);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_get_permission_type")]
-        internal static extern ErrorCode PackageManagerGetPermissionType(string ApplicationId, out PackageManagerPermissionType PermissionType);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_get_permission_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerGetPermissionType(string ApplicationId, out PackageManagerPermissionType PermissionType);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_drm_generate_license_request")]
-        internal static extern ErrorCode PackageManagerDrmGenerateLicenseRequest(string responseData, out string requestData, out string licenseUrl);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_drm_generate_license_request", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerDrmGenerateLicenseRequest(string responseData, out string requestData, out string licenseUrl);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_drm_register_license")]
-        internal static extern ErrorCode PackageManagerDrmRegisterLicense(string responseData);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_drm_register_license", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerDrmRegisterLicense(string responseData);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_drm_decrypt_package")]
-        internal static extern ErrorCode PackageManagerDrmDecryptPackage(string drmFilePath, string decryptedFilePath);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_drm_decrypt_package", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerDrmDecryptPackage(string drmFilePath, string decryptedFilePath);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_request_install_with_cb")]
-        internal static extern ErrorCode PackageManagerRequestInstallWithCB(SafePackageManagerRequestHandle requestHandle, string path, PackageManagerRequestEventCallback callback, IntPtr userData, out int id);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_request_install_with_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerRequestInstallWithCB(SafePackageManagerRequestHandle requestHandle, string path, PackageManagerRequestEventCallback callback, IntPtr userData, out int id);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_request_mount_install_with_cb")]
-        internal static extern ErrorCode PackageManagerRequestMountInstallWithCB(SafePackageManagerRequestHandle requestHandle, string path, PackageManagerRequestEventCallback callback, IntPtr userData, out int id);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_request_mount_install_with_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerRequestMountInstallWithCB(SafePackageManagerRequestHandle requestHandle, string path, PackageManagerRequestEventCallback callback, IntPtr userData, out int id);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_request_uninstall_with_cb")]
-        internal static extern ErrorCode PackageManagerRequestUninstallWithCB(SafePackageManagerRequestHandle requestHandle, string name, PackageManagerRequestEventCallback callback, IntPtr userData, out int id);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_request_uninstall_with_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerRequestUninstallWithCB(SafePackageManagerRequestHandle requestHandle, string name, PackageManagerRequestEventCallback callback, IntPtr userData, out int id);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_request_move_with_cb")]
-        internal static extern ErrorCode PackageManagerRequestMoveWithCB(SafePackageManagerRequestHandle requestHandle, string name, StorageType moveToStorageType, PackageManagerRequestEventCallback callback, IntPtr userData, out int id);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_request_move_with_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerRequestMoveWithCB(SafePackageManagerRequestHandle requestHandle, string name, StorageType moveToStorageType, PackageManagerRequestEventCallback callback, IntPtr userData, out int id);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_request_install_packages")]
-        internal static extern ErrorCode PackageManagerRequestInstallPackages(SafePackageManagerRequestHandle requestHandle, string[] paths, int paths_count, out int id);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_request_install_packages", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerRequestInstallPackages(SafePackageManagerRequestHandle requestHandle, string[] paths, int paths_count, out int id);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_request_install_packages_with_cb")]
-        internal static extern ErrorCode PackageManagerRequestInstallPackagesWithCb(SafePackageManagerRequestHandle requestHandle, string[] paths, int paths_count, PackageManagerRequestEventCallback callback, IntPtr userData, out int id);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_request_install_packages_with_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerRequestInstallPackagesWithCb(SafePackageManagerRequestHandle requestHandle, string[] paths, int paths_count, PackageManagerRequestEventCallback callback, IntPtr userData, out int id);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_request_mount_install_packages")]
-        internal static extern ErrorCode PackageManagerRequestMountInstallPackages(SafePackageManagerRequestHandle requestHandle, string[] paths, int pathsCount, out int id);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_request_mount_install_packages", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerRequestMountInstallPackages(SafePackageManagerRequestHandle requestHandle, string[] paths, int pathsCount, out int id);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_request_mount_install_packages_with_cb")]
-        internal static extern ErrorCode PackageManagerRequestMountInstallPackagesWithCb(SafePackageManagerRequestHandle requestHandle, string[] paths, int pathsCount, PackageManagerRequestEventCallback callback, IntPtr userData, out int id);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "package_manager_request_mount_install_packages_with_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageManagerRequestMountInstallPackagesWithCb(SafePackageManagerRequestHandle requestHandle, string[] paths, int pathsCount, PackageManagerRequestEventCallback callback, IntPtr userData, out int id);
 
     }
 }
+
+
+
+

--- a/src/Tizen.Applications.PackageManager/Interop/Interop.PackageManagerInfoInternal.cs
+++ b/src/Tizen.Applications.PackageManager/Interop/Interop.PackageManagerInfoInternal.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2023 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using CertificateType = Interop.Package.CertificateType;
 
@@ -23,22 +24,25 @@ internal static partial class Interop
 {
     internal static partial class PackageManagerInfoInternal
     {
-        [DllImport(Libraries.PackageManagerInfoInternal, EntryPoint = "pkgmgrinfo_pkginfo_create_certinfo")]
-        internal static extern int PkgmgrinfoPkginfoCreateCertinfo(out IntPtr handle);
+        [LibraryImport(Libraries.PackageManagerInfoInternal, EntryPoint = "pkgmgrinfo_pkginfo_create_certinfo", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int PkgmgrinfoPkginfoCreateCertinfo(out IntPtr handle);
 
-        [DllImport(Libraries.PackageManagerInfoInternal, EntryPoint = "pkgmgrinfo_pkginfo_destroy_certinfo")]
-        internal static extern int PkgmgrinfoPkginfoDestroyCertinfo(IntPtr handle);
+        [LibraryImport(Libraries.PackageManagerInfoInternal, EntryPoint = "pkgmgrinfo_pkginfo_destroy_certinfo", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int PkgmgrinfoPkginfoDestroyCertinfo(IntPtr handle);
 
-        [DllImport(Libraries.PackageManagerInfoInternal, EntryPoint = "pkgmgrinfo_pkginfo_load_certinfo")]
-        internal static extern int PkgmgrinfoPkginfoLoadCertinfo(string pkgid, IntPtr handle, int uid);
+        [LibraryImport(Libraries.PackageManagerInfoInternal, EntryPoint = "pkgmgrinfo_pkginfo_load_certinfo", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int PkgmgrinfoPkginfoLoadCertinfo(string pkgid, IntPtr handle, int uid);
 
-        [DllImport(Libraries.PackageManagerInfoInternal, EntryPoint = "pkgmgrinfo_pkginfo_get_cert_value")]
-        internal static extern int PkgmgrinfoPkginfoGetCertValue(IntPtr handle, CertificateType certType, out IntPtr value);
+        [LibraryImport(Libraries.PackageManagerInfoInternal, EntryPoint = "pkgmgrinfo_pkginfo_get_cert_value", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int PkgmgrinfoPkginfoGetCertValue(IntPtr handle, CertificateType certType, out IntPtr value);
 
-        [DllImport(Libraries.PackageManagerInfoInternal, EntryPoint = "pkgmgrinfo_pkginfo_foreach_depends_on_by_pkgid")]
-        internal static extern int PkgmgrinfoPkginfoForeachDependsOnByPkgId(string pkgid, Interop.Package.PackageInfoDependencyInfoCallback callback, IntPtr userData, int uid);
+        [LibraryImport(Libraries.PackageManagerInfoInternal, EntryPoint = "pkgmgrinfo_pkginfo_foreach_depends_on_by_pkgid", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int PkgmgrinfoPkginfoForeachDependsOnByPkgId(string pkgid, Interop.Package.PackageInfoDependencyInfoCallback callback, IntPtr userData, int uid);
 
-        [DllImport(Libraries.Libc, EntryPoint = "getuid")]
-        internal static extern int GetUID();
+        [LibraryImport(Libraries.Libc, EntryPoint = "getuid", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetUID();
     }
 }
+
+
+

--- a/src/Tizen.Applications.PackageManager/Interop/Interop.PackageManagerInternal.cs
+++ b/src/Tizen.Applications.PackageManager/Interop/Interop.PackageManagerInternal.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2023 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using ErrorCode = Interop.PackageManager.ErrorCode;
 
@@ -23,16 +24,19 @@ internal static partial class Interop
 {
     internal static partial class PackageManagerInternal
     {
-        [DllImport(Libraries.PackageManager, EntryPoint = "pkgmgr_client_new")]
-        internal static extern IntPtr PkgmgrClientNew(int type);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "pkgmgr_client_new", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr PkgmgrClientNew(int type);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "pkgmgr_client_free")]
-        internal static extern ErrorCode PkgmgrClientFree(IntPtr clientHandle);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "pkgmgr_client_free", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PkgmgrClientFree(IntPtr clientHandle);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "pkgmgr_client_activate")]
-        internal static extern ErrorCode PkgmgrClientActivate(IntPtr clientHandle, string pkgType, string pkgId);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "pkgmgr_client_activate", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PkgmgrClientActivate(IntPtr clientHandle, string pkgType, string pkgId);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "pkgmgr_client_deactivate")]
-        internal static extern ErrorCode PkgmgrClientDeactivate(IntPtr clientHandle, string pkgType, string pkgId);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "pkgmgr_client_deactivate", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PkgmgrClientDeactivate(IntPtr clientHandle, string pkgType, string pkgId);
     }
 }
+
+
+

--- a/src/Tizen.Applications.Preference/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.Preference/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string Preference = "libcapi-appfw-preference.so.0";
     }
 }
+
+
+

--- a/src/Tizen.Applications.Preference/Interop/Interop.Preference.cs
+++ b/src/Tizen.Applications.Preference/Interop/Interop.Preference.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 
 /// <summary>
@@ -30,48 +31,52 @@ internal static partial class Interop
     {
         internal delegate void ChangedCallback(string key, IntPtr userData);
 
-        internal delegate bool ItemCallback(string key, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool ItemCallback(string key, IntPtr userData);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_set_int")]
-        internal static extern int SetInt(string key, int value);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_set_int", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetInt(string key, int value);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_get_int")]
-        internal static extern int GetInt(string key, out int value);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_get_int", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetInt(string key, out int value);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_set_double")]
-        internal static extern int SetDouble(string key, double value);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_set_double", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetDouble(string key, double value);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_get_double")]
-        internal static extern int GetDouble(string key, out double value);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_get_double", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetDouble(string key, out double value);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_set_string")]
-        internal static extern int SetString(string key, string value);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_set_string", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetString(string key, string value);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_get_string")]
-        internal static extern int GetString(string key, out string value);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_get_string", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetString(string key, out string value);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_set_boolean")]
-        internal static extern int SetBoolean(string key, bool value);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_set_boolean", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetBoolean(string key, [MarshalAs(UnmanagedType.U1)] bool value);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_get_boolean")]
-        internal static extern int GetBoolean(string key, out bool value);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_get_boolean", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetBoolean(string key, [MarshalAs(UnmanagedType.U1)] out bool value);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_remove")]
-        internal static extern int Remove(string key);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_remove", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Remove(string key);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_is_existing")]
-        internal static extern int IsExisting(string key, out bool existing);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_is_existing", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int IsExisting(string key, [MarshalAs(UnmanagedType.U1)] out bool existing);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_remove_all")]
-        internal static extern int RemoveAll();
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_remove_all", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RemoveAll();
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_set_changed_cb")]
-        internal static extern int SetChangedCb(string key, ChangedCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_set_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetChangedCb(string key, ChangedCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_unset_changed_cb")]
-        internal static extern int UnsetChangedCb(string key);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_unset_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UnsetChangedCb(string key);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_foreach_item")]
-        internal static extern int ForeachItem(ItemCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_foreach_item", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int ForeachItem(ItemCallback callback, IntPtr userData);
     }
 }
+
+
+
+

--- a/src/Tizen.Applications.RemoteView/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.RemoteView/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string WidgetViewerEvas = "libwidget_viewer_evas.so.1";
     }
 }
+
+
+

--- a/src/Tizen.Applications.RemoteView/Interop/Interop.WidgetViewerEvas.cs
+++ b/src/Tizen.Applications.RemoteView/Interop/Interop.WidgetViewerEvas.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Tizen.Applications;
 
@@ -43,53 +44,56 @@ internal static partial class Interop
             MaxExceeded = -0x02F40000 | 0x0011,
         }
 
-        [DllImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_init")]
-        internal static extern ErrorCode Init(IntPtr win);
+        [LibraryImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_init", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode Init(IntPtr win);
 
-        [DllImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_fini")]
-        internal static extern ErrorCode Fini();
+        [LibraryImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_fini", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode Fini();
 
-        [DllImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_add_widget")]
-        internal static extern IntPtr AddWidget(IntPtr parent, string widgetId, string content, double period);
+        [LibraryImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_add_widget", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr AddWidget(IntPtr parent, string widgetId, string content, double period);
 
-        [DllImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_notify_resumed_status_of_viewer")]
-        internal static extern ErrorCode NotifyResumedStatusOfViewer();
+        [LibraryImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_notify_resumed_status_of_viewer", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode NotifyResumedStatusOfViewer();
 
-        [DllImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_notify_paused_status_of_viewer")]
-        internal static extern ErrorCode NotifyPausedStatusOfViewer();
+        [LibraryImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_notify_paused_status_of_viewer", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode NotifyPausedStatusOfViewer();
 
-        [DllImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_pause_widget")]
-        internal static extern ErrorCode PauseWidget(IntPtr widget);
+        [LibraryImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_pause_widget", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PauseWidget(IntPtr widget);
 
-        [DllImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_resume_widget")]
-        internal static extern ErrorCode ResumeWidget(IntPtr widget);
+        [LibraryImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_resume_widget", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ResumeWidget(IntPtr widget);
 
-        [DllImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_get_content_info")]
-        internal static extern IntPtr GetContentInfo(IntPtr widget);
+        [LibraryImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_get_content_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr GetContentInfo(IntPtr widget);
 
-        [DllImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_get_title_string")]
-        internal static extern IntPtr GetTitleString(IntPtr widget);
+        [LibraryImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_get_title_string", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr GetTitleString(IntPtr widget);
 
-        [DllImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_get_widget_id")]
-        internal static extern IntPtr GetWidgetId(IntPtr widget);
+        [LibraryImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_get_widget_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr GetWidgetId(IntPtr widget);
 
-        [DllImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_get_period")]
-        internal static extern double GetPeriod(IntPtr widget);
+        [LibraryImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_get_period", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial double GetPeriod(IntPtr widget);
 
-        [DllImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_cancel_click_event")]
-        internal static extern void CancelClickEvent(IntPtr widget);
+        [LibraryImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_cancel_click_event", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void CancelClickEvent(IntPtr widget);
 
-        [DllImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_disable_loading")]
-        internal static extern void DisableLoading(IntPtr widget);
+        [LibraryImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_disable_loading", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void DisableLoading(IntPtr widget);
 
-        [DllImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_feed_mouse_up_event")]
-        internal static extern ErrorCode FeedMouseUpEvent(IntPtr widget);
+        [LibraryImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_feed_mouse_up_event", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode FeedMouseUpEvent(IntPtr widget);
 
-        [DllImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_disable_preview")]
-        internal static extern void DisablePreview(IntPtr widget);
+        [LibraryImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_disable_preview", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void DisablePreview(IntPtr widget);
 
-        [DllImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_disable_overlay_text")]
-        internal static extern void DisableOverlayText(IntPtr widget);
+        [LibraryImport(Libraries.WidgetViewerEvas, EntryPoint = "widget_viewer_evas_disable_overlay_text", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void DisableOverlayText(IntPtr widget);
 
     }
 }
+
+
+

--- a/src/Tizen.Applications.Service/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.Service/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string AppcoreAgent = "libappcore-agent.so.1";
     }
 }
+
+
+

--- a/src/Tizen.Applications.Service/Interop/Interop.Service.cs
+++ b/src/Tizen.Applications.Service/Interop/Interop.Service.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications.CoreBackend;
 using Tizen.Internals;
 using Tizen.Internals.Errors;
@@ -26,7 +27,7 @@ internal static partial class Interop
     {
         internal delegate void AppEventCallback(IntPtr handle, IntPtr data);
 
-        internal delegate bool ServiceAppCreateCallback(IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool ServiceAppCreateCallback(IntPtr userData);
 
         internal delegate void ServiceAppTerminateCallback(IntPtr userData);
 
@@ -57,3 +58,8 @@ internal static partial class Interop
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.Applications.Shortcut/interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.Shortcut/interop/Interop.Libraries.cs
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string Shortcut = "libshortcut.so.0";
     }
 }
+
+
+

--- a/src/Tizen.Applications.Shortcut/interop/Interop.Shortcut.cs
+++ b/src/Tizen.Applications.Shortcut/interop/Interop.Shortcut.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2017 Samsung Electronics Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Tizen.Applications.Shortcut;
 
@@ -23,7 +24,7 @@ internal static partial class Interop
 {
     internal static partial class Shortcut
     {
-        internal delegate int AddCallback(string appId, string shortcutName, int type, string contentInfo, string iconPath, int processId, double period, bool isAllowDuplicate, IntPtr data);
+        internal delegate int AddCallback(string appId, string shortcutName, int type, string contentInfo, string iconPath, int processId, double period, [MarshalAs(UnmanagedType.U1)] bool isAllowDuplicate, IntPtr data);
 
         internal delegate int DeleteCallback(string appId, string shortcutName, int processId, IntPtr data);
 
@@ -97,28 +98,32 @@ internal static partial class Interop
             COMM = -0x01160000 | 0x40
         }
 
-        [DllImport(Libraries.Shortcut, EntryPoint = "shortcut_add_to_home_sync")]
-        internal static extern ErrorCode AddToHome(string name, int type, string uri, string icon, int dubplicate);
+        [LibraryImport(Libraries.Shortcut, EntryPoint = "shortcut_add_to_home_sync", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AddToHome(string name, int type, string uri, string icon, int dubplicate);
 
-        [DllImport(Libraries.Shortcut, EntryPoint = "shortcut_add_to_home_widget_sync")]
-        internal static extern ErrorCode AddToWidget(string name, ShortcutWidgetSize size,  string widgetId, string icon, double period, int dubplicate);
+        [LibraryImport(Libraries.Shortcut, EntryPoint = "shortcut_add_to_home_widget_sync", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AddToWidget(string name, ShortcutWidgetSize size,  string widgetId, string icon, double period, int dubplicate);
 
-        [DllImport(Libraries.Shortcut, EntryPoint = "shortcut_remove_from_home_sync")]
-        internal static extern ErrorCode Delete(string name);
+        [LibraryImport(Libraries.Shortcut, EntryPoint = "shortcut_remove_from_home_sync", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode Delete(string name);
 
-        [DllImport(Libraries.Shortcut, EntryPoint = "shortcut_get_list")]
-        internal static extern ErrorCode GetList(string name, ListCallback list, IntPtr data);
+        [LibraryImport(Libraries.Shortcut, EntryPoint = "shortcut_get_list", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetList(string name, ListCallback list, IntPtr data);
 
-        [DllImport(Libraries.Shortcut, EntryPoint = "shortcut_set_request_cb")]
-        internal static extern ErrorCode SetShortcutAddCallback(AddCallback cb, IntPtr data);
+        [LibraryImport(Libraries.Shortcut, EntryPoint = "shortcut_set_request_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetShortcutAddCallback(AddCallback cb, IntPtr data);
 
-        [DllImport(Libraries.Shortcut, EntryPoint = "shortcut_unset_request_cb")]
-        internal static extern ErrorCode UnsetShortcutAddCallback();
+        [LibraryImport(Libraries.Shortcut, EntryPoint = "shortcut_unset_request_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode UnsetShortcutAddCallback();
 
-        [DllImport(Libraries.Shortcut, EntryPoint = "shortcut_set_remove_cb")]
-        internal static extern ErrorCode SetShortcutDeleteCallback(DeleteCallback cb, IntPtr data);
+        [LibraryImport(Libraries.Shortcut, EntryPoint = "shortcut_set_remove_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetShortcutDeleteCallback(DeleteCallback cb, IntPtr data);
 
-        [DllImport(Libraries.Shortcut, EntryPoint = "shortcut_unset_remove_cb")]
-        internal static extern ErrorCode UnsetShortcutDeleteCallback();
+        [LibraryImport(Libraries.Shortcut, EntryPoint = "shortcut_unset_remove_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode UnsetShortcutDeleteCallback();
     }
 }
+
+
+
+

--- a/src/Tizen.Applications.ThemeManager/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.ThemeManager/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string ThemeManager = "libcapi-appfw-tizen-theme.so.1";
     }
 }
+
+
+

--- a/src/Tizen.Applications.ThemeManager/Interop/Interop.ThemeManager.cs
+++ b/src/Tizen.Applications.ThemeManager/Interop/Interop.ThemeManager.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen;
 using Tizen.Applications;
 
@@ -37,7 +38,7 @@ internal static partial class Interop
             KeyNotAvailable = Tizen.Internals.Errors.ErrorCode.KeyNotAvailable,
         }
 
-        internal static class ThemeManagerErrorFactory
+        internal static partial class ThemeManagerErrorFactory
         {
             internal static Exception GetException(Interop.ThemeManager.ErrorCode err, string message)
             {
@@ -63,79 +64,83 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int ThemeLoaderChangedCallback(IntPtr handle, IntPtr userData);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_id")]
-        internal static extern ErrorCode GetId(IntPtr handle, out string id);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetId(IntPtr handle, out string id);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_version")]
-        internal static extern ErrorCode GetVersion(IntPtr handle, out string version);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_version", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetVersion(IntPtr handle, out string version);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_tool_version")]
-        internal static extern ErrorCode GetToolVersion(IntPtr handle, out string version);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_tool_version", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetToolVersion(IntPtr handle, out string version);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_title")]
-        internal static extern ErrorCode GetTitle(IntPtr handle, out string title);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_title", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetTitle(IntPtr handle, out string title);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_resolution")]
-        internal static extern ErrorCode GetResolution(IntPtr handle, out string resolution);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_resolution", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetResolution(IntPtr handle, out string resolution);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_preview")]
-        internal static extern ErrorCode GetPreview(IntPtr handle, out string preview);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_preview", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetPreview(IntPtr handle, out string preview);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_description")]
-        internal static extern ErrorCode GetDescription(IntPtr handle, out string description);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_description", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetDescription(IntPtr handle, out string description);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_string")]
-        internal static extern ErrorCode GetString(IntPtr handle, string key, out string val);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_string", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetString(IntPtr handle, string key, out string val);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_string_array")]
-        internal static extern ErrorCode GetStringArray(IntPtr handle, string key, out IntPtr val, out int count);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_string_array", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetStringArray(IntPtr handle, string key, out IntPtr val, out int count);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_path")]
-        internal static extern ErrorCode GetPath(IntPtr handle, string key, out string val);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetPath(IntPtr handle, string key, out string val);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_path_array")]
-        internal static extern ErrorCode GetPathArray(IntPtr handle, string key, out IntPtr val, out int count);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_path_array", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetPathArray(IntPtr handle, string key, out IntPtr val, out int count);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_int")]
-        internal static extern ErrorCode GetInt(IntPtr handle, string key, out int val);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_int", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetInt(IntPtr handle, string key, out int val);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_float")]
-        internal static extern ErrorCode GetFloat(IntPtr handle, string key, out float val);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_float", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetFloat(IntPtr handle, string key, out float val);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_bool")]
-        internal static extern ErrorCode GetBool(IntPtr handle, string key, out bool val);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_bool", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetBool(IntPtr handle, string key, [MarshalAs(UnmanagedType.U1)] out bool val);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_is_key_exist")]
-        internal static extern ErrorCode IsKeyExist(IntPtr handle, string key, out bool val);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_is_key_exist", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode IsKeyExist(IntPtr handle, string key, [MarshalAs(UnmanagedType.U1)] out bool val);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_clone")]
-        internal static extern ErrorCode ThemeClone(IntPtr handle, out IntPtr cloned);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_clone", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ThemeClone(IntPtr handle, out IntPtr cloned);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_destroy")]
-        internal static extern ErrorCode ThemeDestroy(IntPtr handle);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ThemeDestroy(IntPtr handle);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_loader_create")]
-        internal static extern ErrorCode LoaderCreate(out IntPtr loaderHandle);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_loader_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode LoaderCreate(out IntPtr loaderHandle);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_loader_destroy")]
-        internal static extern ErrorCode LoaderDestroy(IntPtr loaderHandle);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_loader_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode LoaderDestroy(IntPtr loaderHandle);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_loader_add_event")]
-        internal static extern ErrorCode LoaderAddEvent(IntPtr loaderHandle, ThemeLoaderChangedCallback callback, IntPtr userData, out string eventId);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_loader_add_event", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode LoaderAddEvent(IntPtr loaderHandle, ThemeLoaderChangedCallback callback, IntPtr userData, out string eventId);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_loader_remove_event")]
-        internal static extern ErrorCode LoaderRemoveEvent(IntPtr loaderHandle, string eventId);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_loader_remove_event", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode LoaderRemoveEvent(IntPtr loaderHandle, string eventId);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_loader_load_current")]
-        internal static extern ErrorCode LoaderLoadCurrentTheme(IntPtr loaderHandle, out IntPtr handle);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_loader_load_current", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode LoaderLoadCurrentTheme(IntPtr loaderHandle, out IntPtr handle);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_loader_load")]
-        internal static extern ErrorCode LoaderLoadTheme(IntPtr loaderHandle, string id, out IntPtr handle);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_loader_load", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode LoaderLoadTheme(IntPtr loaderHandle, string id, out IntPtr handle);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_loader_query_id")]
-        internal static extern ErrorCode LoaderQueryId(IntPtr loaderHandle, out IntPtr ids, out int count);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_loader_query_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode LoaderQueryId(IntPtr loaderHandle, out IntPtr ids, out int count);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_loader_set_current")]
-        internal static extern ErrorCode LoaderSetCurrentTheme(IntPtr loaderHandle, string id);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_loader_set_current", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode LoaderSetCurrentTheme(IntPtr loaderHandle, string id);
     }
 }
+
+
+
+

--- a/src/Tizen.Applications.ToastMessage/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.ToastMessage/Interop/Interop.Libraries.cs
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string ToastMessage = "libnotification.so.0";
     }
 }
+
+
+

--- a/src/Tizen.Applications.ToastMessage/Interop/Interop.ToastMessage.cs
+++ b/src/Tizen.Applications.ToastMessage/Interop/Interop.ToastMessage.cs
@@ -16,13 +16,17 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 
 internal static partial class Interop
 {
-    internal static class ToastMessage
+    internal static partial class ToastMessage
     {
-        [DllImport(Libraries.ToastMessage, EntryPoint = "notification_status_message_post")]
-        internal static extern int ToastMessagePost(string message);
+        [LibraryImport(Libraries.ToastMessage, EntryPoint = "notification_status_message_post", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int ToastMessagePost(string message);
     }
 }
+
+
+

--- a/src/Tizen.Applications.UI/Interop/Interop.Application.cs
+++ b/src/Tizen.Applications.UI/Interop/Interop.Application.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 using Tizen.Applications.CoreBackend;
 using Tizen.Internals;
@@ -27,7 +28,7 @@ internal static partial class Interop
     {
         internal delegate void AppEventCallback(IntPtr handle, IntPtr data);
 
-        internal delegate bool AppCreateCallback(IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool AppCreateCallback(IntPtr userData);
 
         internal delegate void AppPauseCallback(IntPtr userData);
 
@@ -38,23 +39,23 @@ internal static partial class Interop
         internal delegate void AppControlCallback(IntPtr appControl, IntPtr userData);
 
 
-        [DllImport(Libraries.Application, EntryPoint = "app_get_device_orientation")]
-        internal static extern DeviceOrientation AppGetDeviceOrientation();
+        [LibraryImport(Libraries.Application, EntryPoint = "app_get_device_orientation", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial DeviceOrientation AppGetDeviceOrientation();
 
-        [DllImport(Libraries.Application, EntryPoint = "ui_app_main")]
+        [DllImport(Libraries.Application, EntryPoint = "ui_app_main", CallingConvention = CallingConvention.Cdecl)]
         internal static extern ErrorCode Main(int argc, string[] argv, ref UIAppLifecycleCallbacks callback, IntPtr userData);
 
-        [DllImport(Libraries.Application, EntryPoint = "ui_app_exit")]
-        internal static extern void Exit();
+        [LibraryImport(Libraries.Application, EntryPoint = "ui_app_exit", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void Exit();
 
-        [DllImport(Libraries.Application, EntryPoint = "ui_app_add_event_handler")]
-        internal static extern ErrorCode AddEventHandler(out IntPtr handle, DefaultCoreBackend.AppEventType eventType, AppEventCallback callback, IntPtr data);
+        [LibraryImport(Libraries.Application, EntryPoint = "ui_app_add_event_handler", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AddEventHandler(out IntPtr handle, DefaultCoreBackend.AppEventType eventType, AppEventCallback callback, IntPtr data);
 
-        [DllImport(Libraries.Application, EntryPoint = "ui_app_remove_event_handler")]
-        internal static extern ErrorCode RemoveEventHandler(IntPtr handle);
+        [LibraryImport(Libraries.Application, EntryPoint = "ui_app_remove_event_handler", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode RemoveEventHandler(IntPtr handle);
 
-        [DllImport(Libraries.Application, EntryPoint = "ui_app_get_window_position")]
-        internal static extern ErrorCode GetWindowPosition(out int x, out int y, out int w, out int h);
+        [LibraryImport(Libraries.Application, EntryPoint = "ui_app_get_window_position", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetWindowPosition(out int x, out int y, out int w, out int h);
 
         [NativeStruct("ui_app_lifecycle_callback_s", Include="app.h", PkgConfig="capi-appfw-application")]
         [StructLayout(LayoutKind.Sequential)]
@@ -68,4 +69,8 @@ internal static partial class Interop
         }
     }
 }
+
+
+
+
 

--- a/src/Tizen.Applications.UI/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.UI/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string Application = "libcapi-appfw-application.so.0";
     }
 }
+
+
+

--- a/src/Tizen.Applications.UIGadget/Interop/Interop.ApplicationManager.cs
+++ b/src/Tizen.Applications.UIGadget/Interop/Interop.ApplicationManager.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2025 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Tizen.Internals.Errors;
 using Tizen.Applications;
@@ -38,7 +39,10 @@ internal static partial class Interop
             PermissionDenied = Tizen.Internals.Errors.ErrorCode.PermissionDenied
         }
 
-        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_request_remount_gadget_path")]
-        internal static extern ErrorCode AppRemountGadgetPath(out string pkgList);
+        [LibraryImport(Libraries.AppManager, EntryPoint = "app_manager_request_remount_gadget_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode AppRemountGadgetPath(out string pkgList);
     }
 }
+
+
+

--- a/src/Tizen.Applications.UIGadget/Interop/Interop.Libc.cs
+++ b/src/Tizen.Applications.UIGadget/Interop/Interop.Libc.cs
@@ -16,12 +16,16 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
     internal static partial class Libc
     {
-        [DllImport(Libraries.Libc, EntryPoint = "getenv")]
-        internal static extern IntPtr GetEnvironmentVariable(string name);
+        [LibraryImport(Libraries.Libc, EntryPoint = "getenv", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr GetEnvironmentVariable(string name);
     }
 }
+
+
+

--- a/src/Tizen.Applications.UIGadget/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.UIGadget/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2025 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -23,3 +23,6 @@ internal static partial class Interop
         public const string AppManager = "libcapi-appfw-app-manager.so.0";
     }
 }
+
+
+

--- a/src/Tizen.Applications.UIGadget/Interop/Interop.PkgMgrInfo.cs
+++ b/src/Tizen.Applications.UIGadget/Interop/Interop.PkgMgrInfo.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2025 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
@@ -33,19 +34,22 @@ internal static partial class Interop
         internal delegate int PackageInfoPackageMetadataListCallback(string key, string value, IntPtr userData);
         // int (*pkgmgrinfo_pkg_metadata_list_cb)(const char *key, const char *value, void *user_data);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_get_pkginfo")]
-        internal static extern ErrorCode PackageInfoGet(string packageId, out IntPtr handle);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_get_pkginfo", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoGet(string packageId, out IntPtr handle);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_destroy_pkginfo")]
-        internal static extern ErrorCode PackageInfoDestroy(IntPtr handle);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_destroy_pkginfo", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoDestroy(IntPtr handle);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_get_res_type")]
-        internal static extern ErrorCode PackageInfoGetResourceType(IntPtr handle, out IntPtr resourceType);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_get_res_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoGetResourceType(IntPtr handle, out IntPtr resourceType);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_get_res_version")]
-        internal static extern ErrorCode PackageInfoGetResourceVersion(IntPtr handle, out IntPtr resourceVersion);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_get_res_version", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoGetResourceVersion(IntPtr handle, out IntPtr resourceVersion);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_foreach_metadata")]
-        internal static extern ErrorCode PackageInfoForeachMetadata(IntPtr handle, PackageInfoPackageMetadataListCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_foreach_metadata", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoForeachMetadata(IntPtr handle, PackageInfoPackageMetadataListCallback callback, IntPtr userData);
     }
 }
+
+
+

--- a/src/Tizen.Applications.UnitedService/Interop/Interop.Libc.cs
+++ b/src/Tizen.Applications.UnitedService/Interop/Interop.Libc.cs
@@ -16,12 +16,15 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
     internal static partial class Libc
     {
-        [DllImport(Libraries.Libc, EntryPoint = "getenv")]
-        internal static extern IntPtr GetEnviornmentVariable(string name);
+        [LibraryImport(Libraries.Libc, EntryPoint = "getenv", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr GetEnviornmentVariable(string name);
     }
 }
+
+

--- a/src/Tizen.Applications.UnitedService/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.UnitedService/Interop/Interop.Libraries.cs
@@ -22,3 +22,5 @@ internal static partial class Interop
         public const string Libc = "libc.so.6";
     }
 }
+
+

--- a/src/Tizen.Applications.UnitedService/Interop/Interop.PkgMgrInfo.cs
+++ b/src/Tizen.Applications.UnitedService/Interop/Interop.PkgMgrInfo.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
@@ -33,19 +34,21 @@ internal static partial class Interop
         internal delegate int PackageInfoPackageMetadataListCallback(string key, string value, IntPtr userData);
         // int (*pkgmgrinfo_pkg_metadata_list_cb)(const char *key, const char *value, void *user_data);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_get_pkginfo")]
-        internal static extern ErrorCode PackageInfoGet(string packageId, out IntPtr handle);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_get_pkginfo", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoGet(string packageId, out IntPtr handle);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_destroy_pkginfo")]
-        internal static extern ErrorCode PackageInfoDestroy(IntPtr handle);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_destroy_pkginfo", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoDestroy(IntPtr handle);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_get_res_type")]
-        internal static extern ErrorCode PackageInfoGetResourceType(IntPtr handle, out IntPtr resourceType);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_get_res_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoGetResourceType(IntPtr handle, out IntPtr resourceType);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_get_res_version")]
-        internal static extern ErrorCode PackageInfoGetResourceVersion(IntPtr handle, out IntPtr resourceVersion);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_get_res_version", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoGetResourceVersion(IntPtr handle, out IntPtr resourceVersion);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_foreach_metadata")]
-        internal static extern ErrorCode PackageInfoForeachMetadata(IntPtr handle, PackageInfoPackageMetadataListCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_foreach_metadata", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode PackageInfoForeachMetadata(IntPtr handle, PackageInfoPackageMetadataListCallback callback, IntPtr userData);
     }
 }
+
+

--- a/src/Tizen.Applications.WatchApplication/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.WatchApplication/Interop/Interop.Libraries.cs
@@ -22,3 +22,5 @@ internal static partial class Interop
         public const string AppCoreWatch = "libappcore-watch.so.1";
     }
 }
+
+

--- a/src/Tizen.Applications.WatchApplication/Interop/Interop.Watch.cs
+++ b/src/Tizen.Applications.WatchApplication/Interop/Interop.Watch.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Internals;
 using Tizen.Applications;
 
@@ -46,7 +47,7 @@ internal static partial class Interop
 
         internal delegate void AppEventCallback(IntPtr handle, IntPtr data);
 
-        internal delegate bool WatchAppCreateCallback(int width, int height, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool WatchAppCreateCallback(int width, int height, IntPtr userData);
 
         internal delegate void WatchAppPauseCallback(IntPtr userData);
 
@@ -60,7 +61,7 @@ internal static partial class Interop
 
         internal delegate void WatchAppAmbientTickCallback(IntPtr watchTime, IntPtr userData);
 
-        internal delegate void WatchAppAmbientChangedCallback(bool ambientMode, IntPtr userData);
+        internal delegate void WatchAppAmbientChangedCallback([MarshalAs(UnmanagedType.U1)] bool ambientMode, IntPtr userData);
 
 #if !PROFILE_TV
         [NativeStruct("watch_app_lifecycle_callback_s", Include="watch_app.h", PkgConfig="capi-appfw-watch-application")]
@@ -160,3 +161,8 @@ internal static partial class Interop
         internal static extern Tizen.Internals.Errors.ErrorCode AppEventGetRegionFormat(IntPtr handle, out string region);
     }
 }
+
+
+
+
+

--- a/src/Tizen.Applications.WatchfaceComplication/Tizen.Applications/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.WatchfaceComplication/Tizen.Applications/Interop/Interop.Libraries.cs
@@ -6,3 +6,5 @@
         public const string ComplicationProvider = "libwatchface-complication-provider.so.1";
     }
 }
+
+

--- a/src/Tizen.Applications.WatchfaceComplication/Tizen.Applications/Interop/Interop.WatchfaceComplication.cs
+++ b/src/Tizen.Applications.WatchfaceComplication/Tizen.Applications/Interop/Interop.WatchfaceComplication.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using System.Text;
 using Tizen.Applications;
 using Tizen;
@@ -26,213 +27,213 @@ internal static partial class Interop
             NotAvailable = -0x02FC0000 | 0x6
         }
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_highlight_create")]
-        internal static extern ComplicationError CreateHighlight(out IntPtr highlightHandle);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_highlight_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError CreateHighlight(out IntPtr highlightHandle);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_highlight_destroy")]
-        internal static extern ComplicationError DestroyHighlight(IntPtr highlightHandle);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_highlight_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError DestroyHighlight(IntPtr highlightHandle);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_highlight_set_geometry")]
-        internal static extern ComplicationError SetHighlightGeometry(IntPtr highlightHandle, int x, int y, int w, int h);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_highlight_set_geometry", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError SetHighlightGeometry(IntPtr highlightHandle, int x, int y, int w, int h);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_highlight_get_geometry")]
-        internal static extern ComplicationError GetHighlightGeometry(IntPtr highlightHandle, out int x, out int y, out int w, out int h);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_highlight_get_geometry", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetHighlightGeometry(IntPtr highlightHandle, out int x, out int y, out int w, out int h);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_highlight_set_shape_type")]
-        internal static extern ComplicationError SetHighlightShapeType(IntPtr highlightHandle, ShapeType shapeType);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_highlight_set_shape_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError SetHighlightShapeType(IntPtr highlightHandle, ShapeType shapeType);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_highlight_get_shape_type")]
-        internal static extern ComplicationError GetHighlightShapeType(IntPtr highlightHandle, out ShapeType shapeType);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_highlight_get_shape_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetHighlightShapeType(IntPtr highlightHandle, out ShapeType shapeType);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_get_highlight")]
-        internal static extern ComplicationError GetHighlight(IntPtr handle, out IntPtr highlightHandle);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_get_highlight", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetHighlight(IntPtr handle, out IntPtr highlightHandle);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_create")]
-        internal static extern ComplicationError CreateComplication(int complicationId,
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError CreateComplication(int complicationId,
             string defaultProviderId, ComplicationTypes defaultType, int supportTypes, int supportEventTypes, out IntPtr handle);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_destroy")]
-        internal static extern ComplicationError Destroy(IntPtr handle);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError Destroy(IntPtr handle);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_get_current_provider_id")]
-        internal static extern ComplicationError GetCurrentProviderId(IntPtr handle, out string curProviderId);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_get_current_provider_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetCurrentProviderId(IntPtr handle, out string curProviderId);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_get_current_type")]
-        internal static extern ComplicationError GetCurrentType(IntPtr handle, out ComplicationTypes type);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_get_current_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetCurrentType(IntPtr handle, out ComplicationTypes type);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_add_updated_cb")]
-        internal static extern ComplicationError AddUpdatedCallback(IntPtr handle, ComplicationUpdatedCallback callback, ComplicationErrorCallback errCallback, IntPtr userData);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_add_updated_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError AddUpdatedCallback(IntPtr handle, ComplicationUpdatedCallback callback, ComplicationErrorCallback errCallback, IntPtr userData);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_remove_updated_cb")]
-        internal static extern ComplicationError RemoveUpdatedCallback(IntPtr handle, ComplicationUpdatedCallback callback);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_remove_updated_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError RemoveUpdatedCallback(IntPtr handle, ComplicationUpdatedCallback callback);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_send_update_request")]
-        internal static extern ComplicationError SendUpdateRequest(IntPtr handle);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_send_update_request", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError SendUpdateRequest(IntPtr handle);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_type")]
-        internal static extern ComplicationError GetDataType(SafeBundleHandle handle, out ComplicationTypes type);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetDataType(SafeBundleHandle handle, out ComplicationTypes type);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_short_text")]
-        internal static extern ComplicationError GetShortText(SafeBundleHandle handle, out string shortText);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_short_text", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetShortText(SafeBundleHandle handle, out string shortText);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_long_text")]
-        internal static extern ComplicationError GetLongText(SafeBundleHandle handle, out string longText);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_long_text", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetLongText(SafeBundleHandle handle, out string longText);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_title")]
-        internal static extern ComplicationError GetTitle(SafeBundleHandle handle, out string title);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_title", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetTitle(SafeBundleHandle handle, out string title);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_timestamp")]
-        internal static extern ComplicationError GetTimestamp(SafeBundleHandle handle, out long timestamp);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_timestamp", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetTimestamp(SafeBundleHandle handle, out long timestamp);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_image_path")]
-        internal static extern ComplicationError GetImagePath(SafeBundleHandle handle, out string imagePath);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_image_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetImagePath(SafeBundleHandle handle, out string imagePath);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_ranged_value")]
-        internal static extern ComplicationError GetRangedValue(SafeBundleHandle handle, out double currentValue, out double minValue, out double maxValue);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_ranged_value", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetRangedValue(SafeBundleHandle handle, out double currentValue, out double minValue, out double maxValue);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_icon_path")]
-        internal static extern ComplicationError GetIconPath(SafeBundleHandle handle, out string iconPath);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_icon_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetIconPath(SafeBundleHandle handle, out string iconPath);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_extra_data")]
-        internal static extern ComplicationError GetExtraData(SafeBundleHandle handle, out string extraData);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_extra_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetExtraData(SafeBundleHandle handle, out string extraData);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_screen_reader_text")]
-        internal static extern ComplicationError GetScreenReaderText(SafeBundleHandle handle, out string screenReaderText);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_data_get_screen_reader_text", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetScreenReaderText(SafeBundleHandle handle, out string screenReaderText);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_transfer_event")]
-        internal static extern ComplicationError TransferEvent(IntPtr handle, EventTypes e);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_transfer_event", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError TransferEvent(IntPtr handle, EventTypes e);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_allowed_list_create")]
-        internal static extern ComplicationError CreateAllowedList(out IntPtr allowedList);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_allowed_list_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError CreateAllowedList(out IntPtr allowedList);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_allowed_list_destroy")]
-        internal static extern ComplicationError DestroyAllowedList(IntPtr allowedList);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_allowed_list_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError DestroyAllowedList(IntPtr allowedList);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_allowed_list_add")]
-        internal static extern ComplicationError AddAllowedList(IntPtr allowedList, string providerId, int types);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_allowed_list_add", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError AddAllowedList(IntPtr allowedList, string providerId, int types);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_allowed_list_delete")]
-        internal static extern ComplicationError DeleteAllowedList(IntPtr allowedList, string providerId);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_allowed_list_delete", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError DeleteAllowedList(IntPtr allowedList, string providerId);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_allowed_list_get_nth")]
-        internal static extern ComplicationError GetNthAllowedListItem(IntPtr allowedList, int idx, out string providerId, out int types);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_allowed_list_get_nth", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetNthAllowedListItem(IntPtr allowedList, int idx, out string providerId, out int types);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_allowed_list_apply")]
-        internal static extern ComplicationError ApplyAllowedList(IntPtr handle, IntPtr allowedList);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_allowed_list_apply", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError ApplyAllowedList(IntPtr handle, IntPtr allowedList);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_complication_allowed_list_clear")]
-        internal static extern ComplicationError ClearAllowedList(IntPtr handle);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_complication_allowed_list_clear", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError ClearAllowedList(IntPtr handle);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_add_edit_ready_cb")]
-        internal static extern ComplicationError AddEditReadyCallback(EditReadyCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_add_edit_ready_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError AddEditReadyCallback(EditReadyCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_remove_edit_ready_cb")]
-        internal static extern ComplicationError RemoveEditReadyCallback(EditReadyCallback callback);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_remove_edit_ready_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError RemoveEditReadyCallback(EditReadyCallback callback);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_get_current_data_idx")]
-        internal static extern ComplicationError GetCurrentIdx(IntPtr handle, out int curIdx);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_get_current_data_idx", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetCurrentIdx(IntPtr handle, out int curIdx);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_get_current_data")]
-        internal static extern ComplicationError GetCurrentData(IntPtr handle, out SafeBundleHandle data);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_get_current_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetCurrentData(IntPtr handle, out SafeBundleHandle data);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_get_nth_data")]
-        internal static extern ComplicationError GetNthData(IntPtr handle, out SafeBundleHandle data);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_get_nth_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetNthData(IntPtr handle, out SafeBundleHandle data);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_get_editable_id")]
-        internal static extern ComplicationError GetEditableId(IntPtr handle, out int editableId);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_get_editable_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetEditableId(IntPtr handle, out int editableId);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_get_editable_name")]
-        internal static extern ComplicationError GetEditableName(IntPtr handle, out string editableName);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_get_editable_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetEditableName(IntPtr handle, out string editableName);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_set_editable_name")]
-        internal static extern ComplicationError SetEditableName(IntPtr handle, string editableName);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_set_editable_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError SetEditableName(IntPtr handle, string editableName);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_add_complication")]
-        internal static extern ComplicationError AddComplication(IntPtr container, int editId, IntPtr comp, IntPtr highlight);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_add_complication", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError AddComplication(IntPtr container, int editId, IntPtr comp, IntPtr highlight);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_add_design_element")]
-        internal static extern ComplicationError AddDesignElement(IntPtr container, int editId, int curDataIdx, IntPtr listHandle, IntPtr highlight, string editableName);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_add_design_element", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError AddDesignElement(IntPtr container, int editId, int curDataIdx, IntPtr listHandle, IntPtr highlight, string editableName);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_candidates_list_create")]
-        internal static extern ComplicationError CreateCandidatesList(out IntPtr listHandle);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_candidates_list_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError CreateCandidatesList(out IntPtr listHandle);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_candidates_list_add")]
-        internal static extern ComplicationError AddCandidatesListItem(IntPtr listHandle, SafeBundleHandle candidate);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_candidates_list_add", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError AddCandidatesListItem(IntPtr listHandle, SafeBundleHandle candidate);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_candidates_list_destroy")]
-        internal static extern ComplicationError DestroyCandidatesList(IntPtr listHandle);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_candidates_list_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError DestroyCandidatesList(IntPtr listHandle);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_request_edit")]
-        internal static extern ComplicationError RequestEdit(IntPtr container, EditableUpdateRequestedCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_request_edit", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError RequestEdit(IntPtr container, EditableUpdateRequestedCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_container_get")]
-        internal static extern ComplicationError GetEditableContainer(out IntPtr container);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_container_get", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetEditableContainer(out IntPtr container);
 
-        [DllImport(Libraries.Complication, EntryPoint = "watchface_editable_load_current_data")]
-        internal static extern ComplicationError LoadCurrentData(int editableId, out SafeBundleHandle data);
+        [LibraryImport(Libraries.Complication, EntryPoint = "watchface_editable_load_current_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError LoadCurrentData(int editableId, out SafeBundleHandle data);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_add_update_requested_cb")]
-        internal static extern ComplicationError AddUpdateRequestedCallback(string providerId, UpdateRequestedCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_add_update_requested_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError AddUpdateRequestedCallback(string providerId, UpdateRequestedCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_remove_update_requested_cb")]
-        internal static extern ComplicationError RemoveUpdateRequestedCallback(string providerId, UpdateRequestedCallback callback);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_remove_update_requested_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError RemoveUpdateRequestedCallback(string providerId, UpdateRequestedCallback callback);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_type")]
-        internal static extern ComplicationError ProviderSetDataType(IntPtr sharedData, ComplicationTypes type);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError ProviderSetDataType(IntPtr sharedData, ComplicationTypes type);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_title")]
-        internal static extern ComplicationError ProviderSetTitle(IntPtr sharedData, string title);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_title", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError ProviderSetTitle(IntPtr sharedData, string title);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_short_text")]
-        internal static extern ComplicationError ProviderSetShortText(IntPtr sharedData, string shortText);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_short_text", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError ProviderSetShortText(IntPtr sharedData, string shortText);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_long_text")]
-        internal static extern ComplicationError ProviderSetLongText(IntPtr sharedData, string longText);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_long_text", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError ProviderSetLongText(IntPtr sharedData, string longText);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_timestamp")]
-        internal static extern ComplicationError ProviderSetTimestamp(IntPtr sharedData, Int32 timestamp);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_timestamp", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError ProviderSetTimestamp(IntPtr sharedData, Int32 timestamp);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_image_path")]
-        internal static extern ComplicationError ProviderSetImagePath(IntPtr sharedData, string imagePath);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_image_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError ProviderSetImagePath(IntPtr sharedData, string imagePath);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_ranged_value")]
-        internal static extern ComplicationError ProviderSetRangedValue(IntPtr sharedData, double currentValue, double minValue, double maxValue);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_ranged_value", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError ProviderSetRangedValue(IntPtr sharedData, double currentValue, double minValue, double maxValue);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_icon_path")]
-        internal static extern ComplicationError ProviderSetIconPath(IntPtr sharedData, string iconPath);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_icon_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError ProviderSetIconPath(IntPtr sharedData, string iconPath);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_extra_data")]
-        internal static extern ComplicationError ProviderSetExtraData(IntPtr sharedData, string extraData);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_extra_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError ProviderSetExtraData(IntPtr sharedData, string extraData);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_screen_reader_text")]
-        internal static extern ComplicationError ProviderSetScreenReaderText(IntPtr sharedData, string screenReaderText);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_set_screen_reader_text", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError ProviderSetScreenReaderText(IntPtr sharedData, string screenReaderText);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_is_valid")]
-        internal static extern ComplicationError ProviderSharedDataIsValid(IntPtr sharedData, out bool isVaild);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_data_is_valid", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError ProviderSharedDataIsValid(IntPtr sharedData, [MarshalAs(UnmanagedType.U1)] out bool isVaild);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_notify_update")]
-        internal static extern ComplicationError NotifyUpdate(string updatedProviderId);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_notify_update", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError NotifyUpdate(string updatedProviderId);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_event_get_type")]
-        internal static extern ComplicationError GetEventType(SafeAppControlHandle handle, out EventTypes type);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_event_get_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetEventType(SafeAppControlHandle handle, out EventTypes type);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_event_get_provider_id")]
-        internal static extern ComplicationError GetEventProviderId(SafeAppControlHandle handle, out string providerId);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_event_get_provider_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetEventProviderId(SafeAppControlHandle handle, out string providerId);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_event_get_complication_type")]
-        internal static extern ComplicationError GetEventComplicationType(SafeAppControlHandle handle, out ComplicationTypes type);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_event_get_complication_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetEventComplicationType(SafeAppControlHandle handle, out ComplicationTypes type);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_event_get_context")]
-        internal static extern ComplicationError GetEventContext(SafeAppControlHandle handle, out SafeBundleHandle context);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_event_get_context", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetEventContext(SafeAppControlHandle handle, out SafeBundleHandle context);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_setup_reply_to_editor")]
-        internal static extern ComplicationError SetupReplyToEditor(SafeAppControlHandle handle, SafeBundleHandle context);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_setup_reply_to_editor", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError SetupReplyToEditor(SafeAppControlHandle handle, SafeBundleHandle context);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_setup_is_editing")]
-        internal static extern ComplicationError IsSetupEditing(SafeAppControlHandle handle, out bool isEditing);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_setup_is_editing", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError IsSetupEditing(SafeAppControlHandle handle, [MarshalAs(UnmanagedType.U1)] out bool isEditing);
 
-        [DllImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_setup_get_context")]
-        internal static extern ComplicationError GetSetupContext(SafeAppControlHandle handle, out SafeBundleHandle context);
+        [LibraryImport(Libraries.ComplicationProvider, EntryPoint = "watchface_complication_provider_setup_get_context", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ComplicationError GetSetupContext(SafeAppControlHandle handle, out SafeBundleHandle context);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void EditReadyCallback(IntPtr handle, string editorAppId, IntPtr userData);
@@ -254,3 +255,7 @@ internal static partial class Interop
             int state, IntPtr userData);
     }
 }
+
+
+
+

--- a/src/Tizen.Applications.WidgetApplication/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.WidgetApplication/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -23,3 +23,6 @@ internal static partial class Interop
         public const string WidgetService = "libwidget_service.so.1";
     }
 }
+
+
+

--- a/src/Tizen.Applications.WidgetApplication/Interop/Interop.Widget.cs
+++ b/src/Tizen.Applications.WidgetApplication/Interop/Interop.Widget.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Tizen.Internals;
 using Tizen.Applications;
@@ -149,3 +150,7 @@ internal static partial class Interop
         }
     }
 }
+
+
+
+

--- a/src/Tizen.Applications.WidgetControl/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.WidgetControl/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string WidgetService = "libwidget_service.so.1";
     }
 }
+
+
+

--- a/src/Tizen.Applications.WidgetControl/Interop/Interop.WidgetService.cs
+++ b/src/Tizen.Applications.WidgetControl/Interop/Interop.WidgetService.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 
 internal static partial class Interop
@@ -61,61 +62,64 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int WidgetListCallback(string widgetId, int isPrime, IntPtr userData);
 
-        [DllImport(Libraries.WidgetService, EntryPoint = "widget_service_get_icon")]
-        internal static extern string GetIcon(string pkgId, string lang);
+        [LibraryImport(Libraries.WidgetService, EntryPoint = "widget_service_get_icon", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string GetIcon(string pkgId, string lang);
 
-        [DllImport(Libraries.WidgetService, EntryPoint = "widget_service_get_name")]
-        internal static extern string GetName(string widgetId, string lang);
+        [LibraryImport(Libraries.WidgetService, EntryPoint = "widget_service_get_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string GetName(string widgetId, string lang);
 
-        [DllImport(Libraries.WidgetService, EntryPoint = "widget_service_get_nodisplay")]
-        internal static extern int GetNoDisplay(string widgetId);
+        [LibraryImport(Libraries.WidgetService, EntryPoint = "widget_service_get_nodisplay", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetNoDisplay(string widgetId);
 
-        [DllImport(Libraries.WidgetService, EntryPoint = "widget_service_get_widget_instance_list")]
-        internal static extern ErrorCode GetInstances(string widgetId, InstanceCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.WidgetService, EntryPoint = "widget_service_get_widget_instance_list", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetInstances(string widgetId, InstanceCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.WidgetService, EntryPoint = "widget_service_set_lifecycle_event_cb")]
-        internal static extern ErrorCode SetLifecycleEvent(string widgetId, LifecycleCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.WidgetService, EntryPoint = "widget_service_set_lifecycle_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode SetLifecycleEvent(string widgetId, LifecycleCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.WidgetService, EntryPoint = "widget_service_unset_lifecycle_event_cb")]
-        internal static extern ErrorCode UnsetLifecycleEvent(string widgetId, IntPtr userData);
+        [LibraryImport(Libraries.WidgetService, EntryPoint = "widget_service_unset_lifecycle_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode UnsetLifecycleEvent(string widgetId, IntPtr userData);
 
-        [DllImport(Libraries.WidgetService, EntryPoint = "widget_service_trigger_update")]
-        internal static extern ErrorCode UpdateContent(string widgetId, string instanceId, SafeBundleHandle bundle, int force);
+        [LibraryImport(Libraries.WidgetService, EntryPoint = "widget_service_trigger_update", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode UpdateContent(string widgetId, string instanceId, SafeBundleHandle bundle, int force);
 
-        [DllImport(Libraries.WidgetService, EntryPoint = "widget_service_change_period")]
-        internal static extern ErrorCode ChangePeriod(string widgetId, string instanceId, double period);
+        [LibraryImport(Libraries.WidgetService, EntryPoint = "widget_service_change_period", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode ChangePeriod(string widgetId, string instanceId, double period);
 
-        [DllImport(Libraries.WidgetService, EntryPoint = "widget_service_get_content_of_widget_instance")]
-        internal static extern ErrorCode GetContent(string widgetId, string instanceId, out IntPtr bundle);
+        [LibraryImport(Libraries.WidgetService, EntryPoint = "widget_service_get_content_of_widget_instance", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetContent(string widgetId, string instanceId, out IntPtr bundle);
 
-        [DllImport(Libraries.WidgetService, EntryPoint = "widget_service_get_package_id")]
-        internal static extern string GetPkgId(string widgetId);
+        [LibraryImport(Libraries.WidgetService, EntryPoint = "widget_service_get_package_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string GetPkgId(string widgetId);
 
-        [DllImport(Libraries.WidgetService, EntryPoint = "widget_service_get_supported_sizes")]
-        internal static extern ErrorCode GetSupportedSizes(string widgetId, ref int cnt, out IntPtr w, out IntPtr h);
+        [LibraryImport(Libraries.WidgetService, EntryPoint = "widget_service_get_supported_sizes", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetSupportedSizes(string widgetId, ref int cnt, out IntPtr w, out IntPtr h);
 
-        [DllImport(Libraries.WidgetService, EntryPoint = "widget_service_get_supported_size_types")]
-        internal static extern ErrorCode GetSupportedSizeTypes(string widgetId, ref int cnt, out IntPtr types);
+        [LibraryImport(Libraries.WidgetService, EntryPoint = "widget_service_get_supported_size_types", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetSupportedSizeTypes(string widgetId, ref int cnt, out IntPtr types);
 
-        [DllImport(Libraries.WidgetService, EntryPoint = "widget_service_get_preview_image_path")]
-        internal static extern string GetPreviewImagePath(string widgetId, int sizeType);
+        [LibraryImport(Libraries.WidgetService, EntryPoint = "widget_service_get_preview_image_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string GetPreviewImagePath(string widgetId, int sizeType);
 
-        [DllImport(Libraries.WidgetService, EntryPoint = "widget_service_get_widget_list_by_pkgid")]
-        internal static extern ErrorCode GetWidgetListByPkgId(string pkgId, WidgetListCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.WidgetService, EntryPoint = "widget_service_get_widget_list_by_pkgid", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetWidgetListByPkgId(string pkgId, WidgetListCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.WidgetService, EntryPoint = "widget_service_get_main_app_id")]
-        internal static extern string GetWidgetMainAppId(string widgetId);
+        [LibraryImport(Libraries.WidgetService, EntryPoint = "widget_service_get_main_app_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string GetWidgetMainAppId(string widgetId);
 
-        [DllImport(Libraries.WidgetService, EntryPoint = "widget_service_get_package_id")]
-        internal static extern string GetWidgetPackageId(string widgetId);
+        [LibraryImport(Libraries.WidgetService, EntryPoint = "widget_service_get_package_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string GetWidgetPackageId(string widgetId);
 
-        [DllImport(Libraries.WidgetService, EntryPoint = "widget_service_get_widget_max_count")]
-        internal static extern int GetWidgetMaxCount(string widgetId);
+        [LibraryImport(Libraries.WidgetService, EntryPoint = "widget_service_get_widget_max_count", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetWidgetMaxCount(string widgetId);
 
-        [DllImport(Libraries.WidgetService, EntryPoint = "widget_service_get_instance_count")]
-        internal static extern int GetWidgetInstanceCount(string widgetId, string cluster, string category);
+        [LibraryImport(Libraries.WidgetService, EntryPoint = "widget_service_get_instance_count", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetWidgetInstanceCount(string widgetId, string cluster, string category);
 
-        [DllImport(Libraries.WidgetService, EntryPoint = "widget_service_get_app_id_of_setup_app")]
-        internal static extern string GetSetupAppId(string widgetId);
+        [LibraryImport(Libraries.WidgetService, EntryPoint = "widget_service_get_app_id_of_setup_app", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial string GetSetupAppId(string widgetId);
     }
 }
+
+
+

--- a/src/Tizen.Content.Download/Interop/Interop.Download.cs
+++ b/src/Tizen.Content.Download/Interop/Interop.Download.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
 *
 * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 
 internal static partial class Interop
@@ -29,102 +30,106 @@ internal static partial class Interop
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
         internal delegate void ProgressChangedCallback(int requestId, ulong receivedSize, IntPtr userData);
 
-        [DllImport(Libraries.Download, EntryPoint = "download_create")]
-        internal static extern int CreateRequest(out int requestId);
-        [DllImport(Libraries.Download, EntryPoint = "download_destroy")]
-        internal static extern int DestroyRequest(int requestId);
-        [DllImport(Libraries.Download, EntryPoint = "download_set_url")]
-        internal static extern int SetUrl(int requestId, string url);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_url")]
-        internal static extern int GetUrl(int requestId, out string url);
-        [DllImport(Libraries.Download, EntryPoint = "download_set_network_type")]
-        internal static extern int SetNetworkType(int requestId, int networkType);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_network_type")]
-        internal static extern int GetNetworkType(int requestId, out int networkType);
-        [DllImport(Libraries.Download, EntryPoint = "download_set_destination")]
-        internal static extern int SetDestination(int requestId, string path);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_destination")]
-        internal static extern int GetDestination(int requestId, out string path);
-        [DllImport(Libraries.Download, EntryPoint = "download_set_file_name")]
-        internal static extern int SetFileName(int requestId, string fileName);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_file_name")]
-        internal static extern int GetFileName(int requestId, out string path);
-        [DllImport(Libraries.Download, EntryPoint = "download_set_auto_download")]
-        internal static extern int SetAutoDownload(int requestId, bool value);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_auto_download")]
-        internal static extern int GetAutoDownload(int requestId, out bool value);
-        [DllImport(Libraries.Download, EntryPoint = "download_set_temp_file_path")]
-        internal static extern int SetTempFilePath(int requestId, string tempPath);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_temp_path")]
-        internal static extern int GetTempFilePath(int requestId, out string tempPath);
-        [DllImport(Libraries.Download, EntryPoint = "download_add_http_header_field")]
-        internal static extern int AddHttpHeaderField(int requestId, string field, string value);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_downloaded_file_path")]
-        internal static extern int GetDownloadedPath(int requestId, out string downloadedPath);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_mime_type")]
-        internal static extern int GetMimeType(int requestId, out string mimeType);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_state")]
-        internal static extern int GetState(int requestId, out int downloadState);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_content_name")]
-        internal static extern int GetContentName(int requestId, out string contentName);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_content_size")]
-        internal static extern int GetContentSize(int requestId, out ulong size);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_http_status")]
-        internal static extern int GetHttpStatus(int requestId, out int httpStatus);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_etag")]
-        internal static extern int GetETag(int requestId, out string etag);
-        [DllImport(Libraries.Download, EntryPoint = "download_start")]
-        internal static extern int StartDownload(int requestId);
-        [DllImport(Libraries.Download, EntryPoint = "download_pause")]
-        internal static extern int PauseDownload(int requestId);
-        [DllImport(Libraries.Download, EntryPoint = "download_cancel")]
-        internal static extern int CancelDownload(int requestId);
-        [DllImport(Libraries.Download, EntryPoint = "download_set_state_changed_cb")]
-        internal static extern int SetStateChangedCallback(int requestId, StateChangedCallback callback, IntPtr userData);
-        [DllImport(Libraries.Download, EntryPoint = "download_unset_state_changed_cb")]
-        internal static extern int UnsetStateChangedCallback(int requestId);
-        [DllImport(Libraries.Download, EntryPoint = "download_set_progress_cb")]
-        internal static extern int SetProgressCallback(int requestId, ProgressChangedCallback callback, IntPtr userData);
-        [DllImport(Libraries.Download, EntryPoint = "download_unset_progress_cb")]
-        internal static extern int UnsetProgressCallback(int requestId);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CreateRequest(out int requestId);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int DestroyRequest(int requestId);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_set_url", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetUrl(int requestId, string url);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_url", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetUrl(int requestId, out string url);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_set_network_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetNetworkType(int requestId, int networkType);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_network_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetNetworkType(int requestId, out int networkType);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_set_destination", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetDestination(int requestId, string path);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_destination", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetDestination(int requestId, out string path);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_set_file_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetFileName(int requestId, string fileName);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_file_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetFileName(int requestId, out string path);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_set_auto_download", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAutoDownload(int requestId, [MarshalAs(UnmanagedType.U1)] bool value);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_auto_download", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAutoDownload(int requestId, [MarshalAs(UnmanagedType.U1)] out bool value);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_set_temp_file_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetTempFilePath(int requestId, string tempPath);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_temp_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetTempFilePath(int requestId, out string tempPath);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_add_http_header_field", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int AddHttpHeaderField(int requestId, string field, string value);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_downloaded_file_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetDownloadedPath(int requestId, out string downloadedPath);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_mime_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetMimeType(int requestId, out string mimeType);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetState(int requestId, out int downloadState);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_content_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetContentName(int requestId, out string contentName);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_content_size", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetContentSize(int requestId, out ulong size);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_http_status", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetHttpStatus(int requestId, out int httpStatus);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_etag", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetETag(int requestId, out string etag);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_start", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int StartDownload(int requestId);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_pause", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int PauseDownload(int requestId);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_cancel", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CancelDownload(int requestId);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_set_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetStateChangedCallback(int requestId, StateChangedCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_unset_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UnsetStateChangedCallback(int requestId);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_set_progress_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetProgressCallback(int requestId, ProgressChangedCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_unset_progress_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UnsetProgressCallback(int requestId);
 
         // Notification class
 
-        [DllImport(Libraries.Download, EntryPoint = "download_set_notification_title")]
-        internal static extern int SetNotificationTitle(int requestId, string title);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_notification_title")]
-        internal static extern int GetNotificationTitle(int requestId, out string title);
-        [DllImport(Libraries.Download, EntryPoint = "download_set_notification_description")]
-        internal static extern int SetNotificationDescription(int requestId, string description);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_notification_description")]
-        internal static extern int GetNotificationDescription(int requestId, out string description);
-        [DllImport(Libraries.Download, EntryPoint = "download_set_notification_type")]
-        internal static extern int SetNotificationType(int requestId, int type);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_notification_type")]
-        internal static extern int GetNotificationType(int requestId, out int type);
-        [DllImport(Libraries.Download, EntryPoint = "download_set_notification_app_control")]
-        internal static extern int SetNotificationAppControl(int requestId, int appControlType, SafeAppControlHandle handle);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_notification_app_control")]
-        internal static extern int GetNotificationAppControl(int requestId, int appControlType, out SafeAppControlHandle handle);
-        [DllImport(Libraries.Download, EntryPoint = "download_set_cache")]
-        internal static extern int SetDownloadCache(int downloadId, bool enable);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_cache")]
-        internal static extern int GetDownloadCache(int downloadId, out bool enable);
-        [DllImport(Libraries.Download, EntryPoint = "download_reset_cache")]
-        internal static extern int ResetDownloadCache();
-        [DllImport(Libraries.Download, EntryPoint = "download_set_cache_max_size")]
-        internal static extern int SetDownloadCacheMaxSize(uint maxSize);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_cache_max_size")]
-        internal static extern int GetDownloadCacheMaxSize(out uint maxSize);
-        [DllImport(Libraries.Download, EntryPoint = "download_reset_all_cache")]
-        internal static extern int ResetAllDownloadCache();
-        [DllImport(Libraries.Download, EntryPoint = "download_set_cache_path")]
-        internal static extern int SetDownloadCachePath(string cachePath);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_cache_path")]
-        internal static extern int GetDownloadCachePath(out string cachePath);
-        [DllImport(Libraries.Download, EntryPoint = "download_set_cache_lifecycle")]
-        internal static extern int SetDownloadCacheLifeCycle(uint time);
-        [DllImport(Libraries.Download, EntryPoint = "download_get_cache_lifecycle")]
-        internal static extern int GetDownloadCacheLifeCycle(out uint time);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_set_notification_title", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetNotificationTitle(int requestId, string title);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_notification_title", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetNotificationTitle(int requestId, out string title);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_set_notification_description", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetNotificationDescription(int requestId, string description);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_notification_description", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetNotificationDescription(int requestId, out string description);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_set_notification_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetNotificationType(int requestId, int type);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_notification_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetNotificationType(int requestId, out int type);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_set_notification_app_control", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetNotificationAppControl(int requestId, int appControlType, SafeAppControlHandle handle);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_notification_app_control", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetNotificationAppControl(int requestId, int appControlType, out SafeAppControlHandle handle);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_set_cache", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetDownloadCache(int downloadId, [MarshalAs(UnmanagedType.U1)] bool enable);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_cache", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetDownloadCache(int downloadId, [MarshalAs(UnmanagedType.U1)] out bool enable);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_reset_cache", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int ResetDownloadCache();
+        [LibraryImport(Libraries.Download, EntryPoint = "download_set_cache_max_size", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetDownloadCacheMaxSize(uint maxSize);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_cache_max_size", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetDownloadCacheMaxSize(out uint maxSize);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_reset_all_cache", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int ResetAllDownloadCache();
+        [LibraryImport(Libraries.Download, EntryPoint = "download_set_cache_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetDownloadCachePath(string cachePath);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_cache_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetDownloadCachePath(out string cachePath);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_set_cache_lifecycle", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetDownloadCacheLifeCycle(uint time);
+        [LibraryImport(Libraries.Download, EntryPoint = "download_get_cache_lifecycle", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetDownloadCacheLifeCycle(out uint time);
     }
 }
+
+
+
+

--- a/src/Tizen.Content.Download/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Content.Download/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
 *
 * Licensed under the Apache License, Version 2.0 (the License);
@@ -22,3 +22,6 @@ internal static partial class Interop
         public const string Libc = "libc.so.6";
     }
 }
+
+
+

--- a/src/Tizen.Content.MediaContent/Interop/Interop.Album.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.Album.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Content.MediaContent;
 
 internal static partial class Interop
@@ -55,3 +56,7 @@ internal static partial class Interop
             Common.ItemCallback callback, IntPtr userData = default(IntPtr));
     }
 }
+
+
+
+

--- a/src/Tizen.Content.MediaContent/Interop/Interop.AudioInfo.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.AudioInfo.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,55 +16,60 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Content.MediaContent;
 
 internal static partial class Interop
 {
     internal static partial class AudioInfo
     {
-        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_destroy", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_destroy")]
         internal static extern MediaContentError Destroy(IntPtr handle);
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_album", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_album")]
         internal static extern MediaContentError GetAlbum(IntPtr handle, out IntPtr albumName);
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_artist", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_artist")]
         internal static extern MediaContentError GetArtist(IntPtr handle, out IntPtr artistName);
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_album_artist", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_album_artist")]
         internal static extern MediaContentError GetAlbumArtist(IntPtr handle, out IntPtr albumArtistName);
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_genre", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_genre")]
         internal static extern MediaContentError GetGenre(IntPtr handle, out IntPtr genreName);
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_composer", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_composer")]
         internal static extern MediaContentError GetComposer(IntPtr handle, out IntPtr composerName); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_year", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_year")]
         internal static extern MediaContentError GetYear(IntPtr handle, out IntPtr year);
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_recorded_date", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_recorded_date")]
         internal static extern MediaContentError GetRecordedDate(IntPtr handle, out IntPtr recordedDate); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_copyright", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_copyright")]
         internal static extern MediaContentError GetCopyright(IntPtr handle, out IntPtr copyright); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_track_num", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_track_num")]
         internal static extern MediaContentError GetTrackNum(IntPtr handle, out IntPtr trackNum);
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_bit_rate", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_bit_rate")]
         internal static extern MediaContentError GetBitRate(IntPtr handle, out int bitRate); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_bitpersample", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_bitpersample")]
         internal static extern MediaContentError GetBitPerSample(IntPtr handle, out int bitPerSample); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_sample_rate", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_sample_rate")]
         internal static extern MediaContentError GetSampleRate(IntPtr handle, out int sampleRate); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_channel", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_channel")]
         internal static extern MediaContentError GetChannel(IntPtr handle, out int channel); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_duration", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "audio_meta_get_duration")]
         internal static extern MediaContentError GetDuration(IntPtr handle, out int duration); // Deprecated since API12
     }
 }
+
+
+
+

--- a/src/Tizen.Content.MediaContent/Interop/Interop.BookInfo.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.BookInfo.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Content.MediaContent;
 
 internal static partial class Interop
@@ -44,3 +45,7 @@ internal static partial class Interop
         internal static extern MediaContentError GetPathByKeyword(string keyword, out IntPtr path, out uint length);
     }
 }
+
+
+
+

--- a/src/Tizen.Content.MediaContent/Interop/Interop.Bookmark.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.Bookmark.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Content.MediaContent;
 
 internal partial class Interop
@@ -60,3 +61,7 @@ internal partial class Interop
             Common.ItemCallback callback, IntPtr userData = default(IntPtr));
     }
 }
+
+
+
+

--- a/src/Tizen.Content.MediaContent/Interop/Interop.Common.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.Common.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -25,3 +25,6 @@ internal static partial class Interop
         internal delegate bool ItemCallback(IntPtr itemHandle, IntPtr data);
     }
 }
+
+
+

--- a/src/Tizen.Content.MediaContent/Interop/Interop.Face.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.Face.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Content.MediaContent;
 
 internal static partial class Interop
@@ -70,3 +71,7 @@ internal static partial class Interop
             Common.ItemCallback callback, IntPtr userData = default(IntPtr));
     }
 }
+
+
+
+

--- a/src/Tizen.Content.MediaContent/Interop/Interop.Filter.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.Filter.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen;
 using Tizen.Content.MediaContent;
 
@@ -40,7 +41,7 @@ internal static partial class Interop
         internal static extern MediaContentError SetOrder(FilterHandle filter, string orderExpression);
     }
 
-    internal class FilterHandle : MediaContentCriticalHandle
+    internal partial class FilterHandle : MediaContentCriticalHandle
     {
         public static readonly FilterHandle Null = new FilterHandle();
 
@@ -50,3 +51,7 @@ internal static partial class Interop
         }
     }
 }
+
+
+
+

--- a/src/Tizen.Content.MediaContent/Interop/Interop.Folder.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.Folder.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -17,6 +17,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Content.MediaContent;
 
 internal static partial class Interop
@@ -53,3 +54,7 @@ internal static partial class Interop
             Common.ItemCallback callback, IntPtr user_data);
     }
 }
+
+
+
+

--- a/src/Tizen.Content.MediaContent/Interop/Interop.Group.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.Group.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Content.MediaContent;
 
 internal static partial class Interop
@@ -31,7 +32,7 @@ internal static partial class Interop
             MediaInfoColumnKey groupType, FilterHandle filter, out int count);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool MediaGroupCallback(string groupName, IntPtr data);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool MediaGroupCallback(string groupName, IntPtr data);
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_group_foreach_group_from_db")]
         internal static extern MediaContentError ForeachGroup(FilterHandle filter,
@@ -42,3 +43,8 @@ internal static partial class Interop
             FilterHandle filter, Common.ItemCallback callback, IntPtr userData = default(IntPtr));
     }
 }
+
+
+
+
+

--- a/src/Tizen.Content.MediaContent/Interop/Interop.ImageInfo.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.ImageInfo.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,37 +16,42 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Content.MediaContent;
 
 internal static partial class Interop
 {
     internal static partial class ImageInfo
     {
-        [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_destroy", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_destroy")]
         internal static extern MediaContentError Destroy(IntPtr media);
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_orientation", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_orientation")]
         internal static extern MediaContentError GetOrientation(IntPtr handle, out Orientation orientation);
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_date_taken", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_date_taken")]
         internal static extern MediaContentError GetDateTaken(IntPtr handle, out IntPtr dateTaken);
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_exposure_time", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_exposure_time")]
         internal static extern MediaContentError GetExposureTime(IntPtr handle, out IntPtr exposureTime); // Deprecated
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_fnumber", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_fnumber")]
         internal static extern MediaContentError GetFNumber(IntPtr handle, out double fNumber); // Deprecated
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_iso", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_iso")]
         internal static extern MediaContentError GetISO(IntPtr handle, out int iso); // Deprecated
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_model", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_model")]
         internal static extern MediaContentError GetModel(IntPtr handle, out IntPtr model); // Deprecated
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_width", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_width")]
         internal static extern MediaContentError GetWidth(IntPtr handle, out int width);
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_height", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_height")]
         internal static extern MediaContentError GetHeight(IntPtr handle, out int width);
     }
 }
+
+
+
+

--- a/src/Tizen.Content.MediaContent/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string MediaContent = "libcapi-content-media-content.so.0";
     }
 }
+
+
+

--- a/src/Tizen.Content.MediaContent/Interop/Interop.MediaContent.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.MediaContent.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Content.MediaContent;
 
 internal static partial class Interop
@@ -43,7 +44,7 @@ internal static partial class Interop
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_content_scan_folder")]
         internal static extern MediaContentError ScanFolder(string folderPath,
-            bool recursive, MediaScanCompletedCallback scanCompletedCallback, IntPtr userData = default(IntPtr));
+            [MarshalAs(UnmanagedType.U1)] bool recursive, MediaScanCompletedCallback scanCompletedCallback, IntPtr userData = default(IntPtr));
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_content_add_db_updated_cb")]
         internal static extern MediaContentError AddDbUpdatedCb(MediaContentDBUpdatedCallback mediaContentDBUpdatedCallback,
@@ -53,3 +54,8 @@ internal static partial class Interop
         internal static extern MediaContentError RemoveDbUpdatedCb(IntPtr notiHandle);
     }
 }
+
+
+
+
+

--- a/src/Tizen.Content.MediaContent/Interop/Interop.MediaContentHandle.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.MediaContentHandle.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -26,9 +26,7 @@ internal static partial class Interop
         public MediaContentCriticalHandle() : base(IntPtr.Zero)
         {
         }
-
         public override bool IsInvalid => handle == IntPtr.Zero;
-
         protected override bool ReleaseHandle()
         {
             var result = DestroyHandle();
@@ -44,3 +42,7 @@ internal static partial class Interop
         protected abstract MediaContentError DestroyHandle();
     }
 }
+
+
+
+

--- a/src/Tizen.Content.MediaContent/Interop/Interop.MediaInfo.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.MediaInfo.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Content.MediaContent;
 
 internal static partial class Interop
@@ -125,19 +126,19 @@ internal static partial class Interop
         internal static extern MediaContentError GetRating(MediaInfoHandle mediaInformationHandle, out int rating);  // Deprecated since API12
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_info_get_favorite")]
-        internal static extern MediaContentError GetFavorite(MediaInfoHandle mediaInformationHandle, out bool favorite);  // Deprecated since API12
+        internal static extern MediaContentError GetFavorite(MediaInfoHandle mediaInformationHandle, [MarshalAs(UnmanagedType.U1)] out bool favorite);  // Deprecated since API12
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_info_get_title")]
         internal static extern MediaContentError GetTitle(MediaInfoHandle mediaInformationHandle, out IntPtr title);
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_info_is_drm")]
-        internal static extern MediaContentError IsDrm(MediaInfoHandle mediaInformationHandle, out bool isDrm);  // Deprecated since API12
+        internal static extern MediaContentError IsDrm(MediaInfoHandle mediaInformationHandle, [MarshalAs(UnmanagedType.U1)] out bool isDrm);  // Deprecated since API12
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_info_get_media_from_db")]
         internal static extern MediaContentError GetMediaFromDB(string mediaId, out MediaInfoHandle handle);
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_info_set_favorite")]
-        internal static extern MediaContentError SetFavorite(MediaInfoHandle mediaInformationHandle, bool favorite);  // Deprecated since API12
+        internal static extern MediaContentError SetFavorite(MediaInfoHandle mediaInformationHandle, [MarshalAs(UnmanagedType.U1)] bool favorite);  // Deprecated since API12
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_info_update_to_db")]
         internal static extern MediaContentError UpdateToDB(MediaInfoHandle mediaInformationHandle);  // Deprecated since API12
@@ -168,12 +169,10 @@ internal static partial class Interop
         {
             SetHandle(handle);
         }
-
         public override bool IsInvalid
         {
             get { return handle == IntPtr.Zero; }
         }
-
         protected override bool ReleaseHandle()
         {
             MediaInfo.Destroy(handle);
@@ -181,3 +180,10 @@ internal static partial class Interop
         }
     }
 }
+
+
+
+
+
+
+

--- a/src/Tizen.Content.MediaContent/Interop/Interop.Playlist.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.Playlist.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Content.MediaContent;
 
 internal static partial class Interop
@@ -81,7 +82,7 @@ internal static partial class Interop
         internal static extern MediaContentError ExportToFile(IntPtr playlist, string filePath);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool PlaylistMemberCallback(int memberId, IntPtr mediaInfo, IntPtr data);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool PlaylistMemberCallback(int memberId, IntPtr mediaInfo, IntPtr data);
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_playlist_foreach_playlist_from_db")]
         internal static extern MediaContentError ForeachPlaylistFromDb(FilterHandle filter,
@@ -92,3 +93,8 @@ internal static partial class Interop
             PlaylistMemberCallback callback, IntPtr userData = default(IntPtr));
     }
 }
+
+
+
+
+

--- a/src/Tizen.Content.MediaContent/Interop/Interop.Tag.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.Tag.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Content.MediaContent;
 
 internal static partial class Interop
@@ -70,3 +71,7 @@ internal static partial class Interop
             Common.ItemCallback callback, IntPtr userData = default(IntPtr)); // Deprecated since API12
     }
 }
+
+
+
+

--- a/src/Tizen.Content.MediaContent/Interop/Interop.VideoInfo.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.VideoInfo.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,52 +16,57 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Content.MediaContent;
 
 internal static partial class Interop
 {
     internal static partial class VideoInfo
     {
-        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_destroy", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_destroy")]
         internal static extern MediaContentError Destroy(IntPtr handle); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_album", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_album")]
         internal static extern MediaContentError GetAlbum(IntPtr handle, out IntPtr albumName); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_artist", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_artist")]
         internal static extern MediaContentError GetArtist(IntPtr handle, out IntPtr artistName); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_album_artist", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_album_artist")]
         internal static extern MediaContentError GetAlbumArtist(IntPtr handle, out IntPtr albumArtistName); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_genre", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_genre")]
         internal static extern MediaContentError GetGenre(IntPtr handle, out IntPtr genreName); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_composer", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_composer")]
         internal static extern MediaContentError GetComposer(IntPtr handle, out IntPtr composerName); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_year", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_year")]
         internal static extern MediaContentError GetYear(IntPtr handle, out IntPtr year); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_recorded_date", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_recorded_date")]
         internal static extern MediaContentError GetRecordedDate(IntPtr handle, out IntPtr recordedDate); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_copyright", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_copyright")]
         internal static extern MediaContentError GetCopyright(IntPtr handle, out IntPtr copyright); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_track_num", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_track_num")]
         internal static extern MediaContentError GetTrackNum(IntPtr handle, out IntPtr trackNum); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_bit_rate", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_bit_rate")]
         internal static extern MediaContentError GetBitRate(IntPtr handle, out int bitRate); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_duration", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_duration")]
         internal static extern MediaContentError GetDuration(IntPtr handle, out int duration); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_width", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_width")]
         internal static extern MediaContentError GetWidth(IntPtr handle, out int width); // Deprecated since API12
 
-        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_height", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MediaContent, EntryPoint = "video_meta_get_height")]
         internal static extern MediaContentError GetHeight(IntPtr handle, out int width); // Deprecated since API12
     }
 }
+
+
+
+

--- a/src/Tizen.Content.MimeType/Interop/Interop.Glib.cs
+++ b/src/Tizen.Content.MimeType/Interop/Interop.Glib.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,15 +16,20 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
     internal static partial class Glib
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool GSourceFunc(IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool GSourceFunc(IntPtr userData);
 
-        [DllImport(Libraries.Glib, EntryPoint = "g_idle_add", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern uint IdleAdd(GSourceFunc d, IntPtr data);
+        [LibraryImport(Libraries.Glib, EntryPoint = "g_idle_add", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial uint IdleAdd(GSourceFunc d, IntPtr data);
     }
 }
+
+
+
+

--- a/src/Tizen.Content.MimeType/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Content.MimeType/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -22,3 +22,6 @@ internal static partial class Interop
         public const string Glib = "libglib-2.0.so.0";
     }
 }
+
+
+

--- a/src/Tizen.Content.MimeType/Interop/Interop.Mime.cs
+++ b/src/Tizen.Content.MimeType/Interop/Interop.Mime.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,21 +16,26 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
     internal static partial class Mime
     {
-        [DllImport(Libraries.Mime, EntryPoint = "mime_type_get_mime_type", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.Mime, EntryPoint = "mime_type_get_mime_type")]
         internal static extern int GetMime(
             [System.Runtime.InteropServices.InAttribute()]
             [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.LPStr)] string file_extension
             , out string mime_type);
 
-        [DllImport(Libraries.Mime, EntryPoint = "mime_type_get_file_extension", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.Mime, EntryPoint = "mime_type_get_file_extension")]
         internal static extern int GetFile(
             [System.Runtime.InteropServices.InAttribute()]
             [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.LPStr)] string mime_type
             , out System.IntPtr file_extension, out int length);
     }
 }
+
+
+
+

--- a/src/Tizen.Multimedia.AudioIO/Interop/Interop.AudioIO.cs
+++ b/src/Tizen.Multimedia.AudioIO/Interop/Interop.AudioIO.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia;
 
 internal static partial class Interop
@@ -26,119 +27,119 @@ internal static partial class Interop
         public delegate void AudioStreamCallback(IntPtr handle, uint nbytes, IntPtr userdata);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void AudioStateChangedCallback(IntPtr handle, int previous, int current, bool byPolicy, IntPtr userData);
+        public delegate void AudioStateChangedCallback(IntPtr handle, int previous, int current, [MarshalAs(UnmanagedType.U1)] bool byPolicy, IntPtr userData);
 
         internal static partial class AudioInput
         {
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_in_set_state_changed_cb")]
-            internal static extern AudioIOError SetStateChangedCallback(IntPtr handle, AudioStateChangedCallback callback, IntPtr user_data);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_in_set_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError SetStateChangedCallback(IntPtr handle, AudioStateChangedCallback callback, IntPtr user_data);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_in_set_stream_cb")]
-            internal static extern AudioIOError SetStreamCallback(IntPtr handle, AudioStreamCallback callback, IntPtr user_data);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_in_set_stream_cb", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError SetStreamCallback(IntPtr handle, AudioStreamCallback callback, IntPtr user_data);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_in_create")]
-            internal static extern AudioIOError Create(int sampleRate, int channel, int type, out IntPtr handle);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_in_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError Create(int sampleRate, int channel, int type, out IntPtr handle);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_in_destroy")]
-            internal static extern AudioIOError Destroy(IntPtr handle);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_in_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError Destroy(IntPtr handle);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_in_set_sound_stream_info")]
-            internal static extern AudioIOError SetStreamInfo(IntPtr handle, AudioStreamPolicyHandle streamInfoHandle);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_in_set_sound_stream_info", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError SetStreamInfo(IntPtr handle, AudioStreamPolicyHandle streamInfoHandle);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_in_prepare")]
-            internal static extern AudioIOError Prepare(IntPtr handle);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_in_prepare", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError Prepare(IntPtr handle);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_in_unprepare")]
-            internal static extern AudioIOError Unprepare(IntPtr handle);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_in_unprepare", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError Unprepare(IntPtr handle);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_in_pause")]
-            internal static extern AudioIOError Pause(IntPtr handle);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_in_pause", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError Pause(IntPtr handle);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_in_resume")]
-            internal static extern AudioIOError Resume(IntPtr handle);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_in_resume", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError Resume(IntPtr handle);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_in_flush")]
-            internal static extern AudioIOError Flush(IntPtr handle);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_in_flush", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError Flush(IntPtr handle);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_in_read")]
-            internal static extern AudioIOError Read(IntPtr handle, byte[] buffer, int length);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_in_read", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError Read(IntPtr handle, byte[] buffer, int length);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_in_peek")]
-            internal static extern AudioIOError Peek(IntPtr handle, out IntPtr buffer, ref uint length);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_in_peek", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError Peek(IntPtr handle, out IntPtr buffer, ref uint length);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_in_drop")]
-            internal static extern AudioIOError Drop(IntPtr handle);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_in_drop", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError Drop(IntPtr handle);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_in_get_buffer_size")]
-            internal static extern AudioIOError GetBufferSize(IntPtr handle, out int size);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_in_get_buffer_size", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError GetBufferSize(IntPtr handle, out int size);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_in_get_sample_rate")]
-            internal static extern AudioIOError GetSampleRate(IntPtr handle, out int sampleRate);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_in_get_sample_rate", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError GetSampleRate(IntPtr handle, out int sampleRate);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_in_get_channel")]
-            internal static extern AudioIOError GetChannel(IntPtr handle, out int channel);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_in_get_channel", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError GetChannel(IntPtr handle, out int channel);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_in_get_sample_type")]
-            internal static extern AudioIOError GetSampleType(IntPtr handle, out int sampleType);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_in_get_sample_type", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError GetSampleType(IntPtr handle, out int sampleType);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_in_get_volume")]
-            internal static extern AudioIOError GetVolume(IntPtr handle, out double volume);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_in_get_volume", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError GetVolume(IntPtr handle, out double volume);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_in_set_volume")]
-            internal static extern AudioIOError SetVolume(IntPtr handle, double volume);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_in_set_volume", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError SetVolume(IntPtr handle, double volume);
         }
         internal static partial class AudioOutput
         {
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_out_set_state_changed_cb")]
-            internal static extern AudioIOError SetStateChangedCallback(IntPtr handle, AudioStateChangedCallback callback, IntPtr user_data);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_out_set_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError SetStateChangedCallback(IntPtr handle, AudioStateChangedCallback callback, IntPtr user_data);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_out_set_stream_cb")]
-            internal static extern AudioIOError SetStreamChangedCallback(IntPtr handle, AudioStreamCallback callback, IntPtr user_data);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_out_set_stream_cb", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError SetStreamChangedCallback(IntPtr handle, AudioStreamCallback callback, IntPtr user_data);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_out_create_new")]
-            internal static extern AudioIOError Create(int sampleRate, int channel, int type, out IntPtr handle);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_out_create_new", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError Create(int sampleRate, int channel, int type, out IntPtr handle);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_out_destroy")]
-            internal static extern AudioIOError Destroy(IntPtr handle);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_out_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError Destroy(IntPtr handle);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_out_drain")]
-            internal static extern AudioIOError Drain(IntPtr handle);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_out_drain", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError Drain(IntPtr handle);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_out_flush")]
-            internal static extern AudioIOError Flush(IntPtr handle);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_out_flush", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError Flush(IntPtr handle);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_out_get_buffer_size")]
-            internal static extern AudioIOError GetBufferSize(IntPtr handle, out int size);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_out_get_buffer_size", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError GetBufferSize(IntPtr handle, out int size);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_out_get_channel")]
-            internal static extern AudioIOError GetChannel(IntPtr handle, out int channel);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_out_get_channel", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError GetChannel(IntPtr handle, out int channel);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_out_get_sample_rate")]
-            internal static extern AudioIOError GetSampleRate(IntPtr handle, out int sampleRate);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_out_get_sample_rate", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError GetSampleRate(IntPtr handle, out int sampleRate);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_out_get_sample_type")]
-            internal static extern AudioIOError GetSampleType(IntPtr handle, out int sampleType);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_out_get_sample_type", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError GetSampleType(IntPtr handle, out int sampleType);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_out_get_sound_type")]
-            internal static extern AudioIOError GetSoundType(IntPtr handle, out int soundType);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_out_get_sound_type", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError GetSoundType(IntPtr handle, out int soundType);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_out_pause")]
-            internal static extern AudioIOError Pause(IntPtr handle);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_out_pause", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError Pause(IntPtr handle);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_out_prepare")]
-            internal static extern AudioIOError Prepare(IntPtr handle);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_out_prepare", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError Prepare(IntPtr handle);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_out_resume")]
-            internal static extern AudioIOError Resume(IntPtr handle);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_out_resume", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError Resume(IntPtr handle);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_out_set_sound_stream_info")]
-            internal static extern AudioIOError SetStreamInfo(IntPtr handle, AudioStreamPolicyHandle streamInfoHandle);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_out_set_sound_stream_info", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError SetStreamInfo(IntPtr handle, AudioStreamPolicyHandle streamInfoHandle);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_out_unprepare")]
-            internal static extern AudioIOError Unprepare(IntPtr handle);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_out_unprepare", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError Unprepare(IntPtr handle);
 
-            [DllImport(Libraries.AudioIO, EntryPoint = "audio_out_write")]
-            internal static extern AudioIOError Write(IntPtr handle, byte[] buffer, uint length);
+            [LibraryImport(Libraries.AudioIO, EntryPoint = "audio_out_write", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioIOError Write(IntPtr handle, byte[] buffer, uint length);
         }
     }
 }

--- a/src/Tizen.Multimedia.AudioIO/Interop/Interop.TonePlayer.cs
+++ b/src/Tizen.Multimedia.AudioIO/Interop/Interop.TonePlayer.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -15,18 +15,19 @@
  */
 
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia;
 
 internal static partial class Interop
 {
     internal static partial class TonePlayer
     {
-        [DllImport(Libraries.TonePlayer, EntryPoint = "tone_player_start_new")]
-        internal static extern TonePlayerError Start(ToneType tone, AudioStreamPolicyHandle streamInfoHandle,
+        [LibraryImport(Libraries.TonePlayer, EntryPoint = "tone_player_start_new", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial TonePlayerError Start(ToneType tone, AudioStreamPolicyHandle streamInfoHandle,
             int durationMs, out int id);
 
-        [DllImport(Libraries.TonePlayer, EntryPoint = "tone_player_stop")]
-        internal static extern TonePlayerError Stop(int id);
+        [LibraryImport(Libraries.TonePlayer, EntryPoint = "tone_player_stop", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial TonePlayerError Stop(int id);
     }
 }
 

--- a/src/Tizen.Multimedia.AudioIO/Interop/Interop.WavPlayer.cs
+++ b/src/Tizen.Multimedia.AudioIO/Interop/Interop.WavPlayer.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia;
 
 internal static partial class Interop
@@ -25,16 +26,16 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void WavPlayerCompletedCallback(int playerId, IntPtr userData);
 
-        [DllImport(Libraries.WavPlayer, EntryPoint = "wav_player_start_new")]
-        internal static extern WavPlayerError Start(string filePath, AudioStreamPolicyHandle streamInfoHandle,
+        [LibraryImport(Libraries.WavPlayer, EntryPoint = "wav_player_start_new", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial WavPlayerError Start(string filePath, AudioStreamPolicyHandle streamInfoHandle,
             WavPlayerCompletedCallback completedCallback, IntPtr userData, out int id);
 
-        [DllImport(Libraries.WavPlayer, EntryPoint = "wav_player_start_loop")]
-        internal static extern WavPlayerError StartLoop(string filePath, AudioStreamPolicyHandle streamInfoHandle, uint count,
+        [LibraryImport(Libraries.WavPlayer, EntryPoint = "wav_player_start_loop", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial WavPlayerError StartLoop(string filePath, AudioStreamPolicyHandle streamInfoHandle, uint count,
             WavPlayerCompletedCallback completedCallback, IntPtr userData, out int id);
 
-        [DllImport(Libraries.WavPlayer, EntryPoint = "wav_player_stop")]
-        internal static extern WavPlayerError Stop(int id);
+        [LibraryImport(Libraries.WavPlayer, EntryPoint = "wav_player_stop", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial WavPlayerError Stop(int id);
     }
 }
 

--- a/src/Tizen.Multimedia.Camera/Interop/Interop.Camera.cs
+++ b/src/Tizen.Multimedia.Camera/Interop/Interop.Camera.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Internals;
 using Tizen.Multimedia;
 
@@ -27,7 +28,7 @@ internal static partial class Interop
         internal delegate void FaceDetectedCallback(IntPtr faces, int count, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void StateChangedCallback(CameraState previous, CameraState current, bool byPolicy, IntPtr userData);
+        internal delegate void StateChangedCallback(CameraState previous, CameraState current, [MarshalAs(UnmanagedType.U1)] bool byPolicy, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void InterruptedCallback(CameraPolicy policy, CameraState previous, CameraState current, IntPtr userData);
@@ -125,7 +126,7 @@ internal static partial class Interop
         internal static extern CameraError SetDisplayReuseHint(IntPtr handle, bool hint);
 
         [DllImport(Libraries.Camera, EntryPoint = "camera_get_display_reuse_hint")]
-        internal static extern CameraError GetDisplayReuseHint(IntPtr handle, out bool hint);
+        internal static extern CameraError GetDisplayReuseHint(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool hint);
 
         [DllImport(Libraries.Camera, EntryPoint = "camera_set_capture_resolution")]
         internal static extern CameraError SetCaptureResolution(IntPtr handle, int width, int height);
@@ -329,7 +330,7 @@ internal static partial class Interop
     internal static partial class CameraDeviceManager
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void DeviceConnectionChangedCallback(ref CameraDeviceStruct connectedDevice, bool idConnedted, IntPtr userData);
+        internal delegate void DeviceConnectionChangedCallback(ref CameraDeviceStruct connectedDevice, [MarshalAs(UnmanagedType.U1)] bool idConnedted, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate bool SupportedDeviceCallback(ref CameraDeviceStruct supportedDevice, IntPtr userData);

--- a/src/Tizen.Multimedia.Camera/Interop/Interop.CameraCapabilities.cs
+++ b/src/Tizen.Multimedia.Camera/Interop/Interop.CameraCapabilities.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia;
 
 internal static partial class Interop
@@ -162,3 +163,5 @@ internal static partial class Interop
         internal static extern CameraError SupportedPtzTypes(IntPtr handle, PtzTypeCallback callback, IntPtr userData = default);
     }
 }
+
+

--- a/src/Tizen.Multimedia.Camera/Interop/Interop.CameraDisplay.cs
+++ b/src/Tizen.Multimedia.Camera/Interop/Interop.CameraDisplay.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia;
 
 internal static partial class Interop
@@ -29,7 +30,7 @@ internal static partial class Interop
         internal static extern CameraError SetMode(IntPtr handle, CameraDisplayMode mode);
 
         [DllImport(Libraries.Camera, EntryPoint = "camera_is_display_visible")]
-        internal static extern CameraError GetVisible(IntPtr handle, out bool visible);
+        internal static extern CameraError GetVisible(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool visible);
 
         [DllImport(Libraries.Camera, EntryPoint = "camera_set_display_visible")]
         internal static extern CameraError SetVisible(IntPtr handle, bool visible);
@@ -59,3 +60,4 @@ internal static partial class Interop
         internal static extern CameraError SetEcoreDisplay(IntPtr handle, IntPtr ecoreWindow);
     }
 }
+

--- a/src/Tizen.Multimedia.Camera/Interop/Interop.CameraSettings.cs
+++ b/src/Tizen.Multimedia.Camera/Interop/Interop.CameraSettings.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia;
 
 internal static partial class Interop
@@ -194,7 +195,7 @@ internal static partial class Interop
         internal static extern CameraError EnableTag(IntPtr handle, bool enable);
 
         [DllImport(Libraries.Camera, EntryPoint = "camera_attr_is_enabled_tag")]
-        internal static extern CameraError IsEnabledTag(IntPtr handle, out bool enabled);
+        internal static extern CameraError IsEnabledTag(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool enabled);
 
         [DllImport(Libraries.Camera, EntryPoint = "camera_attr_set_tag_image_description")]
         internal static extern CameraError SetImageDescription(IntPtr handle, string description);
@@ -254,19 +255,19 @@ internal static partial class Interop
         internal static extern CameraError EnableAntiShake(IntPtr handle, bool enable);
 
         [DllImport(Libraries.Camera, EntryPoint = " camera_attr_is_enabled_anti_shake")]
-        internal static extern CameraError IsEnabledAntiShake(IntPtr handle, out bool enabled);
+        internal static extern CameraError IsEnabledAntiShake(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool enabled);
 
         [DllImport(Libraries.Camera, EntryPoint = "camera_attr_enable_video_stabilization")]
         internal static extern CameraError EnableVideoStabilization(IntPtr handle, bool enable);
 
         [DllImport(Libraries.Camera, EntryPoint = "camera_attr_is_enabled_video_stabilization")]
-        internal static extern CameraError IsEnabledVideoStabilization(IntPtr handle, out bool enabled);
+        internal static extern CameraError IsEnabledVideoStabilization(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool enabled);
 
         [DllImport(Libraries.Camera, EntryPoint = "camera_attr_enable_auto_contrast")]
         internal static extern CameraError EnableAutoContrast(IntPtr handle, bool enable);
 
         [DllImport(Libraries.Camera, EntryPoint = "camera_attr_is_enabled_auto_contrast")]
-        internal static extern CameraError IsEnabledAutoContrast(IntPtr handle, out bool enabled);
+        internal static extern CameraError IsEnabledAutoContrast(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool enabled);
 
         [DllImport(Libraries.Camera, EntryPoint = "camera_attr_disable_shutter_sound")]
         internal static extern CameraError DisableShutterSound(IntPtr handle, bool disable);
@@ -308,3 +309,4 @@ internal static partial class Interop
         internal static extern CameraError GetPreviewFrameRotation(IntPtr handle, out Rotation rotation);
     }
 }
+

--- a/src/Tizen.Multimedia.MediaCodec/Interop/Interop.MediaCodec.cs
+++ b/src/Tizen.Multimedia.MediaCodec/Interop/Interop.MediaCodec.cs
@@ -16,11 +16,12 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia.MediaCodec;
 
 internal static partial class Interop
 {
-    internal static class MediaCodec
+    internal static partial class MediaCodec
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void InputBufferUsedCallback(IntPtr mediaPacket, IntPtr arg);
@@ -40,84 +41,84 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate bool SupportedCodecCallback(int codecType, IntPtr arg);
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_create")]
-        internal static extern MediaCodecErrorCode Create(out IntPtr handle);
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode Create(out IntPtr handle);
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_destroy")]
-        internal static extern MediaCodecErrorCode Destroy(IntPtr handle);
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode Destroy(IntPtr handle);
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_codec")]
-        internal static extern MediaCodecErrorCode Configure(IntPtr handle, int codecType, int flags);
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_codec", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode Configure(IntPtr handle, int codecType, int flags);
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_vdec_info")]
-        internal static extern MediaCodecErrorCode SetVideoDecoderInfo(IntPtr handle, int width, int height);
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_vdec_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode SetVideoDecoderInfo(IntPtr handle, int width, int height);
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_venc_info")]
-        internal static extern MediaCodecErrorCode SetVideoEncoderInfo(IntPtr handle, int width, int height,
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_venc_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode SetVideoEncoderInfo(IntPtr handle, int width, int height,
             int fps, int targetBits);
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_adec_info")]
-        internal static extern MediaCodecErrorCode SetAudioDecoderInfo(IntPtr handle, int sampleRate, int channel,
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_adec_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode SetAudioDecoderInfo(IntPtr handle, int sampleRate, int channel,
             int bit);
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_aenc_info")]
-        internal static extern MediaCodecErrorCode SetAudioEncoderInfo(IntPtr handle, int sampleRate, int channel,
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_aenc_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode SetAudioEncoderInfo(IntPtr handle, int sampleRate, int channel,
             int bit, int bitRate);
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_prepare")]
-        internal static extern MediaCodecErrorCode Prepare(IntPtr handle);
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_prepare", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode Prepare(IntPtr handle);
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_unprepare")]
-        internal static extern MediaCodecErrorCode Unprepare(IntPtr handle);
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_unprepare", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode Unprepare(IntPtr handle);
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_process_input")]
-        internal static extern MediaCodecErrorCode Process(IntPtr handle, IntPtr mediaPacket, ulong timeoutInUs);
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_process_input", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode Process(IntPtr handle, IntPtr mediaPacket, ulong timeoutInUs);
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_get_output")]
-        internal static extern MediaCodecErrorCode GetOutput(IntPtr handle, out IntPtr packet, ulong timeoutInUs);
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_get_output", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode GetOutput(IntPtr handle, out IntPtr packet, ulong timeoutInUs);
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_flush_buffers")]
-        internal static extern MediaCodecErrorCode FlushBuffers(IntPtr handle);
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_flush_buffers", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode FlushBuffers(IntPtr handle);
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_input_buffer_used_cb")]
-        internal static extern MediaCodecErrorCode SetInputBufferUsedCb(IntPtr handle,
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_input_buffer_used_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode SetInputBufferUsedCb(IntPtr handle,
             InputBufferUsedCallback cb, IntPtr arg = default(IntPtr));
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_unset_input_buffer_used_cb")]
-        internal static extern MediaCodecErrorCode UnsetInputBufferUsedCb(IntPtr handle);
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_unset_input_buffer_used_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode UnsetInputBufferUsedCb(IntPtr handle);
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_output_buffer_available_cb")]
-        internal static extern MediaCodecErrorCode SetOutputBufferAvailableCb(IntPtr handle,
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_output_buffer_available_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode SetOutputBufferAvailableCb(IntPtr handle,
             OutputBufferAvailableCallback cb, IntPtr arg = default(IntPtr));
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_unset_output_buffer_available_cb")]
-        internal static extern MediaCodecErrorCode UnsetOutputBufferAvailableCb(IntPtr handle);
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_unset_output_buffer_available_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode UnsetOutputBufferAvailableCb(IntPtr handle);
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_error_cb")]
-        internal static extern MediaCodecErrorCode SetErrorCb(IntPtr handle, ErrorCallback cb, IntPtr arg = default(IntPtr));
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_error_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode SetErrorCb(IntPtr handle, ErrorCallback cb, IntPtr arg = default(IntPtr));
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_unset_error_cb")]
-        internal static extern MediaCodecErrorCode UnsetErrorCb(IntPtr handle);
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_unset_error_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode UnsetErrorCb(IntPtr handle);
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_eos_cb")]
-        internal static extern MediaCodecErrorCode SetEosCb(IntPtr handle, EosCallback cb, IntPtr arg = default(IntPtr));
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_eos_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode SetEosCb(IntPtr handle, EosCallback cb, IntPtr arg = default(IntPtr));
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_unset_eos_cb")]
-        internal static extern MediaCodecErrorCode UnsetEosCb(IntPtr handle);
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_unset_eos_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode UnsetEosCb(IntPtr handle);
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_buffer_status_cb")]
-        internal static extern MediaCodecErrorCode SetBufferStatusCb(IntPtr handle, BufferStatusCallback cb,
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_set_buffer_status_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode SetBufferStatusCb(IntPtr handle, BufferStatusCallback cb,
             IntPtr arg = default(IntPtr));
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_unset_buffer_status_cb")]
-        internal static extern MediaCodecErrorCode UnsetBufferStatusCb(IntPtr handle);
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_unset_buffer_status_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode UnsetBufferStatusCb(IntPtr handle);
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_get_supported_type")]
-        internal static extern MediaCodecErrorCode GetSupportedType(IntPtr handle, int codecType, bool isEncoder,
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_get_supported_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode GetSupportedType(IntPtr handle, int codecType, [MarshalAs(UnmanagedType.U1)] bool isEncoder,
             out int value);
 
-        [DllImport(Libraries.MediaCodec, EntryPoint = "mediacodec_foreach_supported_codec_static")]
-        internal static extern MediaCodecErrorCode ForeachSupportedCodec(SupportedCodecCallback cb, IntPtr arg);
+        [LibraryImport(Libraries.MediaCodec, EntryPoint = "mediacodec_foreach_supported_codec_static", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MediaCodecErrorCode ForeachSupportedCodec(SupportedCodecCallback cb, IntPtr arg);
     }
 }
 

--- a/src/Tizen.Multimedia.MediaCodec/Interop/Interop.MediaTool.cs
+++ b/src/Tizen.Multimedia.MediaCodec/Interop/Interop.MediaTool.cs
@@ -16,12 +16,13 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
-    internal static class MediaPacket
+    internal static partial class MediaPacket
     {
-        [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_destroy")]
-        internal static extern int Destroy(IntPtr handle);
+        [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Destroy(IntPtr handle);
     }
 }

--- a/src/Tizen.Multimedia.MediaPlayer/Interop/Interop.AudioEffect.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Interop/Interop.AudioEffect.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia;
 
 internal static partial class Interop
@@ -47,6 +48,7 @@ internal static partial class Interop
         internal static extern PlayerErrorCode EqualizerClear(IntPtr player);
 
         [DllImport(Libraries.Player, EntryPoint = "player_audio_effect_equalizer_is_available")]
-        internal static extern PlayerErrorCode EqualizerIsAvailable(IntPtr player, out bool available);
+        internal static extern PlayerErrorCode EqualizerIsAvailable(IntPtr player, [MarshalAs(UnmanagedType.U1)] out bool available);
     }
 }
+

--- a/src/Tizen.Multimedia.MediaPlayer/Interop/Interop.Display.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Interop/Interop.Display.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia;
 
 internal static partial class Interop
@@ -32,7 +33,7 @@ internal static partial class Interop
         internal static extern PlayerErrorCode SetVisible(IntPtr player, bool visible);
 
         [DllImport(Libraries.Player, EntryPoint = "player_is_display_visible")]
-        internal static extern PlayerErrorCode IsVisible(IntPtr player, out bool visible);
+        internal static extern PlayerErrorCode IsVisible(IntPtr player, [MarshalAs(UnmanagedType.U1)] out bool visible);
 
         [DllImport(Libraries.Player, EntryPoint = "player_set_display_rotation")]
         internal static extern PlayerErrorCode SetRotation(IntPtr player, Rotation rotation);
@@ -52,3 +53,4 @@ internal static partial class Interop
 
     }
 }
+

--- a/src/Tizen.Multimedia.MediaPlayer/Interop/Interop.Player.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Interop/Interop.Player.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen;
 using Tizen.Multimedia;
 
@@ -113,7 +114,7 @@ internal static partial class Interop
         internal static extern PlayerErrorCode SetReplayGain(IntPtr player, bool enabled);
 
         [DllImport(Libraries.Player, EntryPoint = "player_is_replaygain_enabled")]
-        internal static extern PlayerErrorCode IsReplayGain(IntPtr player, out bool enabled);
+        internal static extern PlayerErrorCode IsReplayGain(IntPtr player, [MarshalAs(UnmanagedType.U1)] out bool enabled);
 
         [DllImport(Libraries.Player, EntryPoint = "player_set_sound_stream_info")]
         internal static extern PlayerErrorCode SetAudioPolicyInfo(IntPtr player, AudioStreamPolicyHandle streamInfo);
@@ -142,13 +143,13 @@ internal static partial class Interop
         internal static extern PlayerErrorCode SetMute(IntPtr player, bool muted);
 
         [DllImport(Libraries.Player, EntryPoint = "player_is_muted")]
-        internal static extern PlayerErrorCode IsMuted(IntPtr player, out bool muted);
+        internal static extern PlayerErrorCode IsMuted(IntPtr player, [MarshalAs(UnmanagedType.U1)] out bool muted);
 
         [DllImport(Libraries.Player, EntryPoint = "player_set_looping")]
         internal static extern PlayerErrorCode SetLooping(IntPtr player, bool looping);
 
         [DllImport(Libraries.Player, EntryPoint = "player_is_looping")]
-        internal static extern PlayerErrorCode IsLooping(IntPtr player, out bool looping);
+        internal static extern PlayerErrorCode IsLooping(IntPtr player, [MarshalAs(UnmanagedType.U1)] out bool looping);
 
         [DllImport(Libraries.Player, EntryPoint = "player_set_completed_cb")]
         internal static extern PlayerErrorCode SetCompletedCb(IntPtr player,
@@ -308,16 +309,16 @@ internal static partial class Interop
         internal static extern PlayerErrorCode SetAudioOnly(IntPtr player, bool audioOnly);
 
         [DllImport(Libraries.Player, EntryPoint = "player_is_audio_only")]
-        internal static extern PlayerErrorCode IsAudioOnly(IntPtr player, out bool audioOnly);
+        internal static extern PlayerErrorCode IsAudioOnly(IntPtr player, [MarshalAs(UnmanagedType.U1)] out bool audioOnly);
 
         [DllImport(Libraries.Player, EntryPoint = "player_360_is_content_spherical")]
-        internal static extern PlayerErrorCode IsSphericalContent(IntPtr player, out bool isspherical);
+        internal static extern PlayerErrorCode IsSphericalContent(IntPtr player, [MarshalAs(UnmanagedType.U1)] out bool isspherical);
 
         [DllImport(Libraries.Player, EntryPoint = "player_360_set_enabled")]
         internal static extern PlayerErrorCode SetSphericalMode(IntPtr player, bool enabled);
 
         [DllImport(Libraries.Player, EntryPoint = "player_360_is_enabled")]
-        internal static extern PlayerErrorCode IsSphericalMode(IntPtr player, out bool enabled);
+        internal static extern PlayerErrorCode IsSphericalMode(IntPtr player, [MarshalAs(UnmanagedType.U1)] out bool enabled);
 
         [DllImport(Libraries.Player, EntryPoint = "player_360_set_direction_of_view")]
         internal static extern PlayerErrorCode SetDirectionOfView(IntPtr player, float yaw, float pitch);
@@ -359,7 +360,7 @@ internal static partial class Interop
         internal static extern PlayerErrorCode SetAudioPitchEnabled(IntPtr player, bool enabled);
 
         [DllImport(Libraries.Player, EntryPoint = "player_audio_pitch_is_enabled")]
-        internal static extern PlayerErrorCode IsAudioPitchEnabled(IntPtr player, out bool enabled);
+        internal static extern PlayerErrorCode IsAudioPitchEnabled(IntPtr player, [MarshalAs(UnmanagedType.U1)] out bool enabled);
 
         [DllImport(Libraries.Player, EntryPoint = "player_audio_pitch_set_value")]
         internal static extern PlayerErrorCode SetAudioPitch(IntPtr player, float level);
@@ -371,10 +372,10 @@ internal static partial class Interop
         internal static extern PlayerErrorCode SetAudioOffloadEnabled(IntPtr player, bool value);
 
         [DllImport(Libraries.Player, EntryPoint = "player_audio_offload_is_enabled")]
-        internal static extern PlayerErrorCode IsAudioOffloadEnabled(IntPtr player, out bool value);
+        internal static extern PlayerErrorCode IsAudioOffloadEnabled(IntPtr player, [MarshalAs(UnmanagedType.U1)] out bool value);
 
         [DllImport(Libraries.Player, EntryPoint = "player_audio_offload_is_activated")]
-        internal static extern PlayerErrorCode IsAudioOffloadActivated(IntPtr player, out bool value);
+        internal static extern PlayerErrorCode IsAudioOffloadActivated(IntPtr player, [MarshalAs(UnmanagedType.U1)] out bool value);
 
         [DllImport(Libraries.Player, EntryPoint = "player_audio_offload_foreach_supported_format")]
         internal static extern PlayerErrorCode SupportedAudioOffloadFormat(IntPtr player, SupportedMediaFormatCallback callback, IntPtr userData);
@@ -395,7 +396,7 @@ internal static partial class Interop
         internal static extern PlayerErrorCode GetVideoCodecType(IntPtr player, out CodecType type);
     }
 
-    internal class PlayerHandle : SafeHandle
+    internal partial class PlayerHandle : SafeHandle
     {
         protected PlayerHandle() : base(IntPtr.Zero, true)
         {
@@ -421,3 +422,4 @@ internal static partial class Interop
         }
     }
 }
+

--- a/src/Tizen.Multimedia.Metadata/Interop/Interop.MetadataEditor.cs
+++ b/src/Tizen.Multimedia.Metadata/Interop/Interop.MetadataEditor.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,37 +16,38 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia;
 
 internal static partial class Interop
 {
     internal static partial class MetadataEditor
     {
-        [DllImport(Libraries.MetadataEditor, EntryPoint = "metadata_editor_create")]
-        internal static extern MetadataEditorError Create(out IntPtr handle);
+        [LibraryImport(Libraries.MetadataEditor, EntryPoint = "metadata_editor_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MetadataEditorError Create(out IntPtr handle);
 
-        [DllImport(Libraries.MetadataEditor, EntryPoint = "metadata_editor_set_path")]
-        internal static extern MetadataEditorError SetPath(IntPtr handle, string path);
+        [LibraryImport(Libraries.MetadataEditor, EntryPoint = "metadata_editor_set_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MetadataEditorError SetPath(IntPtr handle, string path);
 
-        [DllImport(Libraries.MetadataEditor, EntryPoint = "metadata_editor_destroy")]
-        internal static extern MetadataEditorError Destroy(IntPtr handle);
+        [LibraryImport(Libraries.MetadataEditor, EntryPoint = "metadata_editor_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MetadataEditorError Destroy(IntPtr handle);
 
-        [DllImport(Libraries.MetadataEditor, EntryPoint = "metadata_editor_get_metadata")]
-        internal static extern MetadataEditorError GetMetadata(IntPtr handle, MetadataEditorAttr attribute, out IntPtr value);
+        [LibraryImport(Libraries.MetadataEditor, EntryPoint = "metadata_editor_get_metadata", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MetadataEditorError GetMetadata(IntPtr handle, MetadataEditorAttr attribute, out IntPtr value);
 
-        [DllImport(Libraries.MetadataEditor, EntryPoint = "metadata_editor_set_metadata")]
-        internal static extern MetadataEditorError SetMetadata(IntPtr handle, MetadataEditorAttr attribute, string value);
+        [LibraryImport(Libraries.MetadataEditor, EntryPoint = "metadata_editor_set_metadata", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MetadataEditorError SetMetadata(IntPtr handle, MetadataEditorAttr attribute, string value);
 
-        [DllImport(Libraries.MetadataEditor, EntryPoint = "metadata_editor_update_metadata")]
-        internal static extern MetadataEditorError UpdateMetadata(IntPtr handle);
+        [LibraryImport(Libraries.MetadataEditor, EntryPoint = "metadata_editor_update_metadata", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MetadataEditorError UpdateMetadata(IntPtr handle);
 
-        [DllImport(Libraries.MetadataEditor, EntryPoint = "metadata_editor_get_picture")]
-        internal static extern MetadataEditorError GetPicture(IntPtr handle, int index, out IntPtr picture, out int size, out IntPtr mimeType);
+        [LibraryImport(Libraries.MetadataEditor, EntryPoint = "metadata_editor_get_picture", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MetadataEditorError GetPicture(IntPtr handle, int index, out IntPtr picture, out int size, out IntPtr mimeType);
 
-        [DllImport(Libraries.MetadataEditor, EntryPoint = "metadata_editor_append_picture")]
-        internal static extern MetadataEditorError AddPicture(IntPtr handle, string path);
+        [LibraryImport(Libraries.MetadataEditor, EntryPoint = "metadata_editor_append_picture", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MetadataEditorError AddPicture(IntPtr handle, string path);
 
-        [DllImport(Libraries.MetadataEditor, EntryPoint = "metadata_editor_remove_picture")]
-        internal static extern MetadataEditorError RemovePicture(IntPtr handle, int index);
+        [LibraryImport(Libraries.MetadataEditor, EntryPoint = "metadata_editor_remove_picture", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MetadataEditorError RemovePicture(IntPtr handle, int index);
     }
 }

--- a/src/Tizen.Multimedia.Metadata/Interop/Interop.MetadataExtractor.cs
+++ b/src/Tizen.Multimedia.Metadata/Interop/Interop.MetadataExtractor.cs
@@ -16,40 +16,41 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia;
 
 internal static partial class Interop
 {
     internal static partial class MetadataExtractor
     {
-        [DllImport(Libraries.MetadataExtractor, EntryPoint = "metadata_extractor_create")]
-        internal static extern MetadataExtractorError Create(out IntPtr handle);
+        [LibraryImport(Libraries.MetadataExtractor, EntryPoint = "metadata_extractor_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MetadataExtractorError Create(out IntPtr handle);
 
-        [DllImport(Libraries.MetadataExtractor, EntryPoint = "metadata_extractor_set_path")]
-        internal static extern MetadataExtractorError SetPath(IntPtr handle, string path);
+        [LibraryImport(Libraries.MetadataExtractor, EntryPoint = "metadata_extractor_set_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MetadataExtractorError SetPath(IntPtr handle, string path);
 
-        [DllImport(Libraries.MetadataExtractor, EntryPoint = "metadata_extractor_set_buffer")]
-        internal static extern MetadataExtractorError SetBuffer(IntPtr handle, IntPtr buffer, int size);
+        [LibraryImport(Libraries.MetadataExtractor, EntryPoint = "metadata_extractor_set_buffer", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MetadataExtractorError SetBuffer(IntPtr handle, IntPtr buffer, int size);
 
-        [DllImport(Libraries.MetadataExtractor, EntryPoint = "metadata_extractor_destroy")]
-        internal static extern MetadataExtractorError Destroy(IntPtr handle);
+        [LibraryImport(Libraries.MetadataExtractor, EntryPoint = "metadata_extractor_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MetadataExtractorError Destroy(IntPtr handle);
 
-        [DllImport(Libraries.MetadataExtractor, EntryPoint = "metadata_extractor_get_metadata")]
-        internal static extern MetadataExtractorError GetMetadata(IntPtr handle, MetadataExtractorAttr attribute, out IntPtr value);
+        [LibraryImport(Libraries.MetadataExtractor, EntryPoint = "metadata_extractor_get_metadata", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MetadataExtractorError GetMetadata(IntPtr handle, MetadataExtractorAttr attribute, out IntPtr value);
 
-        [DllImport(Libraries.MetadataExtractor, EntryPoint = "metadata_extractor_get_artwork")]
-        internal static extern MetadataExtractorError GetArtwork(IntPtr handle, out IntPtr artwork,
+        [LibraryImport(Libraries.MetadataExtractor, EntryPoint = "metadata_extractor_get_artwork", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MetadataExtractorError GetArtwork(IntPtr handle, out IntPtr artwork,
             out int size, out IntPtr mimeType);
 
-        [DllImport(Libraries.MetadataExtractor, EntryPoint = "metadata_extractor_get_frame")]
-        internal static extern MetadataExtractorError GetFrame(IntPtr handle, out IntPtr frame, out int size);
+        [LibraryImport(Libraries.MetadataExtractor, EntryPoint = "metadata_extractor_get_frame", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MetadataExtractorError GetFrame(IntPtr handle, out IntPtr frame, out int size);
 
-        [DllImport(Libraries.MetadataExtractor, EntryPoint = "metadata_extractor_get_synclyrics")]
-        internal static extern MetadataExtractorError GetSynclyrics(IntPtr handle, int index,
+        [LibraryImport(Libraries.MetadataExtractor, EntryPoint = "metadata_extractor_get_synclyrics", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MetadataExtractorError GetSynclyrics(IntPtr handle, int index,
             out uint timeStamp, out IntPtr lyrics);
 
-        [DllImport(Libraries.MetadataExtractor, EntryPoint = "metadata_extractor_get_frame_at_time")]
-        internal static extern MetadataExtractorError GetFrameAtTime(IntPtr handle, uint timeStamp,
-            bool isAccurate, out IntPtr frame, out int size);
+        [LibraryImport(Libraries.MetadataExtractor, EntryPoint = "metadata_extractor_get_frame_at_time", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial MetadataExtractorError GetFrameAtTime(IntPtr handle, uint timeStamp,
+            [MarshalAs(UnmanagedType.U1)] bool isAccurate, out IntPtr frame, out int size);
     }
 }

--- a/src/Tizen.Multimedia.Radio/Interop/Interop.Radio.cs
+++ b/src/Tizen.Multimedia.Radio/Interop/Interop.Radio.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,11 +16,12 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia;
 
 internal static partial class Interop
 {
-    internal static class Radio
+    internal static partial class Radio
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void SeekCompletedCallback(int frequency, IntPtr userData);
@@ -82,7 +83,7 @@ internal static partial class Interop
         internal static extern RadioError SetMute(RadioHandle radio, bool muted);
 
         [DllImport(Libraries.Radio, EntryPoint = "radio_is_muted")]
-        internal static extern RadioError GetMuted(RadioHandle radio, out bool muted);
+        internal static extern RadioError GetMuted(RadioHandle radio, [MarshalAs(UnmanagedType.U1)] out bool muted);
 
         [DllImport(Libraries.Radio, EntryPoint = "radio_set_scan_completed_cb")]
         internal static extern RadioError SetScanCompletedCb(RadioHandle radio,
@@ -111,7 +112,7 @@ internal static partial class Interop
         internal static extern RadioError GetVolume(RadioHandle radio, out float volume);
     }
 
-    internal class RadioHandle : SafeHandle
+    internal partial class RadioHandle : SafeHandle
     {
         protected RadioHandle() : base(IntPtr.Zero, true)
         {
@@ -132,3 +133,4 @@ internal static partial class Interop
         }
     }
 }
+

--- a/src/Tizen.Multimedia.Recorder/Interop/Interop.Recorder.Capabilities.cs
+++ b/src/Tizen.Multimedia.Recorder/Interop/Interop.Recorder.Capabilities.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia;
 
 internal static partial class Interop
@@ -34,20 +35,20 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate bool FileFormatCallback(RecorderFileFormat value, IntPtr userData);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_foreach_supported_file_format")]
-        internal static extern RecorderErrorCode GetFileFormats(RecorderHandle handle,
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_foreach_supported_file_format", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetFileFormats(RecorderHandle handle,
             FileFormatCallback callback, IntPtr userData = default(IntPtr));
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_foreach_supported_audio_encoder")]
-        internal static extern RecorderErrorCode GetAudioEncoders(RecorderHandle handle,
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_foreach_supported_audio_encoder", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetAudioEncoders(RecorderHandle handle,
             AudioEncoderCallback callback, IntPtr userData = default(IntPtr));
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_foreach_supported_video_encoder")]
-        internal static extern RecorderErrorCode GetVideoEncoders(RecorderHandle handle,
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_foreach_supported_video_encoder", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetVideoEncoders(RecorderHandle handle,
             VideoEncoderCallback callback, IntPtr userData = default(IntPtr));
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_foreach_supported_video_resolution")]
-        public static extern RecorderErrorCode GetVideoResolutions(RecorderHandle handle,
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_foreach_supported_video_resolution", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial RecorderErrorCode GetVideoResolutions(RecorderHandle handle,
             VideoResolutionCallback callback, IntPtr userData = default(IntPtr));
     }
 }

--- a/src/Tizen.Multimedia.Recorder/Interop/Interop.Recorder.Events.cs
+++ b/src/Tizen.Multimedia.Recorder/Interop/Interop.Recorder.Events.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia;
 
 internal static partial class Interop
@@ -37,52 +38,52 @@ internal static partial class Interop
             uint timeStamp, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void StatechangedCallback(RecorderState previous, RecorderState current, bool byPolicy, IntPtr userData);
+        internal delegate void StatechangedCallback(RecorderState previous, RecorderState current, [MarshalAs(UnmanagedType.U1)] bool byPolicy, IntPtr userData);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_set_error_cb")]
-        internal static extern RecorderErrorCode SetErrorCallback(RecorderHandle handle, RecorderErrorCallback callback,
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_set_error_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetErrorCallback(RecorderHandle handle, RecorderErrorCallback callback,
             IntPtr userData);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_unset_error_cb")]
-        internal static extern RecorderErrorCode UnsetErrorCallback(RecorderHandle handle);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_unset_error_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode UnsetErrorCallback(RecorderHandle handle);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_set_state_changed_cb")]
-        internal static extern RecorderErrorCode SetStateChangedCallback(RecorderHandle handle,
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_set_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetStateChangedCallback(RecorderHandle handle,
             StatechangedCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_unset_state_changed_cb")]
-        internal static extern RecorderErrorCode UnsetStateChangedCallback(RecorderHandle handle);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_unset_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode UnsetStateChangedCallback(RecorderHandle handle);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_set_recording_status_cb")]
-        internal static extern RecorderErrorCode SetRecordingProgressCallback(RecorderHandle handle,
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_set_recording_status_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetRecordingProgressCallback(RecorderHandle handle,
             RecordingProgressCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_unset_recording_status_cb")]
-        internal static extern RecorderErrorCode UnsetRecordingProgressCallback(RecorderHandle handle);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_unset_recording_status_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode UnsetRecordingProgressCallback(RecorderHandle handle);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_set_audio_stream_cb")]
-        internal static extern RecorderErrorCode SetAudioStreamCallback(RecorderHandle handle,
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_set_audio_stream_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetAudioStreamCallback(RecorderHandle handle,
             AudioStreamCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_unset_audio_stream_cb")]
-        internal static extern RecorderErrorCode UnsetAudioStreamCallback(RecorderHandle handle);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_unset_audio_stream_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode UnsetAudioStreamCallback(RecorderHandle handle);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_set_recording_limit_reached_cb")]
-        internal static extern RecorderErrorCode SetLimitReachedCallback(RecorderHandle handle,
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_set_recording_limit_reached_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetLimitReachedCallback(RecorderHandle handle,
             RecordingLimitReachedCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_unset_recording_limit_reached_cb")]
-        internal static extern RecorderErrorCode UnsetLimitReachedCallback(RecorderHandle handle);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_unset_recording_limit_reached_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode UnsetLimitReachedCallback(RecorderHandle handle);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void MuxedStreamCallback(IntPtr stream, int size, ulong offset, IntPtr userData);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_set_muxed_stream_cb")]
-        internal static extern RecorderErrorCode SetMuxedStreamCallback(RecorderHandle handle,
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_set_muxed_stream_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetMuxedStreamCallback(RecorderHandle handle,
             MuxedStreamCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_unset_muxed_stream_cb")]
-        internal static extern RecorderErrorCode UnsetMuxedStreamCallback(RecorderHandle handle);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_unset_muxed_stream_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode UnsetMuxedStreamCallback(RecorderHandle handle);
 
 
         #region InterruptCallback
@@ -90,23 +91,23 @@ internal static partial class Interop
         internal delegate void InterruptedCallback(RecorderPolicy policy, RecorderState previous,
                 RecorderState current, IntPtr userData);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_set_interrupted_cb")]
-        internal static extern RecorderErrorCode SetInterruptedCallback(RecorderHandle handle,
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_set_interrupted_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetInterruptedCallback(RecorderHandle handle,
             InterruptedCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_unset_interrupted_cb")]
-        internal static extern RecorderErrorCode UnsetInterruptedCallback(RecorderHandle handle);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_unset_interrupted_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode UnsetInterruptedCallback(RecorderHandle handle);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void InterruptStartedCallback(RecorderPolicy policy, RecorderState state,
                 IntPtr userData);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_set_interrupt_started_cb")]
-        internal static extern RecorderErrorCode SetInterruptStartedCallback(RecorderHandle handle,
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_set_interrupt_started_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetInterruptStartedCallback(RecorderHandle handle,
             InterruptStartedCallback callback, IntPtr userData = default(IntPtr));
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_unset_interrupt_started_cb")]
-        internal static extern RecorderErrorCode UnsetInterruptStartedCallback(RecorderHandle handle);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_unset_interrupt_started_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode UnsetInterruptStartedCallback(RecorderHandle handle);
 
         #endregion
 
@@ -115,12 +116,12 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void DeviceStateChangedCallback(RecorderType type, RecorderDeviceState state, IntPtr userData);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_add_device_state_changed_cb")]
-        internal static extern RecorderErrorCode AddDeviceStateChangedCallback(DeviceStateChangedCallback callback,
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_add_device_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode AddDeviceStateChangedCallback(DeviceStateChangedCallback callback,
             IntPtr userData, out int id);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_remove_device_state_changed_cb")]
-        internal static extern RecorderErrorCode RemoveDeviceStateChangedCallback(int id);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_remove_device_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode RemoveDeviceStateChangedCallback(int id);
         #endregion
     }
 }

--- a/src/Tizen.Multimedia.Recorder/Interop/Interop.Recorder.Settings.cs
+++ b/src/Tizen.Multimedia.Recorder/Interop/Interop.Recorder.Settings.cs
@@ -16,104 +16,105 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia;
 
 internal static partial class Interop
 {
     internal static partial class Recorder
     {
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_get_audio_channel")]
-        internal static extern RecorderErrorCode GetAudioChannel(RecorderHandle handle, out int channelCount);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_get_audio_channel", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetAudioChannel(RecorderHandle handle, out int channelCount);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_audio_channel")]
-        internal static extern RecorderErrorCode SetAudioChannel(RecorderHandle handle, int channelCount);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_audio_channel", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetAudioChannel(RecorderHandle handle, int channelCount);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_get_audio_device")]
-        internal static extern RecorderErrorCode GetAudioDevice(RecorderHandle handle, out RecorderAudioDevice device);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_get_audio_device", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetAudioDevice(RecorderHandle handle, out RecorderAudioDevice device);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_audio_device")]
-        internal static extern RecorderErrorCode SetAudioDevice(RecorderHandle handle, RecorderAudioDevice device);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_audio_device", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetAudioDevice(RecorderHandle handle, RecorderAudioDevice device);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_get_audio_level")]
-        internal static extern RecorderErrorCode GetAudioLevel(RecorderHandle handle, out double dB);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_get_audio_level", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetAudioLevel(RecorderHandle handle, out double dB);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_get_audio_samplerate")]
-        internal static extern RecorderErrorCode GetAudioSampleRate(RecorderHandle handle, out int sampleRate);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_get_audio_samplerate", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetAudioSampleRate(RecorderHandle handle, out int sampleRate);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_audio_samplerate")]
-        internal static extern RecorderErrorCode SetAudioSampleRate(RecorderHandle handle, int sampleRate);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_audio_samplerate", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetAudioSampleRate(RecorderHandle handle, int sampleRate);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_get_audio_encoder_bitrate")]
-        internal static extern RecorderErrorCode GetAudioEncoderBitrate(RecorderHandle handle, out int bitRate);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_get_audio_encoder_bitrate", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetAudioEncoderBitrate(RecorderHandle handle, out int bitRate);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_audio_encoder_bitrate")]
-        internal static extern RecorderErrorCode SetAudioEncoderBitrate(RecorderHandle handle, int bitRate);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_audio_encoder_bitrate", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetAudioEncoderBitrate(RecorderHandle handle, int bitRate);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_get_video_encoder_bitrate")]
-        internal static extern RecorderErrorCode GetVideoEncoderBitrate(RecorderHandle handle, out int bitRate);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_get_video_encoder_bitrate", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetVideoEncoderBitrate(RecorderHandle handle, out int bitRate);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_video_encoder_bitrate")]
-        internal static extern RecorderErrorCode SetVideoEncoderBitrate(RecorderHandle handle, int bitRate);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_video_encoder_bitrate", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetVideoEncoderBitrate(RecorderHandle handle, int bitRate);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_get_audio_encoder")]
-        internal static extern RecorderErrorCode GetAudioEncoder(RecorderHandle handle, out RecorderAudioCodec codec);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_get_audio_encoder", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetAudioEncoder(RecorderHandle handle, out RecorderAudioCodec codec);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_set_audio_encoder")]
-        internal static extern RecorderErrorCode SetAudioEncoder(RecorderHandle handle, RecorderAudioCodec codec);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_set_audio_encoder", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetAudioEncoder(RecorderHandle handle, RecorderAudioCodec codec);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_get_video_encoder")]
-        internal static extern RecorderErrorCode GetVideoEncoder(RecorderHandle handle, out RecorderVideoCodec codec);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_get_video_encoder", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetVideoEncoder(RecorderHandle handle, out RecorderVideoCodec codec);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_set_video_encoder")]
-        internal static extern RecorderErrorCode SetVideoEncoder(RecorderHandle handle, RecorderVideoCodec codec);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_set_video_encoder", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetVideoEncoder(RecorderHandle handle, RecorderVideoCodec codec);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_get_file_format")]
-        internal static extern RecorderErrorCode GetFileFormat(RecorderHandle handle, out RecorderFileFormat format);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_get_file_format", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetFileFormat(RecorderHandle handle, out RecorderFileFormat format);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_set_file_format")]
-        internal static extern RecorderErrorCode SetFileFormat(RecorderHandle handle, RecorderFileFormat format);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_set_file_format", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetFileFormat(RecorderHandle handle, RecorderFileFormat format);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_get_filename")]
-        internal static extern RecorderErrorCode GetFileName(RecorderHandle handle, out IntPtr path);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_get_filename", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetFileName(RecorderHandle handle, out IntPtr path);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_set_filename")]
-        internal static extern RecorderErrorCode SetFileName(RecorderHandle handle, string path);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_set_filename", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetFileName(RecorderHandle handle, string path);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_get_size_limit")]
-        internal static extern RecorderErrorCode GetSizeLimit(RecorderHandle handle, out int kbyte);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_get_size_limit", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetSizeLimit(RecorderHandle handle, out int kbyte);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_size_limit")]
-        internal static extern RecorderErrorCode SetSizeLimit(RecorderHandle handle, int kbyte);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_size_limit", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetSizeLimit(RecorderHandle handle, int kbyte);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_get_time_limit")]
-        internal static extern RecorderErrorCode GetTimeLimit(RecorderHandle handle, out int second);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_get_time_limit", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetTimeLimit(RecorderHandle handle, out int second);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_time_limit")]
-        internal static extern RecorderErrorCode SetTimeLimit(RecorderHandle handle, int second);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_time_limit", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetTimeLimit(RecorderHandle handle, int second);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_is_muted")]
-        [return: MarshalAs(UnmanagedType.I1)]
-        internal static extern bool GetMute(RecorderHandle handle);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_is_muted", StringMarshalling = StringMarshalling.Utf8)]
+        [return: MarshalAs(UnmanagedType.U1)]
+        internal static partial bool GetMute(RecorderHandle handle);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_mute")]
-        internal static extern RecorderErrorCode SetMute(RecorderHandle handle, bool enable);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_mute", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetMute(RecorderHandle handle, [MarshalAs(UnmanagedType.U1)] bool enable);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_get_recording_motion_rate")]
-        internal static extern RecorderErrorCode GetMotionRate(RecorderHandle handle, out double motionRate);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_get_recording_motion_rate", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetMotionRate(RecorderHandle handle, out double motionRate);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_recording_motion_rate")]
-        internal static extern RecorderErrorCode SetMotionRate(RecorderHandle handle, double motionRate);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_recording_motion_rate", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetMotionRate(RecorderHandle handle, double motionRate);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_get_orientation_tag")]
-        internal static extern RecorderErrorCode GetOrientationTag(RecorderHandle handle, out Rotation orientation);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_get_orientation_tag", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetOrientationTag(RecorderHandle handle, out Rotation orientation);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_orientation_tag")]
-        internal static extern RecorderErrorCode SetOrientationTag(RecorderHandle handle, Rotation orientation);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_attr_set_orientation_tag", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetOrientationTag(RecorderHandle handle, Rotation orientation);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_get_video_resolution")]
-        internal static extern RecorderErrorCode GetVideoResolution(RecorderHandle handle, out int width, out int height);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_get_video_resolution", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetVideoResolution(RecorderHandle handle, out int width, out int height);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_set_video_resolution")]
-        internal static extern RecorderErrorCode SetVideoResolution(RecorderHandle handle, int width, int height);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_set_video_resolution", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetVideoResolution(RecorderHandle handle, int width, int height);
     }
 }

--- a/src/Tizen.Multimedia.Recorder/Interop/Interop.Recorder.cs
+++ b/src/Tizen.Multimedia.Recorder/Interop/Interop.Recorder.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia;
 
 internal static partial class Interop
@@ -28,44 +29,44 @@ internal static partial class Interop
         [DllImport(Libraries.Recorder, EntryPoint = "recorder_create_videorecorder")]
         internal static extern RecorderErrorCode CreateVideo(IntPtr cameraHandle, out RecorderHandle handle);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_prepare")]
-        internal static extern RecorderErrorCode Prepare(RecorderHandle handle);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_prepare", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode Prepare(RecorderHandle handle);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_unprepare")]
-        internal static extern RecorderErrorCode Unprepare(RecorderHandle handle);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_unprepare", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode Unprepare(RecorderHandle handle);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_start")]
-        internal static extern RecorderErrorCode Start(RecorderHandle handle);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_start", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode Start(RecorderHandle handle);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_pause")]
-        internal static extern RecorderErrorCode Pause(RecorderHandle handle);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_pause", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode Pause(RecorderHandle handle);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_commit")]
-        internal static extern RecorderErrorCode Commit(RecorderHandle handle);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_commit", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode Commit(RecorderHandle handle);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_cancel")]
-        internal static extern RecorderErrorCode Cancel(RecorderHandle handle);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_cancel", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode Cancel(RecorderHandle handle);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_get_state")]
-        internal static extern RecorderErrorCode GetState(RecorderHandle handle, out RecorderState state);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_get_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetState(RecorderHandle handle, out RecorderState state);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_set_sound_stream_info")]
-        internal static extern RecorderErrorCode SetAudioStreamPolicy(RecorderHandle handle, AudioStreamPolicyHandle streamInfoHandle);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_set_sound_stream_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode SetAudioStreamPolicy(RecorderHandle handle, AudioStreamPolicyHandle streamInfoHandle);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_get_device_state")]
-        internal static extern RecorderErrorCode GetDeviceState(RecorderType type, out RecorderDeviceState state);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_get_device_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial RecorderErrorCode GetDeviceState(RecorderType type, out RecorderDeviceState state);
     }
 
-    internal class RecorderHandle : SafeHandle
+    internal partial class RecorderHandle : SafeHandle
     {
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_destroy")]
-        private static extern RecorderErrorCode Destroy(IntPtr handle);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        private static partial RecorderErrorCode Destroy(IntPtr handle);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_cancel")]
-        private static extern RecorderErrorCode Cancel(IntPtr handle);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_cancel", StringMarshalling = StringMarshalling.Utf8)]
+        private static partial RecorderErrorCode Cancel(IntPtr handle);
 
-        [DllImport(Libraries.Recorder, EntryPoint = "recorder_unprepare")]
-        private static extern RecorderErrorCode Unprepare(IntPtr handle);
+        [LibraryImport(Libraries.Recorder, EntryPoint = "recorder_unprepare", StringMarshalling = StringMarshalling.Utf8)]
+        private static partial RecorderErrorCode Unprepare(IntPtr handle);
 
         protected RecorderHandle() : base(IntPtr.Zero, true)
         {

--- a/src/Tizen.Multimedia.Remoting/Interop/Interop.MediaControllerClient.cs
+++ b/src/Tizen.Multimedia.Remoting/Interop/Interop.MediaControllerClient.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 using Tizen.Multimedia.Remoting;
 
@@ -51,7 +52,7 @@ internal static partial class Interop
         internal delegate void DisplayRotationUpdatedCallback(string serverName, MediaControlNativeDisplayRotation isEnabned, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void BoolAttributeUpdatedCallback(string serverName, bool isEnabled, IntPtr userData);
+        internal delegate void BoolAttributeUpdatedCallback(string serverName, [MarshalAs(UnmanagedType.U1)] bool isEnabled, IntPtr userData);
 
 
         // Capability updated callbacks
@@ -128,11 +129,11 @@ internal static partial class Interop
 
         [DllImport(Libraries.MediaController, EntryPoint = "mc_client_get_server_subtitles_enabled")]
         internal static extern MediaControllerError IsSubtitleEnabled(MediaControllerClientHandle clientHandle,
-            string serverName, out bool isEnabled);
+            string serverName, [MarshalAs(UnmanagedType.U1)] out bool isEnabled);
 
         [DllImport(Libraries.MediaController, EntryPoint = "mc_client_get_server_360_mode_enabled")]
         internal static extern MediaControllerError IsMode360Enabled(MediaControllerClientHandle clientHandle,
-            string serverName, out bool isEnabled);
+            string serverName, [MarshalAs(UnmanagedType.U1)] out bool isEnabled);
 
         [DllImport(Libraries.MediaController, EntryPoint = "mc_client_get_server_display_mode")]
         internal static extern MediaControllerError GetDisplayMode(MediaControllerClientHandle clientHandle,
@@ -341,7 +342,7 @@ internal static partial class Interop
         #endregion Event
     }
 
-    internal class MediaControllerClientHandle : SafeHandle
+    internal partial class MediaControllerClientHandle : SafeHandle
     {
         protected MediaControllerClientHandle() : base(IntPtr.Zero, true)
         {
@@ -362,3 +363,4 @@ internal static partial class Interop
         }
     }
 }
+

--- a/src/Tizen.Multimedia.Remoting/Interop/Interop.MediaControllerPlaylist.cs
+++ b/src/Tizen.Multimedia.Remoting/Interop/Interop.MediaControllerPlaylist.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 using Tizen.Multimedia.Remoting;
 
@@ -169,3 +170,5 @@ internal static partial class Interop
             PlaylistItemCallback callback, IntPtr userData);
     }
 }
+
+

--- a/src/Tizen.Multimedia.Remoting/Interop/Interop.MediaControllerServer.cs
+++ b/src/Tizen.Multimedia.Remoting/Interop/Interop.MediaControllerServer.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 using Tizen.Multimedia.Remoting;
 
@@ -217,7 +218,7 @@ internal static partial class Interop
         internal static extern MediaControllerError DisconnectDb(IntPtr dbHandle);
 
         [DllImport(Libraries.MediaController, EntryPoint = "mc_db_check_server_table_exist")]
-        internal static extern MediaControllerError CheckServerExist(IntPtr dbHandle, string appId, out bool value);
+        internal static extern MediaControllerError CheckServerExist(IntPtr dbHandle, string appId, [MarshalAs(UnmanagedType.U1)] out bool value);
         #endregion Database
 
 
@@ -312,3 +313,4 @@ internal static partial class Interop
         #endregion Event
     }
 }
+

--- a/src/Tizen.Multimedia.Remoting/Interop/Interop.ScreenMirroring.cs
+++ b/src/Tizen.Multimedia.Remoting/Interop/Interop.ScreenMirroring.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Internals;
 using Tizen.Multimedia;
 using Tizen.Multimedia.Remoting;
@@ -182,3 +183,4 @@ internal static partial class Interop
         }
     }
 }
+

--- a/src/Tizen.Multimedia.Remoting/Interop/Interop.WebRTC.DataChannel.cs
+++ b/src/Tizen.Multimedia.Remoting/Interop/Interop.WebRTC.DataChannel.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 using Tizen.Multimedia.Remoting;
 

--- a/src/Tizen.Multimedia.Remoting/Interop/Interop.WebRTC.SignalingServer.cs
+++ b/src/Tizen.Multimedia.Remoting/Interop/Interop.WebRTC.SignalingServer.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,11 +16,12 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia.Remoting;
 
 internal static partial class Interop
 {
-    internal static class SignalingServer
+    internal static partial class SignalingServer
     {
         [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_signaling_server_create")]
         internal static extern WebRTCErrorCode Create(int port, out IntPtr handle);
@@ -35,7 +36,7 @@ internal static partial class Interop
         internal static extern WebRTCErrorCode Stop(IntPtr handle);
     }
 
-    internal static class SignalingClient
+    internal static partial class SignalingClient
     {
         [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_signaling_connect")]
         internal static extern WebRTCErrorCode Connect(string serverIp, int port, SignalingMessageCallback callback, IntPtr userData, out IntPtr clientHandle);

--- a/src/Tizen.Multimedia.Remoting/Interop/Interop.WebRTC.cs
+++ b/src/Tizen.Multimedia.Remoting/Interop/Interop.WebRTC.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen;
 using Tizen.Applications;
 using Tizen.Internals;
@@ -130,7 +131,7 @@ internal static partial class Interop
         internal static extern WebRTCErrorCode SetFileSourceLooping(IntPtr handle, uint sourceId, bool looping);
 
         [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_file_source_get_looping")]
-        internal static extern WebRTCErrorCode GetFileSourceLooping(IntPtr handle, uint sourceId, out bool looping);
+        internal static extern WebRTCErrorCode GetFileSourceLooping(IntPtr handle, uint sourceId, [MarshalAs(UnmanagedType.U1)] out bool looping);
 
         [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_media_source_get_transceiver_direction")]
         internal static extern WebRTCErrorCode GetTransceiverDirection(IntPtr handle, uint sourceId, MediaType type, out TransceiverDirection mode);
@@ -158,13 +159,13 @@ internal static partial class Interop
         internal static extern WebRTCErrorCode SetPause(IntPtr handle, uint sourceId, MediaType type, bool pause);
 
         [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_media_source_get_pause")]
-        internal static extern WebRTCErrorCode GetPause(IntPtr handle, uint sourceId, MediaType type, out bool isPaused);
+        internal static extern WebRTCErrorCode GetPause(IntPtr handle, uint sourceId, MediaType type, [MarshalAs(UnmanagedType.U1)] out bool isPaused);
 
         [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_media_source_set_mute")]
         internal static extern WebRTCErrorCode SetMute(IntPtr handle, uint sourceId, MediaType type, bool mute);
 
         [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_media_source_get_mute")]
-        internal static extern WebRTCErrorCode GetMute(IntPtr handle, uint sourceId, MediaType type, out bool mute);
+        internal static extern WebRTCErrorCode GetMute(IntPtr handle, uint sourceId, MediaType type, [MarshalAs(UnmanagedType.U1)] out bool mute);
 
         [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_media_source_set_encoder_bitrate")]
         internal static extern WebRTCErrorCode SetEncoderBitrate(IntPtr handle, uint sourceId, MediaType type, int bitrate);
@@ -209,7 +210,7 @@ internal static partial class Interop
         internal static extern WebRTCErrorCode SetAudioMute(IntPtr handle, uint trackId, bool mute);
 
         [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_get_audio_mute")]
-        internal static extern WebRTCErrorCode GetAudioMute(IntPtr handle, uint trackId, out bool isMuted);
+        internal static extern WebRTCErrorCode GetAudioMute(IntPtr handle, uint trackId, [MarshalAs(UnmanagedType.U1)] out bool isMuted);
 
         [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_set_display")]
         internal static extern WebRTCErrorCode SetDisplay(IntPtr handle, uint trackId, WebRTCDisplayType type, IntPtr display);
@@ -227,7 +228,7 @@ internal static partial class Interop
         internal static extern WebRTCErrorCode SetDisplayVisible(IntPtr handle, uint trackId, bool isVisible);
 
         [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_get_display_visible")]
-        internal static extern WebRTCErrorCode GetDisplayVisible(IntPtr handle, uint trackId, out bool isVisible);
+        internal static extern WebRTCErrorCode GetDisplayVisible(IntPtr handle, uint trackId, [MarshalAs(UnmanagedType.U1)] out bool isVisible);
 
         [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_get_stun_server")]
         internal static extern WebRTCErrorCode GetStunServer(IntPtr handle, out string server);
@@ -384,7 +385,7 @@ internal static partial class Interop
         }
     }
 
-    internal class WebRTCHandle : SafeHandle
+    internal partial class WebRTCHandle : SafeHandle
     {
         protected WebRTCHandle() : base(IntPtr.Zero, true)
         {
@@ -407,3 +408,4 @@ internal static partial class Interop
         }
     }
 }
+

--- a/src/Tizen.Multimedia.Util/Interop/Interop.ImageUtil.Decode.cs
+++ b/src/Tizen.Multimedia.Util/Interop/Interop.ImageUtil.Decode.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen;
 using Tizen.Multimedia.Util;
 
@@ -31,27 +32,27 @@ internal static partial class Interop
             [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_decode_create")]
             public static extern ImageUtilError Create(out ImageDecoderHandle handle);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_decode_destroy")]
-            internal static extern ImageUtilError Destroy(IntPtr handle);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_decode_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError Destroy(IntPtr handle);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_decode_set_input_path")]
-            internal static extern ImageUtilError SetInputPath(ImageDecoderHandle handle, IntPtr path);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_decode_set_input_path", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError SetInputPath(ImageDecoderHandle handle, IntPtr path);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_decode_set_input_buffer")]
-            internal static extern ImageUtilError SetInputBuffer(ImageDecoderHandle handle, byte[] srcBuffer, ulong srcSize);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_decode_set_input_buffer", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError SetInputBuffer(ImageDecoderHandle handle, byte[] srcBuffer, ulong srcSize);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_decode_set_colorspace")]
-            internal static extern ImageUtilError SetColorspace(ImageDecoderHandle handle, ImageColorSpace colorspace);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_decode_set_colorspace", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError SetColorspace(ImageDecoderHandle handle, ImageColorSpace colorspace);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_decode_set_jpeg_downscale")]
-            internal static extern ImageUtilError SetJpegDownscale(ImageDecoderHandle handle, JpegDownscale downscale);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_decode_set_jpeg_downscale", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError SetJpegDownscale(ImageDecoderHandle handle, JpegDownscale downscale);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_decode_run2")]
-            internal static extern ImageUtilError DecodeRun(ImageDecoderHandle handle, out IntPtr imageHandle);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_decode_run2", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError DecodeRun(ImageDecoderHandle handle, out IntPtr imageHandle);
         }
     }
 
-    internal class ImageDecoderHandle : SafeHandle
+    internal partial class ImageDecoderHandle : SafeHandle
     {
         protected ImageDecoderHandle() : base(IntPtr.Zero, true)
         {

--- a/src/Tizen.Multimedia.Util/Interop/Interop.ImageUtil.Encode.cs
+++ b/src/Tizen.Multimedia.Util/Interop/Interop.ImageUtil.Encode.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen;
 using Tizen.Multimedia.Util;
 
@@ -23,60 +24,60 @@ internal static partial class Interop
 {
     internal static partial class ImageUtil
     {
-        internal static class Encode
+        internal static partial class Encode
         {
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             internal delegate void EncodeCompletedCallback(ImageUtilError ImageUtilError, IntPtr userData, ulong size);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_run_async")]
-            internal static extern ImageUtilError EncodeRunAsync(ImageEncoderHandle handle,
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_run_async", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError EncodeRunAsync(ImageEncoderHandle handle,
                 EncodeCompletedCallback callback, IntPtr userData = default(IntPtr));
 
             [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_create")]
             internal static extern ImageUtilError Create(ImageFormat type, out ImageEncoderHandle handle);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_destroy")]
-            internal static extern ImageUtilError Destroy(IntPtr handle);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError Destroy(IntPtr handle);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_set_quality")]
-            internal static extern ImageUtilError SetQuality(ImageEncoderHandle handle, int quality);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_set_quality", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError SetQuality(ImageEncoderHandle handle, int quality);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_set_png_compression")]
-            internal static extern ImageUtilError SetPngCompression(ImageEncoderHandle handle, PngCompression compression);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_set_png_compression", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError SetPngCompression(ImageEncoderHandle handle, PngCompression compression);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_run_to_buffer")]
-            internal static extern ImageUtilError RunToBuffer(ImageEncoderHandle handle, IntPtr imageUtilHandle, out IntPtr buffer, out int size);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_run_to_buffer", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError RunToBuffer(ImageEncoderHandle handle, IntPtr imageUtilHandle, out IntPtr buffer, out int size);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_set_lossless")]
-            internal static extern ImageUtilError SetLossless(ImageEncoderHandle handle, bool lossless);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_set_lossless", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError SetLossless(ImageEncoderHandle handle, [MarshalAs(UnmanagedType.U1)] bool lossless);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_create")]
-            internal static extern ImageUtilError AnimationCreate(AnimationType type, out IntPtr animHandle);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError AnimationCreate(AnimationType type, out IntPtr animHandle);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_set_loop_count")]
-            internal static extern ImageUtilError AnimationSetLoopCount(IntPtr animHandle, uint count);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_set_loop_count", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError AnimationSetLoopCount(IntPtr animHandle, uint count);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_set_background_color")]
-            internal static extern ImageUtilError AnimationSetBackgroundColor(IntPtr animHandle, byte r, byte g, byte b, byte a);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_set_background_color", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError AnimationSetBackgroundColor(IntPtr animHandle, byte r, byte g, byte b, byte a);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_set_lossless")]
-            internal static extern ImageUtilError AnimationSetLossless(IntPtr animHandle, bool isLossless);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_set_lossless", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError AnimationSetLossless(IntPtr animHandle, [MarshalAs(UnmanagedType.U1)] bool isLossless);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_add_frame")]
-            internal static extern ImageUtilError AnimationAddFrame(IntPtr animHandle, IntPtr utilHandle, uint delayTime);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_add_frame", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError AnimationAddFrame(IntPtr animHandle, IntPtr utilHandle, uint delayTime);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_save_to_file")]
-            internal static extern ImageUtilError AnimationSaveToFile(IntPtr animHandle, string path);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_save_to_file", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError AnimationSaveToFile(IntPtr animHandle, string path);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_save_to_buffer")]
-            internal static extern ImageUtilError AnimationSaveToBuffer(IntPtr animHandle, out IntPtr dstBuffer, out ulong size);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_save_to_buffer", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError AnimationSaveToBuffer(IntPtr animHandle, out IntPtr dstBuffer, out ulong size);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_destroy")]
-            internal static extern ImageUtilError AnimationDestroy(IntPtr animHandle);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError AnimationDestroy(IntPtr animHandle);
         }
     }
 
-    internal class ImageEncoderHandle : SafeHandle
+    internal partial class ImageEncoderHandle : SafeHandle
     {
         protected ImageEncoderHandle() : base(IntPtr.Zero, true)
         {
@@ -98,7 +99,7 @@ internal static partial class Interop
         }
     }
 
-    internal class AgifImageEncoderHandle : SafeHandle
+    internal partial class AgifImageEncoderHandle : SafeHandle
     {
         protected AgifImageEncoderHandle() : base(IntPtr.Zero, true)
         {

--- a/src/Tizen.Multimedia.Util/Interop/Interop.ImageUtil.Transform.cs
+++ b/src/Tizen.Multimedia.Util/Interop/Interop.ImageUtil.Transform.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen;
 using Tizen.Multimedia.Util;
 
@@ -23,46 +24,46 @@ internal static partial class Interop
 {
     internal static partial class ImageUtil
     {
-        internal static class Transform
+        internal static partial class Transform
         {
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             internal delegate void TransformCompletedCallback(IntPtr resultPacket, ImageUtilError errorCode,
                 IntPtr userData = default(IntPtr));
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_run")]
-            internal static extern ImageUtilError Run(TransformHandle handle, IntPtr srcPacket,
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_run", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError Run(TransformHandle handle, IntPtr srcPacket,
                 TransformCompletedCallback callback, IntPtr userData = default(IntPtr));
 
             [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_create")]
             internal static extern ImageUtilError Create(out TransformHandle handle);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_destroy")]
-            internal static extern ImageUtilError Destroy(IntPtr handle);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError Destroy(IntPtr handle);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_get_colorspace")]
-            internal static extern ImageUtilError GetColorspace(TransformHandle handle, out ImageColorSpace colorspace);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_get_colorspace", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError GetColorspace(TransformHandle handle, out ImageColorSpace colorspace);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_set_colorspace")]
-            internal static extern ImageUtilError SetColorspace(TransformHandle handle, ImageColorSpace colorspace);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_set_colorspace", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError SetColorspace(TransformHandle handle, ImageColorSpace colorspace);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_set_rotation")]
-            internal static extern ImageUtilError SetRotation(TransformHandle handle, ImageRotation rotation);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_set_rotation", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError SetRotation(TransformHandle handle, ImageRotation rotation);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_get_crop_area")]
-            internal static extern ImageUtilError GetCropArea(TransformHandle handle, out uint startX, out uint startY, out uint endX, out uint endY);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_get_crop_area", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError GetCropArea(TransformHandle handle, out uint startX, out uint startY, out uint endX, out uint endY);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_set_crop_area")]
-            internal static extern ImageUtilError SetCropArea(TransformHandle handle, int startX, int startY, int endX, int endY);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_set_crop_area", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError SetCropArea(TransformHandle handle, int startX, int startY, int endX, int endY);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_get_resolution")]
-            internal static extern ImageUtilError GetResolution(TransformHandle handle, out uint width, out uint height);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_get_resolution", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError GetResolution(TransformHandle handle, out uint width, out uint height);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_set_resolution")]
-            internal static extern ImageUtilError SetResolution(TransformHandle handle, uint width, uint height);
+            [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_set_resolution", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial ImageUtilError SetResolution(TransformHandle handle, uint width, uint height);
         }
     }
 
-    internal class TransformHandle : SafeHandle
+    internal partial class TransformHandle : SafeHandle
     {
         protected TransformHandle() : base(IntPtr.Zero, true)
         {

--- a/src/Tizen.Multimedia.Util/Interop/Interop.ImageUtil.cs
+++ b/src/Tizen.Multimedia.Util/Interop/Interop.ImageUtil.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen;
 using Tizen.Multimedia.Util;
 
@@ -26,21 +27,21 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate bool SupportedColorspaceCallback(ImageColorSpace colorspace, IntPtr userData);
 
-        [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_foreach_supported_colorspace")]
-        internal static extern ImageUtilError ForeachSupportedColorspace(ImageFormat type, SupportedColorspaceCallback callback,
+        [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_foreach_supported_colorspace", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ImageUtilError ForeachSupportedColorspace(ImageFormat type, SupportedColorspaceCallback callback,
             IntPtr userData = default(IntPtr));
 
-        [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_extract_color_from_memory")]
-        internal static extern ImageUtilError ExtractColorFromMemory(byte[] buffer, int width, int height, out byte rgbR, out byte rgbG, out byte rgbB);
+        [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_extract_color_from_memory", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ImageUtilError ExtractColorFromMemory(byte[] buffer, int width, int height, out byte rgbR, out byte rgbG, out byte rgbB);
 
-        [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_get_image")]
-        internal static extern ImageUtilError GetImage(IntPtr handle, out int width, out int height,
+        [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_get_image", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ImageUtilError GetImage(IntPtr handle, out int width, out int height,
             out ImageColorSpace colorspace, out IntPtr data, out int size);
 
-        [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_destroy_image")]
-        internal static extern ImageUtilError Destroy(IntPtr handle);
+        [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_destroy_image", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ImageUtilError Destroy(IntPtr handle);
 
-        [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_create_image")]
-        internal static extern ImageUtilError Create(uint width, uint height, ImageColorSpace colorSpace, byte[] srcBuffer, int size, out IntPtr handle);
+        [LibraryImport(Libraries.ImageUtil, EntryPoint = "image_util_create_image", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ImageUtilError Create(uint width, uint height, ImageColorSpace colorSpace, byte[] srcBuffer, int size, out IntPtr handle);
     }
 }

--- a/src/Tizen.Multimedia.Util/Interop/Interop.ThumbnailExtractor.cs
+++ b/src/Tizen.Multimedia.Util/Interop/Interop.ThumbnailExtractor.cs
@@ -16,17 +16,18 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia.Util;
 
 internal static partial class Interop
 {
-    internal static class ThumbnailExtractor
+    internal static partial class ThumbnailExtractor
     {
-        [DllImport(Libraries.ThumbnailExtractor, EntryPoint = "thumbnail_util_extract_to_buffer")]
-        internal static extern ThumbnailExtractorError ExtractToBuffer(string path, uint width, uint height, out IntPtr thumbData,
+        [LibraryImport(Libraries.ThumbnailExtractor, EntryPoint = "thumbnail_util_extract_to_buffer", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ThumbnailExtractorError ExtractToBuffer(string path, uint width, uint height, out IntPtr thumbData,
             out int dataSize, out uint thumbWidth, out uint thumbHeight);
 
-        [DllImport(Libraries.ThumbnailExtractor, EntryPoint = "thumbnail_util_extract_to_file")]
-        internal static extern ThumbnailExtractorError ExtractToFile(string path, uint width, uint height, string thumbPath);
+        [LibraryImport(Libraries.ThumbnailExtractor, EntryPoint = "thumbnail_util_extract_to_file", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ThumbnailExtractorError ExtractToFile(string path, uint width, uint height, string thumbPath);
     }
 }

--- a/src/Tizen.Multimedia.Vision/Interop/Interop.MediaVision.BarCode.cs
+++ b/src/Tizen.Multimedia.Vision/Interop/Interop.MediaVision.BarCode.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia.Vision;
 
 /// <summary>
@@ -33,8 +34,8 @@ internal static partial class Interop
         /// </summary>
         internal static partial class BarcodeDetector
         {
-            [DllImport(Libraries.MediaVisionBarcodeDetector, EntryPoint = "mv_barcode_detect")]
-            internal static extern MediaVisionError Detect(IntPtr source, IntPtr engineCfg, Rectangle roi,
+            [LibraryImport(Libraries.MediaVisionBarcodeDetector, EntryPoint = "mv_barcode_detect", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Detect(IntPtr source, IntPtr engineCfg, Rectangle roi,
                 DetectedCallback detectCb, IntPtr userData = default(IntPtr));
 
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -55,12 +56,12 @@ internal static partial class Interop
         /// </summary>
         internal static partial class BarcodeGenerator
         {
-            [DllImport(Libraries.MediaVisionBarcodeGenerator, EntryPoint = "mv_barcode_generate_source")]
-            internal static extern MediaVisionError GenerateSource(IntPtr engineCfg, string message,
+            [LibraryImport(Libraries.MediaVisionBarcodeGenerator, EntryPoint = "mv_barcode_generate_source", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GenerateSource(IntPtr engineCfg, string message,
                 BarcodeType type, int qrEncMode, int qrEcc, int qrVersion, IntPtr source);
 
-            [DllImport(Libraries.MediaVisionBarcodeGenerator, EntryPoint = "mv_barcode_generate_image")]
-            internal static extern MediaVisionError GenerateImage(IntPtr engineCfg,
+            [LibraryImport(Libraries.MediaVisionBarcodeGenerator, EntryPoint = "mv_barcode_generate_image", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GenerateImage(IntPtr engineCfg,
                 string message, int imageWidth, int imageHeight, BarcodeType type,
                 int qrEncMode, int qrEcc, int qrVersion, string imagePath, BarcodeImageFormat imageFormat);
         }

--- a/src/Tizen.Multimedia.Vision/Interop/Interop.MediaVision.Common.cs
+++ b/src/Tizen.Multimedia.Vision/Interop/Interop.MediaVision.Common.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Internals;
 using Tizen.Multimedia.Vision;
 
@@ -139,39 +140,39 @@ internal static partial class Interop
         /// </summary>
         internal static partial class MediaSource
         {
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_create_source")]
-            internal static extern MediaVisionError Create(out IntPtr source);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_create_source", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Create(out IntPtr source);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_destroy_source")]
-            internal static extern int Destroy(IntPtr /* mv_source_h */ source);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_destroy_source", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Destroy(IntPtr /* mv_source_h */ source);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_source_fill_by_media_packet")]
-            internal static extern MediaVisionError FillMediaPacket(IntPtr source, IntPtr mediaPacket);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_source_fill_by_media_packet", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError FillMediaPacket(IntPtr source, IntPtr mediaPacket);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_source_fill_by_buffer")]
-            internal static extern MediaVisionError FillBuffer(IntPtr source, byte[] buffer,
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_source_fill_by_buffer", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError FillBuffer(IntPtr source, byte[] buffer,
                 int bufferSize, uint imageWidth, uint imageHeight, VisionColorSpace colorspace);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_source_clear")]
-            internal static extern int Clear(IntPtr /* mv_source_h */ source);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_source_clear", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Clear(IntPtr /* mv_source_h */ source);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_source_get_buffer")]
-            internal static extern MediaVisionError GetBuffer(IntPtr source, out IntPtr buffer, out int bufferSize);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_source_get_buffer", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetBuffer(IntPtr source, out IntPtr buffer, out int bufferSize);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_source_get_height")]
-            internal static extern int GetHeight(IntPtr source, out uint imageHeight);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_source_get_height", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetHeight(IntPtr source, out uint imageHeight);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_source_get_width")]
-            internal static extern int GetWidth(IntPtr source, out uint imageWidth);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_source_get_width", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetWidth(IntPtr source, out uint imageWidth);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_source_get_colorspace")]
-            internal static extern int GetColorspace(IntPtr /* mv_source_h */ source, out VisionColorSpace colorspace);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_source_get_colorspace", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetColorspace(IntPtr /* mv_source_h */ source, out VisionColorSpace colorspace);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_source_set_timestamp")]
-            internal static extern int SetTimestamp(IntPtr source, ulong timestamp);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_source_set_timestamp", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetTimestamp(IntPtr source, ulong timestamp);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_source_get_timestamp")]
-            internal static extern int GetTimestamp(IntPtr source, out ulong timestamp);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_source_get_timestamp", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetTimestamp(IntPtr source, out ulong timestamp);
         }
 
         /// <summary>
@@ -179,42 +180,42 @@ internal static partial class Interop
         /// </summary>
         internal static partial class EngineConfig
         {
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_create_engine_config")]
-            internal static extern MediaVisionError Create(out IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_create_engine_config", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Create(out IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_destroy_engine_config")]
-            internal static extern int Destroy(IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_destroy_engine_config", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Destroy(IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_set_double_attribute")]
-            internal static extern MediaVisionError SetDouble(IntPtr handle, string name, double value);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_set_double_attribute", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError SetDouble(IntPtr handle, string name, double value);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_set_int_attribute")]
-            internal static extern MediaVisionError SetInt(IntPtr handle, string name, int value);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_set_int_attribute", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError SetInt(IntPtr handle, string name, int value);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_set_bool_attribute")]
-            internal static extern MediaVisionError SetBool(IntPtr handle, string name, bool value);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_set_bool_attribute", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError SetBool(IntPtr handle, string name, [MarshalAs(UnmanagedType.U1)] bool value);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_set_string_attribute")]
-            internal static extern MediaVisionError SetString(IntPtr handle, string name, string value);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_set_string_attribute", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError SetString(IntPtr handle, string name, string value);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_set_array_string_attribute")]
-            internal static extern MediaVisionError SetStringArray(IntPtr handle, string name,
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_set_array_string_attribute", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError SetStringArray(IntPtr handle, string name,
                 [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] string[] value, int size);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_get_double_attribute")]
-            internal static extern MediaVisionError GetDouble(IntPtr handle, string name, out double value);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_get_double_attribute", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetDouble(IntPtr handle, string name, out double value);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_get_int_attribute")]
-            internal static extern MediaVisionError GetInt(IntPtr handle, string name, out int value);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_get_int_attribute", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetInt(IntPtr handle, string name, out int value);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_get_bool_attribute")]
-            internal static extern MediaVisionError GetBool(IntPtr handle, string name, out bool value);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_get_bool_attribute", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetBool(IntPtr handle, string name, [MarshalAs(UnmanagedType.U1)] out bool value);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_get_string_attribute")]
-            internal static extern MediaVisionError GetString(IntPtr handle, string name, out IntPtr value);
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_get_string_attribute", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetString(IntPtr handle, string name, out IntPtr value);
 
-            [DllImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_get_array_string_attribute")]
-            internal static extern MediaVisionError GetStringArray(IntPtr handle, string name,
+            [LibraryImport(Libraries.MediaVisionCommon, EntryPoint = "mv_engine_config_get_array_string_attribute", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetStringArray(IntPtr handle, string name,
                 out IntPtr value, out int size);
         }
     }

--- a/src/Tizen.Multimedia.Vision/Interop/Interop.MediaVision.Face.cs
+++ b/src/Tizen.Multimedia.Vision/Interop/Interop.MediaVision.Face.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia.Vision;
 
 /// <summary>
@@ -33,28 +34,28 @@ internal static partial class Interop
         /// </summary>
         internal static partial class Face
         {
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_detect")]
-            internal static extern MediaVisionError Detect(IntPtr source, IntPtr engineCfg,
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_detect", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Detect(IntPtr source, IntPtr engineCfg,
                 DetectedCallback detectedCb, IntPtr userData = default(IntPtr)); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognize")]
-            internal static extern MediaVisionError Recognize(IntPtr source, IntPtr recognitionModel, IntPtr engineCfg,
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognize", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Recognize(IntPtr source, IntPtr recognitionModel, IntPtr engineCfg,
                 IntPtr faceLocation, RecognizedCallback recognizedCb, IntPtr userData = default(IntPtr)); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognize")]
-            internal static extern MediaVisionError Recognize(IntPtr source, IntPtr recognitionModel, IntPtr engineCfg,
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognize", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Recognize(IntPtr source, IntPtr recognitionModel, IntPtr engineCfg,
                 ref Rectangle faceLocation, RecognizedCallback recognizedCb, IntPtr userData = default(IntPtr)); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_track")]
-            internal static extern MediaVisionError Track(IntPtr source, IntPtr trackingModel, IntPtr engineCfg,
-                TrackedCallback trackedCb, bool doLearn, IntPtr userData = default(IntPtr)); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_track", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Track(IntPtr source, IntPtr trackingModel, IntPtr engineCfg,
+                TrackedCallback trackedCb, [MarshalAs(UnmanagedType.U1)] bool doLearn, IntPtr userData = default(IntPtr)); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_eye_condition_recognize")]
-            internal static extern MediaVisionError RecognizeEyeCondition(IntPtr source, IntPtr engineCfg,
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_eye_condition_recognize", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError RecognizeEyeCondition(IntPtr source, IntPtr engineCfg,
                 Rectangle faceLocation, EyeConditionRecognizedCallback eyeConditionRecognizedCb, IntPtr userData = default(IntPtr)); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_facial_expression_recognize")]
-            internal static extern MediaVisionError RecognizeFacialExpression(IntPtr source, IntPtr engineCfg,
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_facial_expression_recognize", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError RecognizeFacialExpression(IntPtr source, IntPtr engineCfg,
                 Rectangle faceLocation, MvFaceFacialExpressionRecognizedCallback expressionRecognizedCb, // Deprecated in API 12
                 IntPtr userData = default(IntPtr));
 
@@ -85,40 +86,40 @@ internal static partial class Interop
         /// </summary>
         internal static partial class FaceRecognitionModel
         {
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_create")]
-            internal static extern MediaVisionError Create(out IntPtr handle); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Create(out IntPtr handle); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_destroy")]
-            internal static extern int Destroy(IntPtr handle); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Destroy(IntPtr handle); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_clone")]
-            internal static extern int Clone(IntPtr src, out IntPtr dst); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_clone", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Clone(IntPtr src, out IntPtr dst); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_save")]
-            internal static extern MediaVisionError Save(string fileName, IntPtr handle); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_save", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Save(string fileName, IntPtr handle); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_load")]
-            internal static extern MediaVisionError Load(string fileName, out IntPtr handle); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_load", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Load(string fileName, out IntPtr handle); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_add")]
-            internal static extern MediaVisionError Add(IntPtr source, IntPtr recognitionModel,
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_add", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Add(IntPtr source, IntPtr recognitionModel,
                 ref Rectangle exampleLocation, int faceLabel); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_add")]
-            internal static extern MediaVisionError Add(IntPtr source, IntPtr recognitionModel,
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_add", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Add(IntPtr source, IntPtr recognitionModel,
                 IntPtr exampleLocation, int faceLabel); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_reset")]
-            internal static extern MediaVisionError Reset(IntPtr recognitionModel, IntPtr faceLabel = default(IntPtr)); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_reset", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Reset(IntPtr recognitionModel, IntPtr faceLabel = default(IntPtr)); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_reset")]
-            internal static extern MediaVisionError Remove(IntPtr recognitionModel, ref int faceLabel); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_reset", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Remove(IntPtr recognitionModel, ref int faceLabel); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_learn")]
-            internal static extern MediaVisionError Learn(IntPtr engineCfg, IntPtr handle); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_learn", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Learn(IntPtr engineCfg, IntPtr handle); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_query_labels")]
-            internal static extern MediaVisionError QueryLabels(IntPtr handle, out IntPtr labels, out uint numberOfLabels); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_recognition_model_query_labels", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError QueryLabels(IntPtr handle, out IntPtr labels, out uint numberOfLabels); // Deprecated in API 12
         }
 
         /// <summary>
@@ -126,11 +127,11 @@ internal static partial class Interop
         /// </summary>
         internal static partial class FaceTrackingModel
         {
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_tracking_model_create")]
-            internal static extern MediaVisionError Create(out IntPtr handle); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_tracking_model_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Create(out IntPtr handle); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_tracking_model_destroy")]
-            internal static extern int Destroy(IntPtr handle); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_tracking_model_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Destroy(IntPtr handle); // Deprecated in API 12
 
             [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_tracking_model_prepare")]
             internal static extern MediaVisionError Prepare(IntPtr trackingModel, IntPtr engineCfg,
@@ -140,14 +141,14 @@ internal static partial class Interop
             internal static extern MediaVisionError Prepare(IntPtr trackingModel, IntPtr engineCfg,
                 IntPtr source, IntPtr location); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_tracking_model_clone")]
-            internal static extern int Clone(IntPtr src, out IntPtr dst); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_tracking_model_clone", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Clone(IntPtr src, out IntPtr dst); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_tracking_model_save")]
-            internal static extern MediaVisionError Save(string fileName, IntPtr handle); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_tracking_model_save", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Save(string fileName, IntPtr handle); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_tracking_model_load")]
-            internal static extern MediaVisionError Load(string fileName, out IntPtr handle); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionFace, EntryPoint = "mv_face_tracking_model_load", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Load(string fileName, out IntPtr handle); // Deprecated in API 12
         }
 
         /// <summary>
@@ -155,26 +156,26 @@ internal static partial class Interop
         /// </summary>
         internal static partial class FaceRecognition
         {
-            [DllImport(Libraries.MediaVisionFaceRecognition, EntryPoint = "mv_face_recognition_create")]
-            internal static extern MediaVisionError Create(out IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionFaceRecognition, EntryPoint = "mv_face_recognition_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Create(out IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionFaceRecognition, EntryPoint = "mv_face_recognition_destroy")]
-            internal static extern MediaVisionError Destroy(IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionFaceRecognition, EntryPoint = "mv_face_recognition_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Destroy(IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionFaceRecognition, EntryPoint = "mv_face_recognition_prepare")]
-            internal static extern MediaVisionError Prepare(IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionFaceRecognition, EntryPoint = "mv_face_recognition_prepare", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Prepare(IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionFaceRecognition, EntryPoint = "mv_face_recognition_register")]
-            internal static extern MediaVisionError Register(IntPtr handle, IntPtr source, string label);
+            [LibraryImport(Libraries.MediaVisionFaceRecognition, EntryPoint = "mv_face_recognition_register", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Register(IntPtr handle, IntPtr source, string label);
 
-            [DllImport(Libraries.MediaVisionFaceRecognition, EntryPoint = "mv_face_recognition_unregister")]
-            internal static extern MediaVisionError Unregister(IntPtr handle, string label);
+            [LibraryImport(Libraries.MediaVisionFaceRecognition, EntryPoint = "mv_face_recognition_unregister", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Unregister(IntPtr handle, string label);
 
-            [DllImport(Libraries.MediaVisionFaceRecognition, EntryPoint = "mv_face_recognition_inference")]
-            internal static extern MediaVisionError Inference(IntPtr handle, IntPtr source);
+            [LibraryImport(Libraries.MediaVisionFaceRecognition, EntryPoint = "mv_face_recognition_inference", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Inference(IntPtr handle, IntPtr source);
 
-            [DllImport(Libraries.MediaVisionFaceRecognition, EntryPoint = "mv_face_recognition_get_label")]
-            internal static extern MediaVisionError GetLabel(IntPtr handle, out IntPtr label);
+            [LibraryImport(Libraries.MediaVisionFaceRecognition, EntryPoint = "mv_face_recognition_get_label", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetLabel(IntPtr handle, out IntPtr label);
         }
     }
 }

--- a/src/Tizen.Multimedia.Vision/Interop/Interop.MediaVision.Image.cs
+++ b/src/Tizen.Multimedia.Vision/Interop/Interop.MediaVision.Image.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia.Vision;
 
 /// <summary>
@@ -33,43 +34,43 @@ internal static partial class Interop
         /// </summary>
         internal static partial class Image
         {
-            [DllImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_recognize")]
-            internal static extern MediaVisionError Recognize(IntPtr source, IntPtr[] imageObjects,
+            [LibraryImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_recognize", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Recognize(IntPtr source, IntPtr[] imageObjects,
                 int numberOfObjects, IntPtr engineCfg, RecognizedCallback recognizedCb, IntPtr userData = default(IntPtr)); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_track")]
-            internal static extern MediaVisionError Track(IntPtr source, IntPtr imageTrackingModel,
+            [LibraryImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_track", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Track(IntPtr source, IntPtr imageTrackingModel,
                 IntPtr engineCfg, TrackedCallback trackedCb, IntPtr userData = default(IntPtr)); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_create")]
-            internal static extern MediaVisionError Create(out IntPtr handle); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Create(out IntPtr handle); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_destroy")]
-            internal static extern int Destroy(IntPtr handle); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Destroy(IntPtr handle); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_fill")]
-            internal static extern MediaVisionError Fill(IntPtr handle, IntPtr engineCfg, IntPtr source, ref Rectangle location); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_fill", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Fill(IntPtr handle, IntPtr engineCfg, IntPtr source, ref Rectangle location); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_fill")]
-            internal static extern MediaVisionError Fill(IntPtr handle, IntPtr engineCfg, IntPtr source, IntPtr location); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_fill", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Fill(IntPtr handle, IntPtr engineCfg, IntPtr source, IntPtr location); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_get_recognition_rate")]
-            internal static extern MediaVisionError GetRecognitionRate(IntPtr handle, out double recognitionRate); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_get_recognition_rate", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetRecognitionRate(IntPtr handle, out double recognitionRate); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_set_label")]
-            internal static extern MediaVisionError SetLabel(IntPtr handle, int label); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_set_label", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError SetLabel(IntPtr handle, int label); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_get_label")]
-            internal static extern MediaVisionError GetLabel(IntPtr handle, out int label); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_get_label", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetLabel(IntPtr handle, out int label); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_clone")]
-            internal static extern int Clone(IntPtr src, out IntPtr dst); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_clone", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Clone(IntPtr src, out IntPtr dst); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_save")]
-            internal static extern MediaVisionError Save(string fileName, IntPtr handle); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_save", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Save(string fileName, IntPtr handle); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_load")]
-            internal static extern MediaVisionError Load(string fileName, out IntPtr handle); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_object_load", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Load(string fileName, out IntPtr handle); // Deprecated in API 12
 
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             internal delegate void RecognizedCallback(IntPtr source, IntPtr engineCfg, IntPtr imageObjects,
@@ -86,26 +87,26 @@ internal static partial class Interop
         /// </summary>
         internal static partial class ImageTrackingModel
         {
-            [DllImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_tracking_model_create")]
-            internal static extern MediaVisionError Create(out IntPtr imageTrackingModel); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_tracking_model_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Create(out IntPtr imageTrackingModel); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_tracking_model_set_target")]
-            internal static extern MediaVisionError SetTarget(IntPtr handle, IntPtr imageTrackingModel); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_tracking_model_set_target", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError SetTarget(IntPtr handle, IntPtr imageTrackingModel); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_tracking_model_destroy")]
-            internal static extern int Destroy(IntPtr imageTrackingModel); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_tracking_model_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Destroy(IntPtr imageTrackingModel); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_tracking_model_refresh")]
-            internal static extern MediaVisionError Refresh(IntPtr imageTrackingModel, IntPtr engineCfg); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_tracking_model_refresh", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Refresh(IntPtr imageTrackingModel, IntPtr engineCfg); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_tracking_model_clone")]
-            internal static extern int Clone(IntPtr src, out IntPtr dest); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_tracking_model_clone", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Clone(IntPtr src, out IntPtr dest); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_tracking_model_save")]
-            internal static extern MediaVisionError Save(string fileName, IntPtr imageTrackingModel); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_tracking_model_save", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Save(string fileName, IntPtr imageTrackingModel); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_tracking_model_load")]
-            internal static extern MediaVisionError Load(string fileName, out IntPtr imageTrackingModel); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionImage, EntryPoint = "mv_image_tracking_model_load", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Load(string fileName, out IntPtr imageTrackingModel); // Deprecated in API 12
         }
     }
 }

--- a/src/Tizen.Multimedia.Vision/Interop/Interop.MediaVision.Inference.cs
+++ b/src/Tizen.Multimedia.Vision/Interop/Interop.MediaVision.Inference.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia.Vision;
 
 /// <summary>
@@ -67,190 +68,190 @@ internal static partial class Interop
             internal delegate void PoseLandmarkDetectedCallback(IntPtr source, IntPtr poses,
                 IntPtr userData = default(IntPtr)); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_create")]
-            internal static extern MediaVisionError Create(out IntPtr handle); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Create(out IntPtr handle); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_destroy")]
-            internal static extern MediaVisionError Destroy(IntPtr handle); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Destroy(IntPtr handle); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_configure")]
-            internal static extern MediaVisionError Configure(IntPtr handle, IntPtr engineConfig); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_configure", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Configure(IntPtr handle, IntPtr engineConfig); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_prepare")]
-            internal static extern MediaVisionError Load(IntPtr handle); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_prepare", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Load(IntPtr handle); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_foreach_supported_engine")]
-            internal static extern MediaVisionError ForeachSupportedBackend(IntPtr handle,
+            [LibraryImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_foreach_supported_engine", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError ForeachSupportedBackend(IntPtr handle,
                 SupportedBackendCallback callback, IntPtr userData = default(IntPtr)); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_image_classify")]
-            internal static extern MediaVisionError ClassifyImage(IntPtr source, IntPtr inference,
+            [LibraryImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_image_classify", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError ClassifyImage(IntPtr source, IntPtr inference,
                 IntPtr roi, ImageClassifedCallback callback, IntPtr userData = default(IntPtr)); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_object_detect")]
-            internal static extern MediaVisionError DetectObject(IntPtr source, IntPtr inference,
+            [LibraryImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_object_detect", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError DetectObject(IntPtr source, IntPtr inference,
                 ObjectDetectedCallback callback, IntPtr userData = default(IntPtr)); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_face_detect")]
-            internal static extern MediaVisionError DetectFace(IntPtr source, IntPtr inference,
+            [LibraryImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_face_detect", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError DetectFace(IntPtr source, IntPtr inference,
                 FaceDetectedCallback callback, IntPtr userData = default(IntPtr)); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_facial_landmark_detect")]
-            internal static extern MediaVisionError DetectFacialLandmark(IntPtr source, IntPtr inference,
+            [LibraryImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_facial_landmark_detect", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError DetectFacialLandmark(IntPtr source, IntPtr inference,
                 IntPtr roi, FacialLandmarkDetectedCallback callback, IntPtr userData = default(IntPtr)); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_pose_get_number_of_poses")]
-            internal static extern MediaVisionError GetPoseNum(IntPtr result, out int numPose); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_pose_get_number_of_poses", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetPoseNum(IntPtr result, out int numPose); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_pose_get_number_of_landmarks")]
-            internal static extern MediaVisionError GetLandmarkNum(IntPtr result, out int numLandmark); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_pose_get_number_of_landmarks", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetLandmarkNum(IntPtr result, out int numLandmark); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_pose_get_landmark")]
-            internal static extern MediaVisionError GetLandmark(IntPtr result, int index, int part, out Point location, out float score); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_pose_get_landmark", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetLandmark(IntPtr result, int index, int part, out Point location, out float score); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_pose_landmark_detect")]
-            internal static extern MediaVisionError DetectPoseLandmark(IntPtr source, IntPtr inference,
+            [LibraryImport(Libraries.MediaVisionInference, EntryPoint = "mv_inference_pose_landmark_detect", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError DetectPoseLandmark(IntPtr source, IntPtr inference,
                 IntPtr roi, PoseLandmarkDetectedCallback callback, IntPtr userData = default(IntPtr)); // Deprecated in API 12
         }
 
         internal static partial class InferenceImageClassification
         {
             // Newly added inferernce APIs
-            [DllImport(Libraries.MediaVisionInferenceImageClassification, EntryPoint = "mv_image_classification_create")]
-            internal static extern MediaVisionError Create(out IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferenceImageClassification, EntryPoint = "mv_image_classification_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Create(out IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferenceImageClassification, EntryPoint = "mv_image_classification_destroy")]
-            internal static extern MediaVisionError Destroy(IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferenceImageClassification, EntryPoint = "mv_image_classification_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Destroy(IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferenceImageClassification, EntryPoint = "mv_image_classification_configure")]
-            internal static extern MediaVisionError Configure(IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferenceImageClassification, EntryPoint = "mv_image_classification_configure", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Configure(IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferenceImageClassification, EntryPoint = "mv_image_classification_prepare")]
-            internal static extern MediaVisionError Prepare(IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferenceImageClassification, EntryPoint = "mv_image_classification_prepare", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Prepare(IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferenceImageClassification, EntryPoint = "mv_image_classification_inference")]
-            internal static extern MediaVisionError Inference(IntPtr handle, IntPtr source);
+            [LibraryImport(Libraries.MediaVisionInferenceImageClassification, EntryPoint = "mv_image_classification_inference", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Inference(IntPtr handle, IntPtr source);
 
-            [DllImport(Libraries.MediaVisionInferenceImageClassification, EntryPoint = "mv_image_classification_inference_async")]
-            internal static extern MediaVisionError InferenceAsync(IntPtr handle, IntPtr source);
+            [LibraryImport(Libraries.MediaVisionInferenceImageClassification, EntryPoint = "mv_image_classification_inference_async", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError InferenceAsync(IntPtr handle, IntPtr source);
 
-            [DllImport(Libraries.MediaVisionInferenceImageClassification, EntryPoint = "mv_image_classification_get_result_count")]
-            internal static extern MediaVisionError GetResultCount(IntPtr handle, out ulong requestOrder, out uint count);
+            [LibraryImport(Libraries.MediaVisionInferenceImageClassification, EntryPoint = "mv_image_classification_get_result_count", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetResultCount(IntPtr handle, out ulong requestOrder, out uint count);
 
-            [DllImport(Libraries.MediaVisionInferenceImageClassification, EntryPoint = "mv_image_classification_get_label")]
-            internal static extern MediaVisionError GetLabels(IntPtr handle, uint index, out IntPtr label);
+            [LibraryImport(Libraries.MediaVisionInferenceImageClassification, EntryPoint = "mv_image_classification_get_label", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetLabels(IntPtr handle, uint index, out IntPtr label);
         }
 
         internal static partial class InferenceFaceDetection
         {
             // Newly added inferernce APIs
-            [DllImport(Libraries.MediaVisionInferenceFaceDetection, EntryPoint = "mv_face_detection_create")]
-            internal static extern MediaVisionError Create(out IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferenceFaceDetection, EntryPoint = "mv_face_detection_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Create(out IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferenceFaceDetection, EntryPoint = "mv_face_detection_destroy")]
-            internal static extern MediaVisionError Destroy(IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferenceFaceDetection, EntryPoint = "mv_face_detection_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Destroy(IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferenceFaceDetection, EntryPoint = "mv_face_detection_configure")]
-            internal static extern MediaVisionError Configure(IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferenceFaceDetection, EntryPoint = "mv_face_detection_configure", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Configure(IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferenceFaceDetection, EntryPoint = "mv_face_detection_prepare")]
-            internal static extern MediaVisionError Prepare(IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferenceFaceDetection, EntryPoint = "mv_face_detection_prepare", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Prepare(IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferenceFaceDetection, EntryPoint = "mv_face_detection_inference")]
-            internal static extern MediaVisionError Inference(IntPtr handle, IntPtr source);
+            [LibraryImport(Libraries.MediaVisionInferenceFaceDetection, EntryPoint = "mv_face_detection_inference", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Inference(IntPtr handle, IntPtr source);
 
-            [DllImport(Libraries.MediaVisionInferenceFaceDetection, EntryPoint = "mv_face_detection_inference_async")]
-            internal static extern MediaVisionError InferenceAsync(IntPtr handle, IntPtr source);
+            [LibraryImport(Libraries.MediaVisionInferenceFaceDetection, EntryPoint = "mv_face_detection_inference_async", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError InferenceAsync(IntPtr handle, IntPtr source);
 
-            [DllImport(Libraries.MediaVisionInferenceFaceDetection, EntryPoint = "mv_face_detection_get_result_count")]
-            internal static extern MediaVisionError GetResultCount(IntPtr handle, out ulong requestId, out uint count);
+            [LibraryImport(Libraries.MediaVisionInferenceFaceDetection, EntryPoint = "mv_face_detection_get_result_count", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetResultCount(IntPtr handle, out ulong requestId, out uint count);
 
-            [DllImport(Libraries.MediaVisionInferenceFaceDetection, EntryPoint = "mv_face_detection_get_bound_box")]
-            internal static extern MediaVisionError GetBoundingBoxes(IntPtr handle, uint index, out int left, out int top, out int right, out int bottom);
+            [LibraryImport(Libraries.MediaVisionInferenceFaceDetection, EntryPoint = "mv_face_detection_get_bound_box", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetBoundingBoxes(IntPtr handle, uint index, out int left, out int top, out int right, out int bottom);
         }
 
         internal static partial class InferenceObjectDetection
         {
             // Newly added inferernce APIs
-            [DllImport(Libraries.MediaVisionInferenceObjectDetection, EntryPoint = "mv_object_detection_create")]
-            internal static extern MediaVisionError Create(out IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferenceObjectDetection, EntryPoint = "mv_object_detection_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Create(out IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferenceObjectDetection, EntryPoint = "mv_object_detection_destroy")]
-            internal static extern MediaVisionError Destroy(IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferenceObjectDetection, EntryPoint = "mv_object_detection_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Destroy(IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferenceObjectDetection, EntryPoint = "mv_object_detection_configure")]
-            internal static extern MediaVisionError Configure(IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferenceObjectDetection, EntryPoint = "mv_object_detection_configure", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Configure(IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferenceObjectDetection, EntryPoint = "mv_object_detection_prepare")]
-            internal static extern MediaVisionError Prepare(IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferenceObjectDetection, EntryPoint = "mv_object_detection_prepare", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Prepare(IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferenceObjectDetection, EntryPoint = "mv_object_detection_inference")]
-            internal static extern MediaVisionError Inference(IntPtr handle, IntPtr source);
+            [LibraryImport(Libraries.MediaVisionInferenceObjectDetection, EntryPoint = "mv_object_detection_inference", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Inference(IntPtr handle, IntPtr source);
 
-            [DllImport(Libraries.MediaVisionInferenceObjectDetection, EntryPoint = "mv_object_detection_inference_async")]
-            internal static extern MediaVisionError InferenceAsync(IntPtr handle, IntPtr source);
+            [LibraryImport(Libraries.MediaVisionInferenceObjectDetection, EntryPoint = "mv_object_detection_inference_async", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError InferenceAsync(IntPtr handle, IntPtr source);
 
-            [DllImport(Libraries.MediaVisionInferenceObjectDetection, EntryPoint = "mv_object_detection_get_result_count")]
-            internal static extern MediaVisionError GetResultCount(IntPtr handle, out ulong requestId, out uint count);
+            [LibraryImport(Libraries.MediaVisionInferenceObjectDetection, EntryPoint = "mv_object_detection_get_result_count", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetResultCount(IntPtr handle, out ulong requestId, out uint count);
 
-            [DllImport(Libraries.MediaVisionInferenceObjectDetection, EntryPoint = "mv_object_detection_get_bound_box")]
-            internal static extern MediaVisionError GetBoundingBoxes(IntPtr handle, uint index, out int left, out int top, out int right, out int bottom);
+            [LibraryImport(Libraries.MediaVisionInferenceObjectDetection, EntryPoint = "mv_object_detection_get_bound_box", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetBoundingBoxes(IntPtr handle, uint index, out int left, out int top, out int right, out int bottom);
         }
 
         internal static partial class InferenceFacialLandmarkDetection
         {
             // Newly added inferernce APIs
-            [DllImport(Libraries.MediaVisionInferenceFacialLandmarkDetection, EntryPoint = "mv_facial_landmark_create")]
-            internal static extern MediaVisionError Create(out IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferenceFacialLandmarkDetection, EntryPoint = "mv_facial_landmark_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Create(out IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferenceFacialLandmarkDetection, EntryPoint = "mv_facial_landmark_destroy")]
-            internal static extern MediaVisionError Destroy(IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferenceFacialLandmarkDetection, EntryPoint = "mv_facial_landmark_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Destroy(IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferenceFacialLandmarkDetection, EntryPoint = "mv_facial_landmark_configure")]
-            internal static extern MediaVisionError Configure(IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferenceFacialLandmarkDetection, EntryPoint = "mv_facial_landmark_configure", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Configure(IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferenceFacialLandmarkDetection, EntryPoint = "mv_facial_landmark_prepare")]
-            internal static extern MediaVisionError Prepare(IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferenceFacialLandmarkDetection, EntryPoint = "mv_facial_landmark_prepare", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Prepare(IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferenceFacialLandmarkDetection, EntryPoint = "mv_facial_landmark_inference")]
-            internal static extern MediaVisionError Inference(IntPtr handle, IntPtr source);
+            [LibraryImport(Libraries.MediaVisionInferenceFacialLandmarkDetection, EntryPoint = "mv_facial_landmark_inference", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Inference(IntPtr handle, IntPtr source);
 
-            [DllImport(Libraries.MediaVisionInferenceFacialLandmarkDetection, EntryPoint = "mv_facial_landmark_inference_async")]
-            internal static extern MediaVisionError InferenceAsync(IntPtr handle, IntPtr source);
+            [LibraryImport(Libraries.MediaVisionInferenceFacialLandmarkDetection, EntryPoint = "mv_facial_landmark_inference_async", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError InferenceAsync(IntPtr handle, IntPtr source);
 
-            [DllImport(Libraries.MediaVisionInferenceFacialLandmarkDetection, EntryPoint = "mv_facial_landmark_get_result_count")]
-            internal static extern MediaVisionError GetResultCount(IntPtr handle, out ulong requestId, out uint count);
+            [LibraryImport(Libraries.MediaVisionInferenceFacialLandmarkDetection, EntryPoint = "mv_facial_landmark_get_result_count", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetResultCount(IntPtr handle, out ulong requestId, out uint count);
 
-            [DllImport(Libraries.MediaVisionInferenceFacialLandmarkDetection, EntryPoint = "mv_facial_landmark_get_position")]
-            internal static extern MediaVisionError GetPoints(IntPtr handle, uint index, out uint posX, out uint posY);
+            [LibraryImport(Libraries.MediaVisionInferenceFacialLandmarkDetection, EntryPoint = "mv_facial_landmark_get_position", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetPoints(IntPtr handle, uint index, out uint posX, out uint posY);
         }
 
         internal static partial class InferencePoseLandmarkDetection
         {
             // Newly added inferernce APIs
-            [DllImport(Libraries.MediaVisionInferencePoseLandmarkDetection, EntryPoint = "mv_pose_landmark_create")]
-            internal static extern MediaVisionError Create(out IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferencePoseLandmarkDetection, EntryPoint = "mv_pose_landmark_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Create(out IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferencePoseLandmarkDetection, EntryPoint = "mv_pose_landmark_destroy")]
-            internal static extern MediaVisionError Destroy(IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferencePoseLandmarkDetection, EntryPoint = "mv_pose_landmark_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Destroy(IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferencePoseLandmarkDetection, EntryPoint = "mv_pose_landmark_configure")]
-            internal static extern MediaVisionError Configure(IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferencePoseLandmarkDetection, EntryPoint = "mv_pose_landmark_configure", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Configure(IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferencePoseLandmarkDetection, EntryPoint = "mv_pose_landmark_prepare")]
-            internal static extern MediaVisionError Prepare(IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionInferencePoseLandmarkDetection, EntryPoint = "mv_pose_landmark_prepare", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Prepare(IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionInferencePoseLandmarkDetection, EntryPoint = "mv_pose_landmark_inference")]
-            internal static extern MediaVisionError Inference(IntPtr handle, IntPtr source);
+            [LibraryImport(Libraries.MediaVisionInferencePoseLandmarkDetection, EntryPoint = "mv_pose_landmark_inference", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Inference(IntPtr handle, IntPtr source);
 
-            [DllImport(Libraries.MediaVisionInferencePoseLandmarkDetection, EntryPoint = "mv_pose_landmark_inference_async")]
-            internal static extern MediaVisionError InferenceAsync(IntPtr handle, IntPtr source);
+            [LibraryImport(Libraries.MediaVisionInferencePoseLandmarkDetection, EntryPoint = "mv_pose_landmark_inference_async", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError InferenceAsync(IntPtr handle, IntPtr source);
 
-            [DllImport(Libraries.MediaVisionInferencePoseLandmarkDetection, EntryPoint = "mv_pose_landmark_get_result_count")]
-            internal static extern MediaVisionError GetResultCount(IntPtr handle, out ulong requestId, out uint count);
+            [LibraryImport(Libraries.MediaVisionInferencePoseLandmarkDetection, EntryPoint = "mv_pose_landmark_get_result_count", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetResultCount(IntPtr handle, out ulong requestId, out uint count);
 
-            [DllImport(Libraries.MediaVisionInferencePoseLandmarkDetection, EntryPoint = "mv_pose_landmark_get_position")]
-            internal static extern MediaVisionError GetPoints(IntPtr handle, uint index, out uint posX, out uint posY);
+            [LibraryImport(Libraries.MediaVisionInferencePoseLandmarkDetection, EntryPoint = "mv_pose_landmark_get_position", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetPoints(IntPtr handle, uint index, out uint posX, out uint posY);
         }
     }
 }

--- a/src/Tizen.Multimedia.Vision/Interop/Interop.MediaVision.RoiTracker.cs
+++ b/src/Tizen.Multimedia.Vision/Interop/Interop.MediaVision.RoiTracker.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia.Vision;
 
 /// <summary>
@@ -36,20 +37,20 @@ internal static partial class Interop
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             internal delegate void RoiTrackedCallback(IntPtr source, Rectangle roi, IntPtr userData = default);
 
-            [DllImport(Libraries.MediaVisionRoiTracker, EntryPoint = "mv_roi_tracker_create")]
-            internal static extern MediaVisionError Create(out IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionRoiTracker, EntryPoint = "mv_roi_tracker_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Create(out IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionRoiTracker, EntryPoint = "mv_roi_tracker_destroy")]
-            internal static extern MediaVisionError Destroy(IntPtr handle);
+            [LibraryImport(Libraries.MediaVisionRoiTracker, EntryPoint = "mv_roi_tracker_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Destroy(IntPtr handle);
 
-            [DllImport(Libraries.MediaVisionRoiTracker, EntryPoint = "mv_roi_tracker_configure")]
-            internal static extern MediaVisionError Configure(IntPtr handle, IntPtr engineConfig);
+            [LibraryImport(Libraries.MediaVisionRoiTracker, EntryPoint = "mv_roi_tracker_configure", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Configure(IntPtr handle, IntPtr engineConfig);
 
-            [DllImport(Libraries.MediaVisionRoiTracker, EntryPoint = "mv_roi_tracker_prepare")]
-            internal static extern MediaVisionError Prepare(IntPtr handle, int x, int y, int width, int height);
+            [LibraryImport(Libraries.MediaVisionRoiTracker, EntryPoint = "mv_roi_tracker_prepare", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError Prepare(IntPtr handle, int x, int y, int width, int height);
 
-            [DllImport(Libraries.MediaVisionRoiTracker, EntryPoint = "mv_roi_tracker_perform")]
-            internal static extern MediaVisionError TrackRoi(IntPtr handle, IntPtr source, RoiTrackedCallback callback,
+            [LibraryImport(Libraries.MediaVisionRoiTracker, EntryPoint = "mv_roi_tracker_perform", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError TrackRoi(IntPtr handle, IntPtr source, RoiTrackedCallback callback,
                 IntPtr userData = default);
         }
     }

--- a/src/Tizen.Multimedia.Vision/Interop/Interop.MediaVision.Surveillance.cs
+++ b/src/Tizen.Multimedia.Vision/Interop/Interop.MediaVision.Surveillance.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Multimedia.Vision;
 
 /// <summary>
@@ -33,49 +34,49 @@ internal static partial class Interop
         /// </summary>
         internal static partial class Surveillance
         {
-            [DllImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_event_trigger_create")]
-            internal static extern MediaVisionError EventTriggerCreate(string eventType, out IntPtr trigger); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_event_trigger_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError EventTriggerCreate(string eventType, out IntPtr trigger); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_event_trigger_destroy")]
-            internal static extern int EventTriggerDestroy(IntPtr trigger); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_event_trigger_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int EventTriggerDestroy(IntPtr trigger); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_get_event_trigger_type")]
-            internal static extern int GetEventTriggerType(IntPtr trigger, out string eventType); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_get_event_trigger_type", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetEventTriggerType(IntPtr trigger, out string eventType); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_set_event_trigger_roi")]
-            internal static extern MediaVisionError SetEventTriggerRoi(IntPtr trigger, int numberOfPoints, Point[] roi); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_set_event_trigger_roi", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError SetEventTriggerRoi(IntPtr trigger, int numberOfPoints, Point[] roi); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_get_event_trigger_roi")]
-            internal static extern MediaVisionError GetEventTriggerRoi(IntPtr trigger, out int numberOfPoints, out IntPtr roi); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_get_event_trigger_roi", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetEventTriggerRoi(IntPtr trigger, out int numberOfPoints, out IntPtr roi); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_subscribe_event_trigger")]
-            internal static extern MediaVisionError SubscribeEventTrigger(IntPtr trigger, int videoStreamId,
+            [LibraryImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_subscribe_event_trigger", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError SubscribeEventTrigger(IntPtr trigger, int videoStreamId,
                 IntPtr engineCfg, EventOccurredCallback callback, IntPtr userData = default(IntPtr)); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_unsubscribe_event_trigger")]
-            internal static extern MediaVisionError UnsubscribeEventTrigger(IntPtr trigger, int videoStreamId); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_unsubscribe_event_trigger", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError UnsubscribeEventTrigger(IntPtr trigger, int videoStreamId); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_push_source")]
-            internal static extern MediaVisionError PushSource(IntPtr source, int videoStreamId); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_push_source", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError PushSource(IntPtr source, int videoStreamId); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_foreach_supported_event_type")]
-            internal static extern int ForeachSupportedEventType(EventTypeCallback callback, IntPtr userData); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_foreach_supported_event_type", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int ForeachSupportedEventType(EventTypeCallback callback, IntPtr userData); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_foreach_event_result_name")]
-            internal static extern int ForeachEventResultName(string eventType, EventResultNameCallback callback,
+            [LibraryImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_foreach_event_result_name", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int ForeachEventResultName(string eventType, EventResultNameCallback callback,
                 IntPtr userData); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_get_result_value")]
-            internal static extern MediaVisionError GetResultValue(IntPtr result, string name, out int value); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_get_result_value", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetResultValue(IntPtr result, string name, out int value); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_get_result_value")]
-            internal static extern MediaVisionError GetResultValue(IntPtr result, string name, [Out] int[] value); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_get_result_value", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetResultValue(IntPtr result, string name, [Out] int[] value); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_get_result_value")]
-            internal static extern MediaVisionError GetResultValue(IntPtr result, string name, [Out] double[] value); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_get_result_value", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetResultValue(IntPtr result, string name, [Out] double[] value); // Deprecated in API 12
 
-            [DllImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_get_result_value")]
-            internal static extern MediaVisionError GetResultValue(IntPtr result, string name, [Out] Rectangle[] value); // Deprecated in API 12
+            [LibraryImport(Libraries.MediaVisionSurveillance, EntryPoint = "mv_surveillance_get_result_value", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial MediaVisionError GetResultValue(IntPtr result, string name, [Out] Rectangle[] value); // Deprecated in API 12
 
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             internal delegate void EventOccurredCallback(IntPtr trigger, IntPtr source,

--- a/src/Tizen.Multimedia/Interop/Interop.Device.cs
+++ b/src/Tizen.Multimedia/Interop/Interop.Device.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.Multimedia
 {
@@ -24,77 +25,77 @@ namespace Tizen.Multimedia
         internal static partial class AudioDevice
         {
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-            internal delegate void ConnectionChangedCallback(IntPtr device, bool isConnected, IntPtr userData);
+            internal delegate void ConnectionChangedCallback(IntPtr device, [MarshalAs(UnmanagedType.U1)] bool isConnected, IntPtr userData);
 
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-            internal delegate void RunningChangedCallback(IntPtr device, bool isRunning, IntPtr userData);
+            internal delegate void RunningChangedCallback(IntPtr device, [MarshalAs(UnmanagedType.U1)] bool isRunning, IntPtr userData);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_device_list")]
-            internal static extern AudioManagerError GetDeviceList(AudioDeviceOptions deviceMask, out IntPtr deviceList);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_device_list", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError GetDeviceList(AudioDeviceOptions deviceMask, out IntPtr deviceList);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_free_device_list")]
-            internal static extern AudioManagerError FreeDeviceList(IntPtr deviceList);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_free_device_list", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError FreeDeviceList(IntPtr deviceList);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_next_device")]
-            internal static extern AudioManagerError GetNextDevice(IntPtr deviceList, out IntPtr device);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_next_device", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError GetNextDevice(IntPtr deviceList, out IntPtr device);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_device_type")]
-            internal static extern int GetDeviceType(IntPtr device, out AudioDeviceType type);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_device_type", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetDeviceType(IntPtr device, out AudioDeviceType type);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_device_io_direction")]
-            internal static extern int GetDeviceIoDirection(IntPtr device, out AudioDeviceIoDirection ioDirection);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_device_io_direction", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetDeviceIoDirection(IntPtr device, out AudioDeviceIoDirection ioDirection);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_device_id")]
-            internal static extern int GetDeviceId(IntPtr device, out int id);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_device_id", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetDeviceId(IntPtr device, out int id);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_device_name")]
-            internal static extern int GetDeviceName(IntPtr device, out IntPtr name);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_device_name", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetDeviceName(IntPtr device, out IntPtr name);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_is_device_running_by_id")]
-            internal static extern AudioManagerError IsDeviceRunning(int deviceId, out bool isRunning);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_is_device_running_by_id", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError IsDeviceRunning(int deviceId, [MarshalAs(UnmanagedType.U1)] out bool isRunning);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_supported_sample_formats_by_id")]
-            internal static extern AudioManagerError GetSupportedSampleFormats(int deviceId, out IntPtr formats, out uint numberOfElements);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_supported_sample_formats_by_id", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError GetSupportedSampleFormats(int deviceId, out IntPtr formats, out uint numberOfElements);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_set_sample_format_by_id")]
-            internal static extern AudioManagerError SetSampleFormat(int deviceId, AudioSampleFormat format);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_set_sample_format_by_id", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError SetSampleFormat(int deviceId, AudioSampleFormat format);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_sample_format_by_id")]
-            internal static extern AudioManagerError GetSampleFormat(int deviceId, out AudioSampleFormat format);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_sample_format_by_id", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError GetSampleFormat(int deviceId, out AudioSampleFormat format);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_supported_sample_rates_by_id")]
-            internal static extern AudioManagerError GetSupportedSampleRates(int deviceId, out IntPtr rates, out uint numberOfElements);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_supported_sample_rates_by_id", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError GetSupportedSampleRates(int deviceId, out IntPtr rates, out uint numberOfElements);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_set_sample_rate_by_id")]
-            internal static extern AudioManagerError SetSampleRate(int deviceId, uint rate);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_set_sample_rate_by_id", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError SetSampleRate(int deviceId, uint rate);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_sample_rate_by_id")]
-            internal static extern AudioManagerError GetSampleRate(int deviceId, out uint rate);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_sample_rate_by_id", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError GetSampleRate(int deviceId, out uint rate);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_set_avoid_resampling_by_id")]
-            internal static extern AudioManagerError SetAvoidResampling(int deviceId, bool enable);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_set_avoid_resampling_by_id", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError SetAvoidResampling(int deviceId, [MarshalAs(UnmanagedType.U1)] bool enable);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_avoid_resampling_by_id")]
-            internal static extern AudioManagerError GetAvoidResampling(int deviceId, out bool enabled);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_avoid_resampling_by_id", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError GetAvoidResampling(int deviceId, [MarshalAs(UnmanagedType.U1)] out bool enabled);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_set_media_stream_only_by_id")]
-            internal static extern AudioManagerError SetMediaStreamOnly(int deviceId, bool enable);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_set_media_stream_only_by_id", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError SetMediaStreamOnly(int deviceId, [MarshalAs(UnmanagedType.U1)] bool enable);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_media_stream_only_by_id")]
-            internal static extern AudioManagerError GetMediaStreamOnly(int deviceId, out bool enabled);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_media_stream_only_by_id", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError GetMediaStreamOnly(int deviceId, [MarshalAs(UnmanagedType.U1)] out bool enabled);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_add_device_connection_changed_cb")]
+            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_add_device_connection_changed_cb", CallingConvention = CallingConvention.Cdecl)]
             internal static extern AudioManagerError AddDeviceConnectionChangedCallback(
                 AudioDeviceOptions deviceMask, ConnectionChangedCallback callback, IntPtr userData, out int id);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_remove_device_connection_changed_cb")]
+            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_remove_device_connection_changed_cb", CallingConvention = CallingConvention.Cdecl)]
             internal static extern AudioManagerError RemoveDeviceConnectionChangedCallback(int id);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_add_device_running_changed_cb")]
+            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_add_device_running_changed_cb", CallingConvention = CallingConvention.Cdecl)]
             internal static extern AudioManagerError AddDeviceRunningChangedCallback(AudioDeviceOptions deviceMask,
                 RunningChangedCallback callback, IntPtr userData, out int id);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_remove_device_running_changed_cb")]
+            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_remove_device_running_changed_cb", CallingConvention = CallingConvention.Cdecl)]
             internal static extern AudioManagerError RemoveDeviceRunningChangedCallback(int id);
         }
     }

--- a/src/Tizen.Multimedia/Interop/Interop.Ducking.cs
+++ b/src/Tizen.Multimedia/Interop/Interop.Ducking.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.Multimedia
 {
@@ -24,23 +25,23 @@ namespace Tizen.Multimedia
         internal static partial class AudioDucking
         {
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-            internal delegate void DuckingStateChangedCallback(IntPtr ducking, bool isDucked, IntPtr userData);
+            internal delegate void DuckingStateChangedCallback(IntPtr ducking, [MarshalAs(UnmanagedType.U1)] bool isDucked, IntPtr userData);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_create_stream_ducking")]
-            internal static extern AudioManagerError Create(AudioStreamType targetType,
+            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_create_stream_ducking", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern AudioManagerError Create(AudioStreamType targetType,
                 DuckingStateChangedCallback callback, IntPtr userData, out AudioDuckingHandle ducking);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_destroy_stream_ducking")]
-            internal static extern AudioManagerError Destroy(IntPtr ducking);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_destroy_stream_ducking", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError Destroy(IntPtr ducking);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_is_ducked")]
-            internal static extern AudioManagerError IsDucked(AudioDuckingHandle ducking, out bool isDucked);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_is_ducked", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError IsDucked(AudioDuckingHandle ducking, [MarshalAs(UnmanagedType.U1)] out bool isDucked);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_activate_ducking")]
-            internal static extern AudioManagerError Activate(AudioDuckingHandle ducking, uint duration, double ratio);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_activate_ducking", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError Activate(AudioDuckingHandle ducking, uint duration, double ratio);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_deactivate_ducking")]
-            internal static extern AudioManagerError Deactivate(AudioDuckingHandle ducking);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_deactivate_ducking", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError Deactivate(AudioDuckingHandle ducking);
         }
     }
 }

--- a/src/Tizen.Multimedia/Interop/Interop.EvasObject.cs
+++ b/src/Tizen.Multimedia/Interop/Interop.EvasObject.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.Multimedia
 {
@@ -23,11 +24,11 @@ namespace Tizen.Multimedia
     {
         internal static partial class EvasObject
         {
-            [DllImport("libevas.so.1")]
-            internal static extern IntPtr evas_object_image_add(IntPtr parent);
+            [LibraryImport("libevas.so.1", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial IntPtr evas_object_image_add(IntPtr parent);
 
-            [DllImport("libevas.so.1")]
-            internal static extern IntPtr evas_object_evas_get(IntPtr obj);
+            [LibraryImport("libevas.so.1", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial IntPtr evas_object_evas_get(IntPtr obj);
         }
     }
 }

--- a/src/Tizen.Multimedia/Interop/Interop.Libc.cs
+++ b/src/Tizen.Multimedia/Interop/Interop.Libc.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.Multimedia
 {
@@ -23,17 +24,17 @@ namespace Tizen.Multimedia
     {
         internal static partial class Libc
         {
-            internal static class AccessMode
+            internal static partial class AccessMode
             {
                 internal const int W_OK = 0x02;
                 internal const int R_OK = 0x04;
             }
 
-            [DllImport(Libraries.Libc, EntryPoint = "free", CallingConvention = CallingConvention.Cdecl)]
-            public static extern void Free(IntPtr ptr);
+            [LibraryImport(Libraries.Libc, EntryPoint = "free", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Free(IntPtr ptr);
 
-            [DllImport(Libraries.Libc, EntryPoint = "access", CallingConvention = CallingConvention.Cdecl)]
-            public static extern int Access(string path, int mode);
+            [LibraryImport(Libraries.Libc, EntryPoint = "access", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int Access(string path, int mode);
         }
     }
 }

--- a/src/Tizen.Multimedia/Interop/Interop.MediaTool.cs
+++ b/src/Tizen.Multimedia/Interop/Interop.MediaTool.cs
@@ -16,216 +16,217 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.Multimedia
 {
     internal static partial class Interop
     {
-        internal static class MediaPacket
+        internal static partial class MediaPacket
         {
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             internal delegate void DisposedCallback(IntPtr handle, IntPtr userData);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_create")]
-            internal static extern int Create(IntPtr format, IntPtr finalizeCb, IntPtr cbData, out IntPtr handle);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Create(IntPtr format, IntPtr finalizeCb, IntPtr cbData, out IntPtr handle);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_alloc")]
-            internal static extern int Alloc(IntPtr handle);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_alloc", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Alloc(IntPtr handle);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_destroy")]
-            internal static extern int Destroy(IntPtr handle);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Destroy(IntPtr handle);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_new")]
-            internal static extern int New(IntPtr format, IntPtr disposedCb, IntPtr cbData, out IntPtr handle);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_new", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int New(IntPtr format, IntPtr disposedCb, IntPtr cbData, out IntPtr handle);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_ref")]
-            internal static extern int Ref(IntPtr handle);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_ref", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Ref(IntPtr handle);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_unref")]
-            internal static extern int Unref(IntPtr handle);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_unref", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Unref(IntPtr handle);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_add_dispose_cb")]
+            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_add_dispose_cb", CallingConvention = CallingConvention.Cdecl)]
             internal static extern int AddDisposedCallback(IntPtr handle, DisposedCallback disposedCb, IntPtr userData, out int callbackId);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_get_format")]
-            internal static extern int GetFormat(IntPtr handle, out IntPtr format);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_get_format", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetFormat(IntPtr handle, out IntPtr format);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_get_buffer_data_ptr")]
-            internal static extern int GetBufferData(IntPtr handle, out IntPtr dataHandle);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_get_buffer_data_ptr", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetBufferData(IntPtr handle, out IntPtr dataHandle);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_get_buffer_size")]
-            internal static extern int GetBufferSize(IntPtr handle, out ulong size);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_get_buffer_size", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetBufferSize(IntPtr handle, out ulong size);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_set_buffer_size")]
-            internal static extern int SetBufferSize(IntPtr handle, ulong size);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_set_buffer_size", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetBufferSize(IntPtr handle, ulong size);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_get_allocated_buffer_size")]
-            internal static extern int GetAllocatedBufferSize(IntPtr handle, out int size);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_get_allocated_buffer_size", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetAllocatedBufferSize(IntPtr handle, out int size);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_get_number_of_video_planes")]
-            internal static extern int GetNumberOfVideoPlanes(IntPtr handle, out uint num);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_get_number_of_video_planes", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetNumberOfVideoPlanes(IntPtr handle, out uint num);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_get_video_stride_width")]
-            internal static extern int GetVideoStrideWidth(IntPtr handle, int planeIndex, out int value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_get_video_stride_width", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetVideoStrideWidth(IntPtr handle, int planeIndex, out int value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_get_video_stride_height")]
-            internal static extern int GetVideoStrideHeight(IntPtr handle, int planeIndex, out int value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_get_video_stride_height", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetVideoStrideHeight(IntPtr handle, int planeIndex, out int value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_get_video_plane_data_ptr")]
-            internal static extern int GetVideoPlaneData(IntPtr handle, int planeIndex, out IntPtr dataHandle);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_get_video_plane_data_ptr", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetVideoPlaneData(IntPtr handle, int planeIndex, out IntPtr dataHandle);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_is_encoded")]
-            internal static extern int IsEncoded(IntPtr handle, out bool value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_is_encoded", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int IsEncoded(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_get_flags")]
-            internal static extern int GetBufferFlags(IntPtr handle, out MediaPacketBufferFlags value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_get_flags", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetBufferFlags(IntPtr handle, out MediaPacketBufferFlags value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_set_flags")]
-            internal static extern int SetBufferFlags(IntPtr handle, int value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_set_flags", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetBufferFlags(IntPtr handle, int value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_reset_flags")]
-            internal static extern int ResetBufferFlags(IntPtr handle);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_reset_flags", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int ResetBufferFlags(IntPtr handle);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_get_pts")]
-            internal static extern int GetPts(IntPtr handle, out ulong value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_get_pts", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetPts(IntPtr handle, out ulong value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_get_dts")]
-            internal static extern int GetDts(IntPtr handle, out ulong value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_get_dts", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetDts(IntPtr handle, out ulong value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_set_pts")]
-            internal static extern int SetPts(IntPtr handle, ulong value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_set_pts", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetPts(IntPtr handle, ulong value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_set_dts")]
-            internal static extern int SetDts(IntPtr handle, ulong value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_set_dts", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetDts(IntPtr handle, ulong value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_set_extra")]
-            internal static extern int SetExtra(IntPtr handle, IntPtr value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_set_extra", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetExtra(IntPtr handle, IntPtr value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_get_extra")]
-            internal static extern int GetExtra(IntPtr handle, out IntPtr value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_get_extra", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetExtra(IntPtr handle, out IntPtr value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_set_rotate_method")]
-            internal static extern int SetRotation(IntPtr handle, RotationFlip rotationFlip);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_set_rotate_method", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetRotation(IntPtr handle, RotationFlip rotationFlip);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_get_rotate_method")]
-            internal static extern int GetRotation(IntPtr handle, out RotationFlip rotationFlip);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_get_rotate_method", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetRotation(IntPtr handle, out RotationFlip rotationFlip);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_set_duration")]
-            internal static extern int SetDuration(IntPtr handle, ulong value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_set_duration", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetDuration(IntPtr handle, ulong value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_get_duration")]
-            internal static extern int GetDuration(IntPtr handle, out ulong value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_get_duration", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetDuration(IntPtr handle, out ulong value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_get_tbm_surface")]
-            internal static extern int GetTbmSurface(IntPtr handle, out IntPtr surface);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_get_tbm_surface", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetTbmSurface(IntPtr handle, out IntPtr surface);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_has_tbm_surface_buffer")]
-            internal static extern int HasTbmSurface(IntPtr handle, out bool hasTbmSurface);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_packet_has_tbm_surface_buffer", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int HasTbmSurface(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool hasTbmSurface);
 
         }
 
-        internal static class MediaFormat
+        internal static partial class MediaFormat
         {
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_create")]
-            internal static extern int Create(out IntPtr handle);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Create(out IntPtr handle);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_unref")]
-            internal static extern int Unref(IntPtr handle);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_unref", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Unref(IntPtr handle);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_get_type")]
-            internal static extern int GetType(IntPtr handle, out MediaFormatType type);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_get_type", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetType(IntPtr handle, out MediaFormatType type);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_get_container_mime")]
-            internal static extern int GetContainerMimeType(IntPtr handle,
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_get_container_mime", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetContainerMimeType(IntPtr handle,
                 out MediaFormatContainerMimeType mimeType);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_container_mime")]
-            internal static extern int SetContainerMimeType(IntPtr handle,
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_set_container_mime", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetContainerMimeType(IntPtr handle,
                 MediaFormatContainerMimeType mimeType);
 
             #region Video apis
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_get_video_info")]
-            internal static extern int GetVideoInfo(IntPtr handle, out MediaFormatVideoMimeType mimeType,
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_get_video_info", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetVideoInfo(IntPtr handle, out MediaFormatVideoMimeType mimeType,
                 out int width, out int height, out int averageBps, out int maxBps);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_get_video_frame_rate")]
-            internal static extern int GetVideoFrameRate(IntPtr handle, out int frameRate);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_get_video_frame_rate", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetVideoFrameRate(IntPtr handle, out int frameRate);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_video_mime")]
-            internal static extern int SetVideoMimeType(IntPtr handle, MediaFormatVideoMimeType value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_set_video_mime", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetVideoMimeType(IntPtr handle, MediaFormatVideoMimeType value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_video_width")]
-            internal static extern int SetVideoWidth(IntPtr handle, int value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_set_video_width", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetVideoWidth(IntPtr handle, int value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_video_height")]
-            internal static extern int SetVideoHeight(IntPtr handle, int value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_set_video_height", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetVideoHeight(IntPtr handle, int value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_video_avg_bps")]
-            internal static extern int SetVideoAverageBps(IntPtr handle, int value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_set_video_avg_bps", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetVideoAverageBps(IntPtr handle, int value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_video_max_bps")]
-            internal static extern int SetVideoMaxBps(IntPtr handle, int value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_set_video_max_bps", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetVideoMaxBps(IntPtr handle, int value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_video_frame_rate")]
-            internal static extern int SetVideoFrameRate(IntPtr handle, int value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_set_video_frame_rate", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetVideoFrameRate(IntPtr handle, int value);
             #endregion
 
             #region Audio apis
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_get_audio_info")]
-            internal static extern int GetAudioInfo(IntPtr handle, out MediaFormatAudioMimeType mimeType,
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_get_audio_info", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetAudioInfo(IntPtr handle, out MediaFormatAudioMimeType mimeType,
                 out int channel, out int sampleRate, out int bit, out int averageBps);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_get_audio_aac_header_type")]
-            internal static extern int GetAudioAacType(IntPtr handle, out MediaFormatAacType aacType);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_get_audio_aac_header_type", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetAudioAacType(IntPtr handle, out MediaFormatAacType aacType);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_audio_mime")]
-            internal static extern int SetAudioMimeType(IntPtr handle, MediaFormatAudioMimeType value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_set_audio_mime", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetAudioMimeType(IntPtr handle, MediaFormatAudioMimeType value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_audio_channel")]
-            internal static extern int SetAudioChannel(IntPtr handle, int value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_set_audio_channel", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetAudioChannel(IntPtr handle, int value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_audio_samplerate")]
-            internal static extern int SetAudioSampleRate(IntPtr handle, int value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_set_audio_samplerate", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetAudioSampleRate(IntPtr handle, int value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_audio_bit")]
-            internal static extern int SetAudioBit(IntPtr handle, int value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_set_audio_bit", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetAudioBit(IntPtr handle, int value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_audio_avg_bps")]
-            internal static extern int SetAudioAverageBps(IntPtr handle, int value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_set_audio_avg_bps", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetAudioAverageBps(IntPtr handle, int value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_audio_aac_header_type")]
-            internal static extern int SetAudioAacType(IntPtr handle, MediaFormatAacType value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_set_audio_aac_header_type", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetAudioAacType(IntPtr handle, MediaFormatAacType value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_audio_channel_mask")]
-            internal static extern int SetAudioChannelMask(IntPtr handle, ulong mask);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_set_audio_channel_mask", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetAudioChannelMask(IntPtr handle, ulong mask);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_get_audio_channel_mask")]
-            internal static extern int GetAudioChannelMask(IntPtr handle, out ulong mask);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_get_audio_channel_mask", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetAudioChannelMask(IntPtr handle, out ulong mask);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_is_little_endian")]
-            internal static extern int IsLittleEndian(IntPtr handle, out bool isLittleEndian);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_is_little_endian", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int IsLittleEndian(IntPtr handle, [MarshalAs(UnmanagedType.U1)] out bool isLittleEndian);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_get_audio_bit_depth")]
-            internal static extern int GetAudioBitDepth(IntPtr handle, out int bitDepth);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_get_audio_bit_depth", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetAudioBitDepth(IntPtr handle, out int bitDepth);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_channel_positions_from_mask")]
+            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_channel_positions_from_mask", CallingConvention = CallingConvention.Cdecl)]
             internal static extern int GetChannelPositionFromMask(IntPtr handle, ulong mask,
                 ref MediaFormatAudioChannelPosition[] position);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_channel_positions_to_mask")]
+            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_channel_positions_to_mask", CallingConvention = CallingConvention.Cdecl)]
             internal static extern int GetMaskFromChannelPosition(IntPtr handle,
                 MediaFormatAudioChannelPosition[] position, out ulong mask);
             #endregion
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_get_text_info")]
-            internal static extern int GetTextInfo(IntPtr handle,
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_get_text_info", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetTextInfo(IntPtr handle,
                 out MediaFormatTextMimeType mimeType, out MediaFormatTextType textType);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_text_mime")]
-            internal static extern int SetTextMimeType(IntPtr handle, MediaFormatTextMimeType value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_set_text_mime", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetTextMimeType(IntPtr handle, MediaFormatTextMimeType value);
 
-            [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_text_type")]
-            internal static extern int SetTextType(IntPtr handle, MediaFormatTextType value);
+            [LibraryImport(Libraries.MediaTool, EntryPoint = "media_format_set_text_type", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetTextType(IntPtr handle, MediaFormatTextType value);
         }
     }
 }

--- a/src/Tizen.Multimedia/Interop/Interop.StreamPolicy.cs
+++ b/src/Tizen.Multimedia/Interop/Interop.StreamPolicy.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.Multimedia
 {
@@ -33,78 +34,79 @@ namespace Tizen.Multimedia
                 AudioStreamFocusState focusState, AudioStreamFocusChangedReason reason, string extraInfo,
                 IntPtr userData);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_create_stream_information")]
-            internal static extern AudioManagerError Create(AudioStreamType streamType,
+            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_create_stream_information", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern AudioManagerError Create(AudioStreamType streamType,
                 FocusStateChangedCallback callback, IntPtr userData, out AudioStreamPolicyHandle streamInfo);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_destroy_stream_information")]
-            internal static extern AudioManagerError Destroy(IntPtr streamInfo);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_destroy_stream_information", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError Destroy(IntPtr streamInfo);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_add_device_id_for_stream_routing")]
-            internal static extern AudioManagerError AddDeviceForStreamRouting(
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_add_device_id_for_stream_routing", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError AddDeviceForStreamRouting(
                 AudioStreamPolicyHandle streamInfo, int deviceId);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_remove_device_id_for_stream_routing")]
-            internal static extern AudioManagerError RemoveDeviceForStreamRouting(
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_remove_device_id_for_stream_routing", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError RemoveDeviceForStreamRouting(
                 AudioStreamPolicyHandle streamInfo, int device);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_apply_stream_routing")]
-            internal static extern AudioManagerError ApplyStreamRouting(AudioStreamPolicyHandle streamInfo);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_apply_stream_routing", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError ApplyStreamRouting(AudioStreamPolicyHandle streamInfo);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_set_stream_preferred_device_id")]
-            internal static extern AudioManagerError SetPreferredDevice(AudioStreamPolicyHandle streamInfo, AudioDeviceIoDirection direction, int deviceId);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_set_stream_preferred_device_id", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError SetPreferredDevice(AudioStreamPolicyHandle streamInfo, AudioDeviceIoDirection direction, int deviceId);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_stream_preferred_device")]
-            internal static extern AudioManagerError GetPreferredDevice(AudioStreamPolicyHandle streamInfo, out int inDeviceId, out int outDeviceId);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_stream_preferred_device", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError GetPreferredDevice(AudioStreamPolicyHandle streamInfo, out int inDeviceId, out int outDeviceId);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_acquire_focus")]
-            internal static extern AudioManagerError AcquireFocus(AudioStreamPolicyHandle streamInfo,
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_acquire_focus", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError AcquireFocus(AudioStreamPolicyHandle streamInfo,
                 AudioStreamFocusOptions focusMask, AudioStreamBehaviors audioStreamBehavior, string extraInfo);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_release_focus")]
-            internal static extern AudioManagerError ReleaseFocus(AudioStreamPolicyHandle streamInfo,
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_release_focus", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError ReleaseFocus(AudioStreamPolicyHandle streamInfo,
                 AudioStreamFocusOptions focusMask, AudioStreamBehaviors audioStreamBehavior, string extraInfo);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_focus_state")]
-            internal static extern int GetFocusState(AudioStreamPolicyHandle streamInfo,
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_focus_state", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetFocusState(AudioStreamPolicyHandle streamInfo,
                 out AudioStreamFocusState stateForPlayback, out AudioStreamFocusState stateForRecording);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_set_focus_reacquisition")]
-            internal static extern AudioManagerError SetFocusReacquisition(AudioStreamPolicyHandle streamInfo,
-                bool enable);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_set_focus_reacquisition", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError SetFocusReacquisition(AudioStreamPolicyHandle streamInfo,
+                [MarshalAs(UnmanagedType.U1)] bool enable);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_focus_reacquisition")]
-            internal static extern AudioManagerError GetFocusReacquisition(AudioStreamPolicyHandle streamInfo,
-                out bool enabled);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_focus_reacquisition", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError GetFocusReacquisition(AudioStreamPolicyHandle streamInfo,
+                [MarshalAs(UnmanagedType.U1)] out bool enabled);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_sound_type")]
-            internal static extern AudioManagerError GetSoundType(AudioStreamPolicyHandle streamInfo,
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_sound_type", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError GetSoundType(AudioStreamPolicyHandle streamInfo,
                 out AudioVolumeType soundType);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_add_focus_state_watch_cb")]
+            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_add_focus_state_watch_cb", CallingConvention = CallingConvention.Cdecl)]
             internal static extern AudioManagerError AddFocusStateWatchCallback(AudioStreamFocusOptions focusMask,
                 FocusStateWatchCallback callback, IntPtr userData, out int id);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_remove_focus_state_watch_cb")]
+            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_remove_focus_state_watch_cb", CallingConvention = CallingConvention.Cdecl)]
             internal static extern int RemoveFocusStateWatchCallback(int id);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_is_stream_on_device_by_id")]
-            internal static extern AudioManagerError IsStreamOnDevice(AudioStreamPolicyHandle streamInfo, int deviceId,
-                out bool isOn);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_is_stream_on_device_by_id", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError IsStreamOnDevice(AudioStreamPolicyHandle streamInfo, int deviceId,
+                [MarshalAs(UnmanagedType.U1)] out bool isOn);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_set_effect_method_with_reference_by_id")]
-            internal static extern AudioManagerError SetSoundEffectWithReference(AudioStreamPolicyHandle streamInfo,
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_set_effect_method_with_reference_by_id", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError SetSoundEffectWithReference(AudioStreamPolicyHandle streamInfo,
                 SoundEffectWithReferenceNative effect, int deviceId);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_effect_method_with_reference")]
-            internal static extern AudioManagerError GetSoundEffectWithReference(AudioStreamPolicyHandle streamInfo,
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_effect_method_with_reference", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError GetSoundEffectWithReference(AudioStreamPolicyHandle streamInfo,
                 out SoundEffectWithReferenceNative effect, out int deviceId);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_set_effect_method")]
-            internal static extern AudioManagerError SetSoundEffect(AudioStreamPolicyHandle streamInfo, int effect);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_set_effect_method", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError SetSoundEffect(AudioStreamPolicyHandle streamInfo, int effect);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_effect_method")]
-            internal static extern AudioManagerError GetSoundEffect(AudioStreamPolicyHandle streamInfo, out int effect);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_effect_method", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError GetSoundEffect(AudioStreamPolicyHandle streamInfo, out int effect);
         }
     }
 }
+

--- a/src/Tizen.Multimedia/Interop/Interop.Volume.cs
+++ b/src/Tizen.Multimedia/Interop/Interop.Volume.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.Multimedia
 {
@@ -26,23 +27,23 @@ namespace Tizen.Multimedia
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             internal delegate void VolumeChangedCallback(AudioVolumeType type, uint volume, IntPtr userData);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_max_volume")]
-            internal static extern AudioManagerError GetMaxVolume(AudioVolumeType type, out int max);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_max_volume", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError GetMaxVolume(AudioVolumeType type, out int max);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_set_volume")]
-            internal static extern AudioManagerError SetVolume(AudioVolumeType type, int volume);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_set_volume", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError SetVolume(AudioVolumeType type, int volume);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_volume")]
-            internal static extern AudioManagerError GetVolume(AudioVolumeType type, out int volume);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_volume", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError GetVolume(AudioVolumeType type, out int volume);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_current_sound_type")]
-            internal static extern AudioManagerError GetCurrentSoundType(out AudioVolumeType type);
+            [LibraryImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_current_sound_type", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial AudioManagerError GetCurrentSoundType(out AudioVolumeType type);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_add_volume_changed_cb")]
+            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_add_volume_changed_cb", CallingConvention = CallingConvention.Cdecl)]
             internal static extern AudioManagerError AddVolumeChangedCallback(VolumeChangedCallback callback,
                 IntPtr userData, out int id);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_remove_volume_changed_cb")]
+            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_remove_volume_changed_cb", CallingConvention = CallingConvention.Cdecl)]
             internal static extern AudioManagerError RemoveVolumeChangedCallback(int id);
         }
     }

--- a/src/Tizen.Network.Bluetooth/Interop/Interop.Bluetooth.cs
+++ b/src/Tizen.Network.Bluetooth/Interop/Interop.Bluetooth.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -17,6 +17,7 @@
 using System;
 using Tizen.Network.Bluetooth;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
@@ -40,7 +41,7 @@ internal static partial class Interop
         internal delegate void DiscoveryStateChangedCallback(int result, BluetoothDeviceDiscoveryState state, IntPtr deviceInfo, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool BondedDeviceCallback([MarshalAs(UnmanagedType.Struct)]ref BluetoothDeviceStruct device, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool BondedDeviceCallback([MarshalAs(UnmanagedType.Struct)]ref BluetoothDeviceStruct device, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void BondCreatedCallback(int result, [MarshalAs(UnmanagedType.Struct)]ref BluetoothDeviceStruct device, IntPtr userData);
@@ -51,9 +52,9 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void ServiceSearchedCallback(int result, [MarshalAs(UnmanagedType.Struct)]ref BluetoothDeviceSdpStruct sdp, IntPtr userData);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void DeviceConnectionStateChangedCallback(bool connected, [MarshalAs(UnmanagedType.Struct)]ref BluetoothDeviceConnectionStruct device, IntPtr userData);
+        internal delegate void DeviceConnectionStateChangedCallback([MarshalAs(UnmanagedType.U1)] bool connected, [MarshalAs(UnmanagedType.Struct)]ref BluetoothDeviceConnectionStruct device, IntPtr userData);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool ConnectedProfileCallback(int profile, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool ConnectedProfileCallback(int profile, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void DataReceivedCallback([MarshalAs(UnmanagedType.Struct)]ref SocketDataStruct socketData, IntPtr userData);
@@ -61,7 +62,7 @@ internal static partial class Interop
         internal delegate void SocketConnectionStateChangedCallback(int result, BluetoothSocketState connectionState, [MarshalAs(UnmanagedType.Struct)]ref SocketConnectionStruct socketConnection, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void AudioConnectionStateChangedCallback(int result, bool connected, string deviceAddress, int profileType, IntPtr userData);
+        internal delegate void AudioConnectionStateChangedCallback(int result, [MarshalAs(UnmanagedType.U1)] bool connected, string deviceAddress, int profileType, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void ConnectionRequestedCallback(string deviceAddress, IntPtr userData);
@@ -81,7 +82,7 @@ internal static partial class Interop
         internal delegate void PushFinishedCallback(int result, string deviceAddress, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void TargetConnectionStateChangedCallback(bool connected, string deviceAddress, IntPtr userData);
+        internal delegate void TargetConnectionStateChangedCallback([MarshalAs(UnmanagedType.U1)] bool connected, string deviceAddress, IntPtr userData);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void EqualizerStateChangedCallback(int equalizer, IntPtr userData);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -92,7 +93,7 @@ internal static partial class Interop
         internal delegate void ScanModeChangedCallback(int scan, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void AvrcpControlConnectionChangedCallback(bool connected, string remoteAddress, IntPtr userData);
+        internal delegate void AvrcpControlConnectionChangedCallback([MarshalAs(UnmanagedType.U1)] bool connected, string remoteAddress, IntPtr userData);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void PositionChangedCallback(uint position, IntPtr userData);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -101,13 +102,13 @@ internal static partial class Interop
         internal delegate void TrackInfoChangedCallback([MarshalAs(UnmanagedType.Struct)]ref TrackInfoStruct track, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void ConnectionChangedCallback(int result, bool connected, string deviceAddress, IntPtr userData);
+        internal delegate void ConnectionChangedCallback(int result, [MarshalAs(UnmanagedType.U1)] bool connected, string deviceAddress, IntPtr userData);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void ClientCharacteristicValueChangedCallback(IntPtr characteristicHandle, string value, int len, IntPtr userData);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void GattClientRequestedCallback(int result, IntPtr handle, IntPtr userData);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool GattForEachCallback(int total, int index, IntPtr handle, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool GattForEachCallback(int total, int index, IntPtr handle, IntPtr userData);
 
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_initialize")]
         internal static extern int Initialize();
@@ -131,7 +132,7 @@ internal static partial class Interop
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_adapter_get_visibility")]
         internal static extern int GetVisibility(out int visibility, out int duration);
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_adapter_is_discovering")]
-        internal static extern int IsDiscovering(out bool isDiscovering);
+        internal static extern int IsDiscovering([MarshalAs(UnmanagedType.U1)] out bool isDiscovering);
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_adapter_start_device_discovery")]
         internal static extern int StartDiscovery();
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_adapter_stop_device_discovery")]
@@ -143,7 +144,7 @@ internal static partial class Interop
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_adapter_free_device_info")]
         internal static extern int FreeDeviceInfo(IntPtr deviceInfo);
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_adapter_is_service_used")]
-        internal static extern int IsServiceUsed(string serviceUuid, out bool used);
+        internal static extern int IsServiceUsed(string serviceUuid, [MarshalAs(UnmanagedType.U1)] out bool used);
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_adapter_get_local_oob_data")]
         internal static extern int GetOobData(out IntPtr hash, out IntPtr randomizer, out int hashLen, out int randomizerLen);
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_adapter_set_remote_oob_data")]
@@ -171,7 +172,7 @@ internal static partial class Interop
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_adapter_unset_device_discovery_state_changed_cb")]
         internal static extern int UnsetDiscoveryStateChangedCallback();
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_adapter_passkey_confirmation_reply")]
-        internal static extern int PasskeyConfirmationReply(bool confirmationReply);
+        internal static extern int PasskeyConfirmationReply([MarshalAs(UnmanagedType.U1)] bool confirmationReply);
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_adapter_set_authentication_req_cb")]
         internal static extern int SetAuthenticationRequestedCallback(AuthenticationRequestedCallback stateChangedCb, IntPtr userData);
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_adapter_unset_authentication_req_cb")]
@@ -199,7 +200,7 @@ internal static partial class Interop
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_device_foreach_connected_profiles")]
         internal static extern int GetConnectedProfiles(string deviceAddress, ConnectedProfileCallback connectedProfileCb, IntPtr userData);
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_device_is_profile_connected")]
-        internal static extern int IsProfileConnected(string deviceAddress, int profile, out bool connectionStatus);
+        internal static extern int IsProfileConnected(string deviceAddress, int profile, [MarshalAs(UnmanagedType.U1)] out bool connectionStatus);
 
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_device_set_bond_created_cb")]
         internal static extern int SetBondCreatedCallback(BondCreatedCallback bondCreatedCb, IntPtr userData);
@@ -238,7 +239,7 @@ internal static partial class Interop
                             BluetoothLeAdvertisingState advertisingState, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void GattConnectionStateChangedCallBack(int result, bool connected,
+        public delegate void GattConnectionStateChangedCallBack(int result, [MarshalAs(UnmanagedType.U1)] bool connected,
                                         string remoteAddress, IntPtr userData);
 
         //Bluetooth Le Adapter Apis
@@ -284,7 +285,7 @@ internal static partial class Interop
                             out int manufDataLength);
 
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_gatt_connect")]
-        internal static extern int GattConnect(string deviceAddress, bool autoConnect);
+        internal static extern int GattConnect(string deviceAddress, [MarshalAs(UnmanagedType.U1)] bool autoConnect);
 
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_gatt_disconnect")]
         internal static extern int GattDisconnect(string deviceAddress);
@@ -324,11 +325,11 @@ internal static partial class Interop
 
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_adapter_le_set_advertising_device_name")]
         public static extern int SetAdvertisingDeviceName(IntPtr advertiserHandle, BluetoothLePacketType packetType,
-                                                bool includeName);
+                                                [MarshalAs(UnmanagedType.U1)] bool includeName);
 
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_adapter_le_set_advertising_tx_power_level")]
         public static extern int SetAdvertisingTxPowerLevel(IntPtr advertiserHandle, BluetoothLePacketType packetType,
-                                                bool includePowerLevel);
+                                                [MarshalAs(UnmanagedType.U1)] bool includePowerLevel);
 
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_adapter_le_clear_advertising_data")]
         public static extern int ClearAdvertisingData(IntPtr advertiserHandle, BluetoothLePacketType packetType);
@@ -346,7 +347,7 @@ internal static partial class Interop
 
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_adapter_le_set_advertising_connectable")]
         public static extern int SetAdvertisingConnectable(IntPtr advertiserHandle,
-                                        bool connectable);
+                                        [MarshalAs(UnmanagedType.U1)] bool connectable);
 
         //Bluetooth Socket
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -387,7 +388,7 @@ internal static partial class Interop
 
         // Bluetooth Audio
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void AgScoStateChangedCallback(int result, bool opened, IntPtr userData);
+        internal delegate void AgScoStateChangedCallback(int result, [MarshalAs(UnmanagedType.U1)] bool opened, IntPtr userData);
 
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_audio_initialize")]
         internal static extern int InitializeAudio();
@@ -408,19 +409,19 @@ internal static partial class Interop
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_ag_close_sco")]
         internal static extern int CloseAgSco();
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_ag_is_sco_opened")]
-        internal static extern int IsAgScoOpened(out bool opened);
+        internal static extern int IsAgScoOpened([MarshalAs(UnmanagedType.U1)] out bool opened);
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_ag_set_sco_state_changed_cb")]
         internal static extern int SetAgScoStateChangedCallback(AgScoStateChangedCallback scoStateChangedCb, IntPtr userData);
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_ag_unset_sco_state_changed_cb")]
         internal static extern int UnsetAgScoStateChangedCallback();
         [DllImport(Libraries.Bluetooth, EntryPoint = "bt_ag_notify_voice_recognition_state")]
-        internal static extern int NotifyAgVoiceRecognitionState(bool enable);
+        internal static extern int NotifyAgVoiceRecognitionState([MarshalAs(UnmanagedType.U1)] bool enable);
 
         // Bluetooth Hid
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void HidConnectionStateChangedCallback(int result, bool connected, string deviceAddress, IntPtr userData);
+        internal delegate void HidConnectionStateChangedCallback(int result, [MarshalAs(UnmanagedType.U1)] bool connected, string deviceAddress, IntPtr userData);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void HidDeviceConnectionStateChangedCallback(int result, bool connected, string deviceAddress, IntPtr userData);
+        internal delegate void HidDeviceConnectionStateChangedCallback(int result, [MarshalAs(UnmanagedType.U1)] bool connected, string deviceAddress, IntPtr userData);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void HidDeviceDataReceivedCallback(ref BluetoothHidDeviceReceivedDataStruct receivedData, IntPtr userData);
 
@@ -620,22 +621,22 @@ internal static partial class Interop
         // Bluetooth GATT
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
-        internal delegate bool BtGattForeachCallback(int total, int index, IntPtr gattHandle, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool BtGattForeachCallback(int total, int index, IntPtr gattHandle, IntPtr userData);
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
         internal delegate void BtGattServerReadValueRequestedCallback(string clientAddress, int requestId, IntPtr serverHandle, IntPtr gattHandle, int offset, IntPtr userData);
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
-        internal delegate void BtGattServerWriteValueRequestedCallback(string clientAddress, int requestId, IntPtr serverHandle, IntPtr gattHandle, bool response_needed, int offset, IntPtr value, int len, IntPtr userData);
+        internal delegate void BtGattServerWriteValueRequestedCallback(string clientAddress, int requestId, IntPtr serverHandle, IntPtr gattHandle, [MarshalAs(UnmanagedType.U1)] bool response_needed, int offset, IntPtr value, int len, IntPtr userData);
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
         internal delegate void BtClientCharacteristicValueChangedCallback(IntPtr characteristicHandle, IntPtr value, int len, IntPtr userData);
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
-        internal delegate void BtGattServerNotificationStateChangeCallback(bool notify, IntPtr serverHandle, IntPtr characteristicHandle, IntPtr userData);
+        internal delegate void BtGattServerNotificationStateChangeCallback([MarshalAs(UnmanagedType.U1)] bool notify, IntPtr serverHandle, IntPtr characteristicHandle, IntPtr userData);
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
-        internal delegate void BtGattServerNotificationSentCallback(int result, string clientAddress, IntPtr serverHandle, IntPtr characteristicHandle, bool completed, IntPtr userData);
+        internal delegate void BtGattServerNotificationSentCallback(int result, string clientAddress, IntPtr serverHandle, IntPtr characteristicHandle, [MarshalAs(UnmanagedType.U1)] bool completed, IntPtr userData);
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
         internal delegate void BtGattClientRequestCompletedCallback(int result, IntPtr requestHandle, IntPtr userData);
@@ -842,5 +843,11 @@ internal static partial class Interop
         internal static extern int BtGattServerGetDeviceMtu(string remoteAddress, out int mtu);
     }
 }
+
+
+
+
+
+
 
 

--- a/src/Tizen.Network.Bluetooth/Interop/Interop.Glib.cs
+++ b/src/Tizen.Network.Bluetooth/Interop/Interop.Glib.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,18 +16,23 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
     internal static partial class Glib
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool GSourceFunc(IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool GSourceFunc(IntPtr userData);
 
-        [DllImport(Libraries.Glib, EntryPoint = "g_idle_add", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern uint IdleAdd(GSourceFunc d, IntPtr data);
+        [LibraryImport(Libraries.Glib, EntryPoint = "g_idle_add", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial uint IdleAdd(GSourceFunc d, IntPtr data);
 
-        [DllImport(Libraries.Glib, EntryPoint = "g_free", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void Gfree(IntPtr ptr);
+        [LibraryImport(Libraries.Glib, EntryPoint = "g_free", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void Gfree(IntPtr ptr);
     }
 }
+
+
+
+

--- a/src/Tizen.Network.Bluetooth/Interop/Interop.Libc.cs
+++ b/src/Tizen.Network.Bluetooth/Interop/Interop.Libc.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,12 +16,16 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
     internal static partial class Libc
     {
-        [DllImport(Libraries.Libc, EntryPoint = "free", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int Free(IntPtr ptr);
+        [LibraryImport(Libraries.Libc, EntryPoint = "free", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Free(IntPtr ptr);
     }
 }
+
+
+

--- a/src/Tizen.Network.Bluetooth/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Network.Bluetooth/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -23,3 +23,6 @@ internal static partial class Interop
         public const string Libc = "libc.so.6";
     }
 }
+
+
+

--- a/src/Tizen.Network.Connection/Interop/Interop.Connection.cs
+++ b/src/Tizen.Network.Connection/Interop/Interop.Connection.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Network.Connection;
 
 internal static partial class Interop
@@ -31,118 +32,119 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void ConnectionCallback(ConnectionError result, IntPtr userData);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate bool IPv6AddressCallback(IntPtr ipv6, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] public delegate bool IPv6AddressCallback(IntPtr ipv6, IntPtr userData);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_create")]
-        public static extern int Create(out IntPtr handle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_create", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int Create(out IntPtr handle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_destroy")]
-        public static extern int Destroy(IntPtr handle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int Destroy(IntPtr handle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_get_type")]
-        public static extern int GetType(IntPtr handle, out int type);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_get_type", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetType(IntPtr handle, out int type);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_get_ip_address")]
-        public static extern int GetIPAddress(IntPtr handle, int family, out IntPtr address);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_get_ip_address", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetIPAddress(IntPtr handle, int family, out IntPtr address);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_foreach_ipv6_address")]
-        public static extern int GetAllIPv6Addresses(IntPtr handle, int type, IPv6AddressCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_foreach_ipv6_address", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetAllIPv6Addresses(IntPtr handle, int type, IPv6AddressCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_get_proxy")]
-        public static extern int GetProxy(IntPtr handle, int family, out IntPtr address);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_get_proxy", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetProxy(IntPtr handle, int family, out IntPtr address);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_get_mac_address")]
-        public static extern int GetMacAddress(IntPtr handle, int family, out IntPtr address);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_get_mac_address", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetMacAddress(IntPtr handle, int family, out IntPtr address);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_get_wifi_state")]
-        public static extern int GetWiFiState(IntPtr handle, out int state);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_get_wifi_state", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetWiFiState(IntPtr handle, out int state);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_get_cellular_state")]
-        public static extern int GetCellularState(IntPtr handle, out int state);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_get_cellular_state", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetCellularState(IntPtr handle, out int state);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_get_ethernet_state")]
-        public static extern int GetEthernetState(IntPtr handle, out int state);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_get_ethernet_state", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetEthernetState(IntPtr handle, out int state);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_get_ethernet_cable_state")]
-        public static extern int GetEthernetCableState(IntPtr handle, out int state);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_get_ethernet_cable_state", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetEthernetCableState(IntPtr handle, out int state);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_get_bt_state")]
-        public static extern int GetBtState(IntPtr handle, out int state);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_get_bt_state", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetBtState(IntPtr handle, out int state);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_get_statistics")]
-        public static extern int GetStatistics(IntPtr handle, int connectionType, int statisticsType, out long size);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_get_statistics", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetStatistics(IntPtr handle, int connectionType, int statisticsType, out long size);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_reset_statistics")]
-        public static extern int ResetStatistics(IntPtr handle, int connectionType, int statisticsType);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_reset_statistics", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int ResetStatistics(IntPtr handle, int connectionType, int statisticsType);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_add_route_entry")]
-        public static extern int AddRoute(IntPtr handle, AddressFamily family, string interfaceName, string address, string gateway);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_add_route_entry", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int AddRoute(IntPtr handle, AddressFamily family, string interfaceName, string address, string gateway);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_remove_route_entry")]
-        public static extern int RemoveRoute(IntPtr handle, AddressFamily family, string interfaceName, string address, string gateway);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_remove_route_entry", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int RemoveRoute(IntPtr handle, AddressFamily family, string interfaceName, string address, string gateway);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_set_type_changed_cb")]
-        public static extern int SetTypeChangedCallback(IntPtr handle, ConnectionTypeChangedCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_set_type_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetTypeChangedCallback(IntPtr handle, ConnectionTypeChangedCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_set_ip_address_changed_cb")]
-        public static extern int SetIPAddressChangedCallback(IntPtr handle, ConnectionAddressChangedCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_set_ip_address_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetIPAddressChangedCallback(IntPtr handle, ConnectionAddressChangedCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_set_ethernet_cable_state_changed_cb")]
-        public static extern int SetEthernetCableStateChagedCallback(IntPtr handle, EthernetCableStateChangedCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_set_ethernet_cable_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetEthernetCableStateChagedCallback(IntPtr handle, EthernetCableStateChangedCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_set_proxy_address_changed_cb")]
-        public static extern int SetProxyAddressChangedCallback(IntPtr handle, ConnectionAddressChangedCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_set_proxy_address_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetProxyAddressChangedCallback(IntPtr handle, ConnectionAddressChangedCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_unset_type_changed_cb")]
-        public static extern int UnsetTypeChangedCallback(IntPtr handle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_unset_type_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int UnsetTypeChangedCallback(IntPtr handle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_unset_ip_address_changed_cb")]
-        public static extern int UnsetIPAddressChangedCallback(IntPtr handle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_unset_ip_address_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int UnsetIPAddressChangedCallback(IntPtr handle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_unset_ethernet_cable_state_changed_cb")]
-        public static extern int UnsetEthernetCableStateChagedCallback(IntPtr handle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_unset_ethernet_cable_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int UnsetEthernetCableStateChagedCallback(IntPtr handle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_unset_proxy_address_changed_cb")]
-        public static extern int UnsetProxyAddressChangedCallback(IntPtr handle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_unset_proxy_address_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int UnsetProxyAddressChangedCallback(IntPtr handle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_add_profile")]
-        public static extern int AddProfile(IntPtr handle, IntPtr profileHandle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_add_profile", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int AddProfile(IntPtr handle, IntPtr profileHandle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_remove_profile")]
-        public static extern int RemoveProfile(IntPtr handle, IntPtr profileHandle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_remove_profile", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int RemoveProfile(IntPtr handle, IntPtr profileHandle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_update_profile")]
-        public static extern int UpdateProfile(IntPtr handle, IntPtr profileHandle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_update_profile", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int UpdateProfile(IntPtr handle, IntPtr profileHandle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_get_default_cellular_service_profile")]
-        public static extern int GetDefaultCellularServiceProfile(IntPtr handle, int type, out IntPtr profileHandle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_get_default_cellular_service_profile", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetDefaultCellularServiceProfile(IntPtr handle, int type, out IntPtr profileHandle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_get_current_profile")]
-        public static extern int GetCurrentProfile(IntPtr handle, out IntPtr profileHandle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_get_current_profile", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetCurrentProfile(IntPtr handle, out IntPtr profileHandle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_open_profile")]
-        public static extern int OpenProfile(IntPtr handle, IntPtr profileHandle, ConnectionCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_open_profile", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int OpenProfile(IntPtr handle, IntPtr profileHandle, ConnectionCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_close_profile")]
-        public static extern int CloseProfile(IntPtr handle, IntPtr profileHandle, ConnectionCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_close_profile", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int CloseProfile(IntPtr handle, IntPtr profileHandle, ConnectionCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_reset_profile")]
-        public static extern int ResetProfile(IntPtr handle, int Option, int Id, ConnectionCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_reset_profile", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int ResetProfile(IntPtr handle, int Option, int Id, ConnectionCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_set_default_cellular_service_profile_async")]
-        public static extern int SetDefaultCellularServiceProfileAsync(IntPtr handle, int Type, IntPtr profileHandle, ConnectionCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_set_default_cellular_service_profile_async", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetDefaultCellularServiceProfileAsync(IntPtr handle, int Type, IntPtr profileHandle, ConnectionCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_get_profile_iterator")]
-        public static extern int GetProfileIterator(IntPtr handle, int type, out IntPtr iterHandle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_get_profile_iterator", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetProfileIterator(IntPtr handle, int type, out IntPtr iterHandle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_iterator_next")]
-        public static extern int GetNextProfileIterator(IntPtr iterHandle, out IntPtr profileHandle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_iterator_next", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetNextProfileIterator(IntPtr iterHandle, out IntPtr profileHandle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_iterator_has_next")]
-        public static extern bool HasNextProfileIterator(IntPtr iterHandle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_iterator_has_next", StringMarshalling = StringMarshalling.Utf8)]
+        [return: MarshalAs(UnmanagedType.U1)]
+        public static partial bool HasNextProfileIterator(IntPtr iterHandle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_destroy_profile_iterator")]
-        public static extern int DestroyProfileIterator(IntPtr iterHandle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_destroy_profile_iterator", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int DestroyProfileIterator(IntPtr iterHandle);
     }
 
     internal static partial class ConnectionProfile
@@ -150,191 +152,196 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void ProfileStateChangedCallback(ProfileState type, IntPtr userData);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_create")]
-        public static extern int Create(int ProfileType, string Keyword, out IntPtr profileHandle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_create", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int Create(int ProfileType, string Keyword, out IntPtr profileHandle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_clone")]
-        public static extern int Clone(out IntPtr cloneHandle, IntPtr profileHandle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_clone", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int Clone(out IntPtr cloneHandle, IntPtr profileHandle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_destroy")]
-        public static extern int Destroy(IntPtr profileHandle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int Destroy(IntPtr profileHandle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_id")]
-        public static extern int GetId(IntPtr profileHandle, out IntPtr profileId);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_id", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetId(IntPtr profileHandle, out IntPtr profileId);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_name")]
-        public static extern int GetName(IntPtr profileHandle, out IntPtr name);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_name", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetName(IntPtr profileHandle, out IntPtr name);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_type")]
-        public static extern int GetType(IntPtr profileHandle, out int type);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_type", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetType(IntPtr profileHandle, out int type);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_network_interface_name")]
-        public static extern int GetNetworkInterfaceName(IntPtr profileHandle, out IntPtr interfaceName);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_network_interface_name", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetNetworkInterfaceName(IntPtr profileHandle, out IntPtr interfaceName);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_state")]
-        public static extern int GetState(IntPtr profileHandle, out int type);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_state", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetState(IntPtr profileHandle, out int type);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_ipv6_state")]
-        public static extern int GetIPv6State(IntPtr profileHandle, out int type);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_ipv6_state", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetIPv6State(IntPtr profileHandle, out int type);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_ip_config_type")]
-        public static extern int GetIPConfigType(IntPtr profileHandle, int family, out int type);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_ip_config_type", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetIPConfigType(IntPtr profileHandle, int family, out int type);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_proxy_type")]
-        public static extern int GetProxyType(IntPtr profileHandle, out int type);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_proxy_type", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetProxyType(IntPtr profileHandle, out int type);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_ip_address")]
-        public static extern int GetIPAddress(IntPtr profileHandle, int family, out IntPtr address);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_ip_address", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetIPAddress(IntPtr profileHandle, int family, out IntPtr address);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_subnet_mask")]
-        public static extern int GetSubnetMask(IntPtr profileHandle, int family, out IntPtr address);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_subnet_mask", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetSubnetMask(IntPtr profileHandle, int family, out IntPtr address);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_gateway_address")]
-        public static extern int GetGatewayAddress(IntPtr profileHandle, int family, out IntPtr address);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_gateway_address", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetGatewayAddress(IntPtr profileHandle, int family, out IntPtr address);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_dns_address")]
-        public static extern int GetDnsAddress(IntPtr profileHandle, int order, int Family, out IntPtr address);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_dns_address", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetDnsAddress(IntPtr profileHandle, int order, int Family, out IntPtr address);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_proxy_address")]
-        public static extern int GetProxyAddress(IntPtr profileHandle, int family, out IntPtr address);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_proxy_address", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetProxyAddress(IntPtr profileHandle, int family, out IntPtr address);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_prefix_length")]
-        public static extern int GetPrefixLength(IntPtr profileHandle, int family, out int length);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_prefix_length", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetPrefixLength(IntPtr profileHandle, int family, out int length);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_dns_config_type")]
-        public static extern int GetDnsConfigType(IntPtr profileHandle, int family, out int type);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_dns_config_type", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetDnsConfigType(IntPtr profileHandle, int family, out int type);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_dhcp_server_address")]
-        public static extern int GetDhcpServerAddress(IntPtr profileHandle, AddressFamily family, out string dhcpServerAddress);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_dhcp_server_address", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetDhcpServerAddress(IntPtr profileHandle, AddressFamily family, out string dhcpServerAddress);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_dhcp_lease_duration")]
-        public static extern int GetDhcpLeaseDuration(IntPtr profileHandle, AddressFamily family, out int dhcpLeaseDuration);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_dhcp_lease_duration", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetDhcpLeaseDuration(IntPtr profileHandle, AddressFamily family, out int dhcpLeaseDuration);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_refresh")]
-        public static extern int Refresh(IntPtr profileHandle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_refresh", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int Refresh(IntPtr profileHandle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_set_ip_config_type")]
-        public static extern int SetIPConfigType(IntPtr profileHandle, int family, int type);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_set_ip_config_type", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetIPConfigType(IntPtr profileHandle, int family, int type);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_set_proxy_type")]
-        public static extern int SetProxyType(IntPtr profileHandle, int type);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_set_proxy_type", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetProxyType(IntPtr profileHandle, int type);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_set_ip_address")]
-        public static extern int SetIPAddress(IntPtr profileHandle, int family, string address);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_set_ip_address", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetIPAddress(IntPtr profileHandle, int family, string address);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_set_subnet_mask")]
-        public static extern int SetSubnetMask(IntPtr profileHandle, int family, string address);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_set_subnet_mask", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetSubnetMask(IntPtr profileHandle, int family, string address);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_set_gateway_address")]
-        public static extern int SetGatewayAddress(IntPtr profileHandle, int family, string address);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_set_gateway_address", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetGatewayAddress(IntPtr profileHandle, int family, string address);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_set_dns_address")]
-        public static extern int SetDnsAddress(IntPtr profileHandle, int order, int family, string address);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_set_dns_address", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetDnsAddress(IntPtr profileHandle, int order, int family, string address);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_set_proxy_address")]
-        public static extern int SetProxyAddress(IntPtr profileHandle, int family, string address);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_set_proxy_address", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetProxyAddress(IntPtr profileHandle, int family, string address);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_set_prefix_length")]
-        public static extern int SetPrefixLength(IntPtr profileHandle, int family, int length);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_set_prefix_length", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetPrefixLength(IntPtr profileHandle, int family, int length);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_set_dns_config_type")]
-        public static extern int SetDnsConfigType(IntPtr profileHandle, int family, int type);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_set_dns_config_type", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetDnsConfigType(IntPtr profileHandle, int family, int type);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_set_state_changed_cb")]
-        public static extern int SetStateChangeCallback(IntPtr profileHandle, ProfileStateChangedCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_set_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetStateChangeCallback(IntPtr profileHandle, ProfileStateChangedCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_unset_state_changed_cb")]
-        public static extern int UnsetStateChangeCallback(IntPtr profileHandle);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_unset_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int UnsetStateChangeCallback(IntPtr profileHandle);
     }
 
     internal static partial class ConnectionCellularProfile
     {
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_cellular_service_type")]
-        public static extern int GetServiceType(IntPtr profileHandle, out int type);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_cellular_service_type", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetServiceType(IntPtr profileHandle, out int type);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_cellular_apn")]
-        public static extern int GetApn(IntPtr profileHandle, out IntPtr apn);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_cellular_apn", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetApn(IntPtr profileHandle, out IntPtr apn);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_cellular_auth_info")]
-        public static extern int GetAuthInfo(IntPtr profileHandle, out int authType, out string name, out string password);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_cellular_auth_info", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetAuthInfo(IntPtr profileHandle, out int authType, out string name, out string password);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_cellular_home_url")]
-        public static extern int GetHomeUrl(IntPtr profileHandle, out IntPtr homeUrl);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_cellular_home_url", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetHomeUrl(IntPtr profileHandle, out IntPtr homeUrl);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_cellular_pdn_type")]
-        public static extern int GetPdnType(IntPtr profileHandle, out int pdnType);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_cellular_pdn_type", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetPdnType(IntPtr profileHandle, out int pdnType);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_cellular_roam_pdn_type")]
-        public static extern int GetRoamingPdnType(IntPtr profileHandle, out int roamPdnType);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_cellular_roam_pdn_type", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetRoamingPdnType(IntPtr profileHandle, out int roamPdnType);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_is_cellular_roaming")]
-        public static extern int IsRoaming(IntPtr profileHandle, out bool roaming);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_is_cellular_roaming", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int IsRoaming(IntPtr profileHandle, [MarshalAs(UnmanagedType.U1)] out bool roaming);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_is_cellular_hidden")]
-        public static extern int IsHidden(IntPtr profileHandle, out bool hidden);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_is_cellular_hidden", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int IsHidden(IntPtr profileHandle, [MarshalAs(UnmanagedType.U1)] out bool hidden);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_is_cellular_editable")]
-        public static extern int IsEditable(IntPtr profileHandle, out bool editable);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_is_cellular_editable", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int IsEditable(IntPtr profileHandle, [MarshalAs(UnmanagedType.U1)] out bool editable);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_is_cellular_default")]
-        public static extern int IsDefault(IntPtr profileHandle, out bool isDefault);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_is_cellular_default", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int IsDefault(IntPtr profileHandle, [MarshalAs(UnmanagedType.U1)] out bool isDefault);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_set_cellular_service_type")]
-        public static extern int SetServiceType(IntPtr profileHandle, int type);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_set_cellular_service_type", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetServiceType(IntPtr profileHandle, int type);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_set_cellular_apn")]
-        public static extern int SetApn(IntPtr profileHandle, string apn);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_set_cellular_apn", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetApn(IntPtr profileHandle, string apn);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_set_cellular_auth_info")]
-        public static extern int SetAuthInfo(IntPtr profileHandle, int authType, string name, string password);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_set_cellular_auth_info", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetAuthInfo(IntPtr profileHandle, int authType, string name, string password);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_set_cellular_home_url")]
-        public static extern int SetHomeUrl(IntPtr profileHandle, string homeUrl);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_set_cellular_home_url", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetHomeUrl(IntPtr profileHandle, string homeUrl);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_set_cellular_pdn_type")]
-        public static extern int SetPdnType(IntPtr profileHandle, int pdnType);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_set_cellular_pdn_type", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetPdnType(IntPtr profileHandle, int pdnType);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_set_cellular_roam_pdn_type")]
-        public static extern int SetRoamingPdnType(IntPtr profileHandle, int roamPdnType);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_set_cellular_roam_pdn_type", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetRoamingPdnType(IntPtr profileHandle, int roamPdnType);
     }
 
     internal static partial class ConnectionWiFiProfile
     {
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_wifi_essid")]
-        public static extern int GetEssid(IntPtr profileHandle, out IntPtr essid);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_wifi_essid", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetEssid(IntPtr profileHandle, out IntPtr essid);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_wifi_bssid")]
-        public static extern int GetBssid(IntPtr profileHandle, out IntPtr bssid);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_wifi_bssid", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetBssid(IntPtr profileHandle, out IntPtr bssid);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_wifi_rssi")]
-        public static extern int GetRssi(IntPtr profileHandle, out int rssi);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_wifi_rssi", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetRssi(IntPtr profileHandle, out int rssi);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_wifi_frequency")]
-        public static extern int GetFrequency(IntPtr profileHandle, out int frequency);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_wifi_frequency", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetFrequency(IntPtr profileHandle, out int frequency);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_wifi_max_speed")]
-        public static extern int GetMaxSpeed(IntPtr profileHandle, out int maxSpeed);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_wifi_max_speed", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetMaxSpeed(IntPtr profileHandle, out int maxSpeed);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_wifi_security_type")]
-        public static extern int GetSecurityType(IntPtr profileHandle, out int type);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_wifi_security_type", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetSecurityType(IntPtr profileHandle, out int type);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_get_wifi_encryption_type")]
-        public static extern int GetEncryptionType(IntPtr profileHandle, out int type);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_get_wifi_encryption_type", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GetEncryptionType(IntPtr profileHandle, out int type);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_is_wifi_passphrase_required")]
-        public static extern int IsRequiredPassphrase(IntPtr profileHandle, out bool required);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_is_wifi_passphrase_required", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int IsRequiredPassphrase(IntPtr profileHandle, [MarshalAs(UnmanagedType.U1)] out bool required);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_set_wifi_passphrase")]
-        public static extern int SetPassphrase(IntPtr profileHandle, string passphrase);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_set_wifi_passphrase", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetPassphrase(IntPtr profileHandle, string passphrase);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_profile_is_wifi_wps_supported")]
-        public static extern int IsSupportedWps(IntPtr profileHandle, out bool supported);
+        [LibraryImport(Libraries.Connection, EntryPoint = "connection_profile_is_wifi_wps_supported", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int IsSupportedWps(IntPtr profileHandle, [MarshalAs(UnmanagedType.U1)] out bool supported);
     }
 	
     internal static partial class Libc
     {
-        [DllImport(Libraries.Libc, EntryPoint = "free")]
-        public static extern void Free(IntPtr userData);
+        [LibraryImport(Libraries.Libc, EntryPoint = "free", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial void Free(IntPtr userData);
 
     }
 }
+
+
+
+
+

--- a/src/Tizen.Network.Connection/Interop/Interop.Glib.cs
+++ b/src/Tizen.Network.Connection/Interop/Interop.Glib.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,12 +16,16 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
     internal static partial class Glib
     {
-        [DllImport(Libraries.Glib, EntryPoint = "g_free", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern uint Free(IntPtr data);
+        [LibraryImport(Libraries.Glib, EntryPoint = "g_free", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial uint Free(IntPtr data);
     }
 }
+
+
+

--- a/src/Tizen.Network.Connection/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Network.Connection/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -23,3 +23,6 @@ internal static partial class Interop
         public const string Glib = "libglib-2.0.so.0";
     }
 }
+
+
+

--- a/src/Tizen.Network.IoTConnectivity/Interop/Interop.IoTConnectivity.Client.cs
+++ b/src/Tizen.Network.IoTConnectivity/Interop/Interop.IoTConnectivity.Client.cs
@@ -1,4 +1,4 @@
- /*
+﻿ /*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -17,6 +17,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
@@ -27,7 +28,7 @@ internal static partial class Interop
         {
             internal static partial class DeviceInformation
             {
-                internal delegate bool DeviceInformationCallback(IntPtr deviceInfoHandle, int result, IntPtr userData);
+                [return: MarshalAs(UnmanagedType.U1)] internal delegate bool DeviceInformationCallback(IntPtr deviceInfoHandle, int result, IntPtr userData);
 
                 internal enum Property
                 {
@@ -37,16 +38,16 @@ internal static partial class Interop
                     DataModelVersion,
                 }
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_find_device_info")]
-                internal static extern int Find(string hostAddress, int connectivityType, IntPtr query, DeviceInformationCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_find_device_info", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Find(string hostAddress, int connectivityType, IntPtr query, DeviceInformationCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_device_info_get_property")]
-                internal static extern int GetProperty(IntPtr deviceInfoHandle, int property, out IntPtr value);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_device_info_get_property", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetProperty(IntPtr deviceInfoHandle, int property, out IntPtr value);
             }
 
             internal static partial class PlatformInformation
             {
-                internal delegate bool PlatformInformationCallback(IntPtr platformInfoHandle, int result, IntPtr userData);
+                [return: MarshalAs(UnmanagedType.U1)] internal delegate bool PlatformInformationCallback(IntPtr platformInfoHandle, int result, IntPtr userData);
 
                 internal enum Propery
                 {
@@ -63,11 +64,11 @@ internal static partial class Interop
                     SystemTime
                 }
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_find_platform_info")]
-                internal static extern int Find(string hostAddress, int connectivityType, IntPtr query, PlatformInformationCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_find_platform_info", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Find(string hostAddress, int connectivityType, IntPtr query, PlatformInformationCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_platform_info_get_property")]
-                internal static extern int GetProperty(IntPtr platformInfoHandle, int property, out IntPtr value);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_platform_info_get_property", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetProperty(IntPtr platformInfoHandle, int property, out IntPtr value);
             }
 
             internal static partial class RemoteResource
@@ -93,113 +94,113 @@ internal static partial class Interop
                     Ipv6
                 }
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_create")]
-                internal static extern int Create(string hostAddress, int connectivityType, string uriPath, int properties, IntPtr resourceTypes, IntPtr resourceInterfaces, out IntPtr remoteResource);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_create", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Create(string hostAddress, int connectivityType, string uriPath, int properties, IntPtr resourceTypes, IntPtr resourceInterfaces, out IntPtr remoteResource);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_destroy")]
-                internal static extern void Destroy(IntPtr resource);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_destroy", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial void Destroy(IntPtr resource);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_clone")]
-                internal static extern int Clone(IntPtr src, out IntPtr dest);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_clone", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Clone(IntPtr src, out IntPtr dest);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_observe_register")]
-                internal static extern int RegisterObserve(IntPtr resource, int observePolicy, IntPtr query, ObserveCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_observe_register", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int RegisterObserve(IntPtr resource, int observePolicy, IntPtr query, ObserveCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_observe_deregister")]
-                internal static extern int DeregisterObserve(IntPtr resource);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_observe_deregister", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int DeregisterObserve(IntPtr resource);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get")]
-                internal static extern int Get(IntPtr resource, IntPtr query, ResponseCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Get(IntPtr resource, IntPtr query, ResponseCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_put")]
-                internal static extern int Put(IntPtr resource, IntPtr repr, IntPtr query, ResponseCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_put", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Put(IntPtr resource, IntPtr repr, IntPtr query, ResponseCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_post")]
-                internal static extern int Post(IntPtr resource, IntPtr repr, IntPtr query, ResponseCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_post", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Post(IntPtr resource, IntPtr repr, IntPtr query, ResponseCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_delete")]
-                internal static extern int Delete(IntPtr resource, ResponseCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_delete", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Delete(IntPtr resource, ResponseCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_start_caching")]
-                internal static extern int StartCaching(IntPtr resource, CachedRepresentationChangedCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_start_caching", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int StartCaching(IntPtr resource, CachedRepresentationChangedCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_stop_caching")]
-                internal static extern int StopCaching(IntPtr resource);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_stop_caching", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int StopCaching(IntPtr resource);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_start_monitoring")]
-                internal static extern int StartMonitoring(IntPtr resource, StateChangedCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_start_monitoring", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int StartMonitoring(IntPtr resource, StateChangedCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_stop_monitoring")]
-                internal static extern int StopMonitoring(IntPtr resource);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_stop_monitoring", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int StopMonitoring(IntPtr resource);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_uri_path")]
-                internal static extern int GetUriPath(IntPtr resource, out IntPtr uriPath);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_uri_path", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetUriPath(IntPtr resource, out IntPtr uriPath);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_connectivity_type")]
-                internal static extern int GetConnectivityType(IntPtr resource, out int connectivityType);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_connectivity_type", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetConnectivityType(IntPtr resource, out int connectivityType);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_host_address")]
-                internal static extern int GetHostAddress(IntPtr resource, out IntPtr hostAddress);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_host_address", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetHostAddress(IntPtr resource, out IntPtr hostAddress);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_device_id")]
-                internal static extern int GetDeviceId(IntPtr resource, out IntPtr deviceId);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_device_id", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetDeviceId(IntPtr resource, out IntPtr deviceId);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_types")]
-                internal static extern int GetTypes(IntPtr resource, out IntPtr types);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_types", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetTypes(IntPtr resource, out IntPtr types);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_interfaces")]
-                internal static extern int GetInterfaces(IntPtr resource, out IntPtr ifaces);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_interfaces", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetInterfaces(IntPtr resource, out IntPtr ifaces);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_policies")]
-                internal static extern int GetPolicies(IntPtr resource, out int properties);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_policies", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetPolicies(IntPtr resource, out int properties);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_options")]
-                internal static extern int GetOptions(IntPtr resource, out IntPtr options);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_options", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetOptions(IntPtr resource, out IntPtr options);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_set_options")]
-                internal static extern int SetOptions(IntPtr resource, IntPtr options);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_set_options", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int SetOptions(IntPtr resource, IntPtr options);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_cached_representation")]
-                internal static extern int GetCachedRepresentation(IntPtr resource, out IntPtr representation);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_cached_representation", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetCachedRepresentation(IntPtr resource, out IntPtr representation);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_checking_interval")]
-                internal static extern int GetTimeInterval(IntPtr resource, out int timeInterval);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_get_checking_interval", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetTimeInterval(IntPtr resource, out int timeInterval);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_set_checking_interval")]
-                internal static extern int SetTimeInterval(IntPtr resource, int timeInterval);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remote_resource_set_checking_interval", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int SetTimeInterval(IntPtr resource, int timeInterval);
             }
 
             internal static partial class IoTCon
             {
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_initialize")]
-                internal static extern int Initialize(string filePath);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_initialize", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Initialize(string filePath);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_deinitialize")]
-                internal static extern void Deinitialize();
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_deinitialize", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial void Deinitialize();
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_get_timeout")]
-                internal static extern int GetTimeout(out int timeoutSeconds);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_get_timeout", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetTimeout(out int timeoutSeconds);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_set_timeout")]
-                internal static extern int SetTimeout(int timeoutSeconds);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_set_timeout", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int SetTimeout(int timeoutSeconds);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_polling_get_interval")]
-                internal static extern int GetPollingInterval(out int interval);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_polling_get_interval", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetPollingInterval(out int interval);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_polling_set_interval")]
-                internal static extern int SetPollingInterval(int interval);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_polling_set_interval", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int SetPollingInterval(int interval);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_polling_invoke")]
-                internal static extern int InvokePolling();
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_polling_invoke", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int InvokePolling();
             }
 
             internal static partial class ResourceFinder
             {
                 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-                internal delegate bool FoundResourceCallback(IntPtr remoteResourceHandle, int result, IntPtr userData);
+                [return: MarshalAs(UnmanagedType.U1)] internal delegate bool FoundResourceCallback(IntPtr remoteResourceHandle, int result, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_find_resource")]
-                internal static extern int AddResourceFoundCb(string hostAddress, int connectivityType, IntPtr query, FoundResourceCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_find_resource", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int AddResourceFoundCb(string hostAddress, int connectivityType, IntPtr query, FoundResourceCallback cb, IntPtr userData);
             }
 
             internal static partial class Presence
@@ -207,39 +208,43 @@ internal static partial class Interop
                 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
                 internal delegate void PresenceCallback(IntPtr presenceResponseHandle, int err, IntPtr response, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_add_presence_cb")]
-                internal static extern int AddPresenceCb(string hostAddress, int connectivityType, string resourceType, PresenceCallback cb, IntPtr userData, out IntPtr presenceHandle);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_add_presence_cb", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int AddPresenceCb(string hostAddress, int connectivityType, string resourceType, PresenceCallback cb, IntPtr userData, out IntPtr presenceHandle);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_remove_presence_cb")]
-                internal static extern int RemovePresenceCb(IntPtr presenceHandle);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_remove_presence_cb", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int RemovePresenceCb(IntPtr presenceHandle);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_presence_get_host_address")]
-                internal static extern int GetHostAddress(IntPtr presence, out IntPtr hostAddress);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_presence_get_host_address", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetHostAddress(IntPtr presence, out IntPtr hostAddress);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_presence_get_connectivity_type")]
-                internal static extern int GetConnectivityType(IntPtr presence, out int connectivityType);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_presence_get_connectivity_type", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetConnectivityType(IntPtr presence, out int connectivityType);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_presence_get_resource_type")]
-                internal static extern int GetResourceType(IntPtr presence, out IntPtr resourceType);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_presence_get_resource_type", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetResourceType(IntPtr presence, out IntPtr resourceType);
             }
 
             internal static partial class PresenceResponse
             {
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_presence_response_get_result")]
-                internal static extern int GetResult(IntPtr response, out int result);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_presence_response_get_result", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetResult(IntPtr response, out int result);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_presence_response_get_trigger")]
-                internal static extern int GetTrigger(IntPtr response, out int trigger);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_presence_response_get_trigger", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetTrigger(IntPtr response, out int trigger);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_presence_response_get_host_address")]
-                internal static extern int GetHostAddress(IntPtr response, out IntPtr hostAddress);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_presence_response_get_host_address", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetHostAddress(IntPtr response, out IntPtr hostAddress);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_presence_response_get_connectivity_type")]
-                internal static extern int GetConnectivityType(IntPtr response, out int connectivityType);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_presence_response_get_connectivity_type", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetConnectivityType(IntPtr response, out int connectivityType);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_presence_response_get_resource_type")]
-                internal static extern int GetResourceType(IntPtr response, out IntPtr resourceType);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_presence_response_get_resource_type", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetResourceType(IntPtr response, out IntPtr resourceType);
             }
         }
     }
 }
+
+
+
+

--- a/src/Tizen.Network.IoTConnectivity/Interop/Interop.IoTConnectivity.Common.cs
+++ b/src/Tizen.Network.IoTConnectivity/Interop/Interop.IoTConnectivity.Common.cs
@@ -1,4 +1,4 @@
- /*
+﻿ /*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
@@ -40,330 +41,334 @@ internal static partial class Interop
             internal static partial class ResourceTypes
             {
                 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-                internal delegate bool ForeachCallback(string type, IntPtr userData);
+                [return: MarshalAs(UnmanagedType.U1)] internal delegate bool ForeachCallback(string type, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_types_create")]
-                internal static extern int Create(out IntPtr types);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_types_create", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Create(out IntPtr types);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_types_destroy")]
-                internal static extern void Destroy(IntPtr types);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_types_destroy", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial void Destroy(IntPtr types);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_types_add")]
-                internal static extern int Add(IntPtr types, string type);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_types_add", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Add(IntPtr types, string type);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_types_remove")]
-                internal static extern int Remove(IntPtr types, string type);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_types_remove", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Remove(IntPtr types, string type);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_types_foreach")]
-                internal static extern int Foreach(IntPtr types, ForeachCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_types_foreach", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Foreach(IntPtr types, ForeachCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_types_clone")]
-                internal static extern int Clone(IntPtr src, out IntPtr dest);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_types_clone", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Clone(IntPtr src, out IntPtr dest);
             }
 
             internal static partial class ResourceInterfaces
             {
                 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-                internal delegate bool ForeachCallback(string iface, IntPtr userData);
+                [return: MarshalAs(UnmanagedType.U1)] internal delegate bool ForeachCallback(string iface, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_interfaces_create")]
-                internal static extern int Create(out IntPtr ifaces);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_interfaces_create", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Create(out IntPtr ifaces);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_interfaces_destroy")]
-                internal static extern void Destroy(IntPtr ifaces);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_interfaces_destroy", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial void Destroy(IntPtr ifaces);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_interfaces_add")]
-                internal static extern int Add(IntPtr ifaces, string iface);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_interfaces_add", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Add(IntPtr ifaces, string iface);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_interfaces_remove")]
-                internal static extern int Remove(IntPtr ifaces, string iface);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_interfaces_remove", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Remove(IntPtr ifaces, string iface);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_interfaces_foreach")]
-                internal static extern int Foreach(IntPtr ifaces, ForeachCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_interfaces_foreach", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Foreach(IntPtr ifaces, ForeachCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_interfaces_clone")]
-                internal static extern int Clone(IntPtr src, out IntPtr dest);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_interfaces_clone", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Clone(IntPtr src, out IntPtr dest);
             }
 
             internal static partial class Attributes
             {
-                internal delegate bool AttributesCallback(IntPtr attributes, string key, IntPtr userData);
+                [return: MarshalAs(UnmanagedType.U1)] internal delegate bool AttributesCallback(IntPtr attributes, string key, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_create")]
-                internal static extern int Create(out IntPtr attributes);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_create", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Create(out IntPtr attributes);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_destroy")]
-                internal static extern void Destroy(IntPtr attributes);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_destroy", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial void Destroy(IntPtr attributes);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_clone")]
-                internal static extern int Clone(IntPtr attributes, out IntPtr attributes_clone);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_clone", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Clone(IntPtr attributes, out IntPtr attributes_clone);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_add_int")]
-                internal static extern int AddInt(IntPtr attributes, string key, int val);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_add_int", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int AddInt(IntPtr attributes, string key, int val);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_add_bool")]
-                internal static extern int AddBool(IntPtr attributes, string key, bool val);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_add_bool", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int AddBool(IntPtr attributes, string key, [MarshalAs(UnmanagedType.U1)] bool val);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_add_double")]
-                internal static extern int AddDouble(IntPtr attributes, string key, double val);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_add_double", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int AddDouble(IntPtr attributes, string key, double val);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_add_str")]
-                internal static extern int AddStr(IntPtr attributes, string key, string val);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_add_str", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int AddStr(IntPtr attributes, string key, string val);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_add_byte_str")]
-                internal static extern int AddByteStr(IntPtr attributes, string key, byte[] val, int len);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_add_byte_str", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int AddByteStr(IntPtr attributes, string key, byte[] val, int len);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_add_list")]
-                internal static extern int AddList(IntPtr attributes, string key, IntPtr list);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_add_list", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int AddList(IntPtr attributes, string key, IntPtr list);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_add_attributes")]
-                internal static extern int AddAttributes(IntPtr dest, string key, IntPtr src);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_add_attributes", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int AddAttributes(IntPtr dest, string key, IntPtr src);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_add_null")]
-                internal static extern int AddNull(IntPtr attributes, string key);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_add_null", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int AddNull(IntPtr attributes, string key);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_get_int")]
-                internal static extern int GetInt(IntPtr attributes, string key, out int val);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_get_int", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetInt(IntPtr attributes, string key, out int val);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_get_bool")]
-                internal static extern int GetBool(IntPtr attributes, string key, out bool val);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_get_bool", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetBool(IntPtr attributes, string key, [MarshalAs(UnmanagedType.U1)] out bool val);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_get_double")]
-                internal static extern int GetDouble(IntPtr attributes, string key, out double val);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_get_double", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetDouble(IntPtr attributes, string key, out double val);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_get_str")]
-                internal static extern int GetStr(IntPtr attributes, string key, out IntPtr val);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_get_str", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetStr(IntPtr attributes, string key, out IntPtr val);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_get_byte_str")]
-                internal static extern int GetByteStr(IntPtr attributes, string key, out IntPtr value, out int size);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_get_byte_str", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetByteStr(IntPtr attributes, string key, out IntPtr value, out int size);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_get_list")]
-                internal static extern int GetList(IntPtr attributes, string key, out IntPtr list);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_get_list", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetList(IntPtr attributes, string key, out IntPtr list);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_get_attributes")]
-                internal static extern int GetAttributes(IntPtr src, string key, out IntPtr dest);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_get_attributes", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetAttributes(IntPtr src, string key, out IntPtr dest);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_is_null")]
-                internal static extern int IsNull(IntPtr attributes, string key, out bool isNull);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_is_null", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int IsNull(IntPtr attributes, string key, [MarshalAs(UnmanagedType.U1)] out bool isNull);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_remove")]
-                internal static extern int Remove(IntPtr attributes, string key);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_remove", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Remove(IntPtr attributes, string key);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_get_type")]
-                internal static extern int GetType(IntPtr attributes, string key, out DataType type);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_get_type", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetType(IntPtr attributes, string key, out DataType type);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_foreach")]
-                internal static extern int Foreach(IntPtr attributes, AttributesCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_foreach", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Foreach(IntPtr attributes, AttributesCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_get_keys_count")]
-                internal static extern int GetKeysCount(IntPtr attributes, out int count);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_attributes_get_keys_count", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetKeysCount(IntPtr attributes, out int count);
             }
 
             internal static partial class Query
             {
-                internal delegate bool QueryCallback(string key, string value, IntPtr userData);
+                [return: MarshalAs(UnmanagedType.U1)] internal delegate bool QueryCallback(string key, string value, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_query_create")]
-                internal static extern int Create(out IntPtr query);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_query_create", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Create(out IntPtr query);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_query_destroy")]
-                internal static extern void Destroy(IntPtr query);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_query_destroy", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial void Destroy(IntPtr query);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_query_get_resource_type")]
-                internal static extern int GetResourceType(IntPtr query, out IntPtr resourceType);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_query_get_resource_type", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetResourceType(IntPtr query, out IntPtr resourceType);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_query_get_interface")]
-                internal static extern int GetInterface(IntPtr query, out IntPtr resourceInterface);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_query_get_interface", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetInterface(IntPtr query, out IntPtr resourceInterface);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_query_set_resource_type")]
-                internal static extern int SetResourceType(IntPtr query, string resourceType);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_query_set_resource_type", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int SetResourceType(IntPtr query, string resourceType);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_query_set_interface")]
-                internal static extern int SetInterface(IntPtr query, string resourceInterface);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_query_set_interface", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int SetInterface(IntPtr query, string resourceInterface);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_query_add")]
-                internal static extern int Add(IntPtr query, string key, string value);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_query_add", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Add(IntPtr query, string key, string value);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_query_remove")]
-                internal static extern int Remove(IntPtr query, string key);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_query_remove", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Remove(IntPtr query, string key);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_query_lookup")]
-                internal static extern int Lookup(IntPtr query, string key, out IntPtr data);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_query_lookup", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Lookup(IntPtr query, string key, out IntPtr data);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_query_foreach")]
-                internal static extern int Foreach(IntPtr query, QueryCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_query_foreach", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Foreach(IntPtr query, QueryCallback cb, IntPtr userData);
             }
 
             internal static partial class Representation
             {
-                internal delegate bool RepresentationChildrenCallback(IntPtr child, IntPtr userData);
+                [return: MarshalAs(UnmanagedType.U1)] internal delegate bool RepresentationChildrenCallback(IntPtr child, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_create")]
-                internal static extern int Create(out IntPtr repr);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_create", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Create(out IntPtr repr);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_destroy")]
-                internal static extern void Destroy(IntPtr repr);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_destroy", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial void Destroy(IntPtr repr);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_clone")]
-                internal static extern int Clone(IntPtr src, out IntPtr dest);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_clone", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Clone(IntPtr src, out IntPtr dest);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_set_uri_path")]
-                internal static extern int SetUriPath(IntPtr repr, string uriPath);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_set_uri_path", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int SetUriPath(IntPtr repr, string uriPath);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_get_uri_path")]
-                internal static extern int GetUriPath(IntPtr repr, out IntPtr uriPath);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_get_uri_path", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetUriPath(IntPtr repr, out IntPtr uriPath);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_set_resource_types")]
-                internal static extern int SetResourceTypes(IntPtr repr, IntPtr types);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_set_resource_types", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int SetResourceTypes(IntPtr repr, IntPtr types);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_get_resource_types")]
-                internal static extern int GetResourceTypes(IntPtr repr, out IntPtr types);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_get_resource_types", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetResourceTypes(IntPtr repr, out IntPtr types);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_set_resource_interfaces")]
-                internal static extern int SetResourceInterfaces(IntPtr repr, IntPtr ifaces);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_set_resource_interfaces", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int SetResourceInterfaces(IntPtr repr, IntPtr ifaces);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_get_resource_interfaces")]
-                internal static extern int GetResourceInterfaces(IntPtr repr, out IntPtr ifaces);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_get_resource_interfaces", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetResourceInterfaces(IntPtr repr, out IntPtr ifaces);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_set_attributes")]
-                internal static extern int SetAttributes(IntPtr repr, IntPtr attribs);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_set_attributes", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int SetAttributes(IntPtr repr, IntPtr attribs);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_get_attributes")]
-                internal static extern int GetAttributes(IntPtr repr, out IntPtr attribs);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_get_attributes", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetAttributes(IntPtr repr, out IntPtr attribs);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_add_child")]
-                internal static extern int AddChild(IntPtr parent, IntPtr child);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_add_child", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int AddChild(IntPtr parent, IntPtr child);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_remove_child")]
-                internal static extern int RemoveChild(IntPtr parent, IntPtr child);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_remove_child", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int RemoveChild(IntPtr parent, IntPtr child);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_foreach_children")]
-                internal static extern int ForeachChildren(IntPtr parent, RepresentationChildrenCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_foreach_children", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int ForeachChildren(IntPtr parent, RepresentationChildrenCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_get_children_count")]
-                internal static extern int GetChildrenCount(IntPtr parent, out int count);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_get_children_count", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetChildrenCount(IntPtr parent, out int count);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_get_nth_child")]
-                internal static extern int GetNthChild(IntPtr parent, int pos, out IntPtr child);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_representation_get_nth_child", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetNthChild(IntPtr parent, int pos, out IntPtr child);
             }
 
             internal static partial class Options
             {
-                internal delegate bool OptionsCallback(ushort id, string data, IntPtr userData);
+                [return: MarshalAs(UnmanagedType.U1)] internal delegate bool OptionsCallback(ushort id, string data, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_options_create")]
-                internal static extern int Create(out IntPtr options);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_options_create", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Create(out IntPtr options);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_options_destroy")]
-                internal static extern void Destroy(IntPtr options);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_options_destroy", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial void Destroy(IntPtr options);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_options_add")]
-                internal static extern int Add(IntPtr options, ushort id, string data);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_options_add", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Add(IntPtr options, ushort id, string data);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_options_remove")]
-                internal static extern int Remove(IntPtr options, ushort id);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_options_remove", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Remove(IntPtr options, ushort id);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_options_lookup")]
-                internal static extern int Lookup(IntPtr options, ushort id, out IntPtr data);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_options_lookup", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Lookup(IntPtr options, ushort id, out IntPtr data);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_options_foreach")]
-                internal static extern int ForEach(IntPtr options, OptionsCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_options_foreach", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int ForEach(IntPtr options, OptionsCallback cb, IntPtr userData);
             }
 
             internal static partial class List
             {
-                internal delegate bool IntCallback(int pos, int value, IntPtr userData);
+                [return: MarshalAs(UnmanagedType.U1)] internal delegate bool IntCallback(int pos, int value, IntPtr userData);
 
-                internal delegate bool BoolCallback(int pos, bool value, IntPtr userData);
+                [return: MarshalAs(UnmanagedType.U1)] internal delegate bool BoolCallback(int pos, [MarshalAs(UnmanagedType.U1)] bool value, IntPtr userData);
 
-                internal delegate bool DoubleCallback(int pos, double value, IntPtr userData);
+                [return: MarshalAs(UnmanagedType.U1)] internal delegate bool DoubleCallback(int pos, double value, IntPtr userData);
 
-                internal delegate bool ByteStrCallback(int pos, byte[] value, int len, IntPtr userData);
+                [return: MarshalAs(UnmanagedType.U1)] internal delegate bool ByteStrCallback(int pos, byte[] value, int len, IntPtr userData);
 
-                internal delegate bool StrCallback(int pos, string value, IntPtr userData);
+                [return: MarshalAs(UnmanagedType.U1)] internal delegate bool StrCallback(int pos, string value, IntPtr userData);
 
-                internal delegate bool ListCallback(int pos, IntPtr value, IntPtr userData);
+                [return: MarshalAs(UnmanagedType.U1)] internal delegate bool ListCallback(int pos, IntPtr value, IntPtr userData);
 
-                internal delegate bool AttribsCallback(int pos, IntPtr value, IntPtr userData);
+                [return: MarshalAs(UnmanagedType.U1)] internal delegate bool AttribsCallback(int pos, IntPtr value, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_create")]
-                internal static extern int Create(DataType type, out IntPtr list);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_create", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Create(DataType type, out IntPtr list);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_destroy")]
-                internal static extern void Destroy(IntPtr list);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_destroy", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial void Destroy(IntPtr list);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_add_int")]
-                internal static extern int AddInt(IntPtr list, int val, int pos);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_add_int", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int AddInt(IntPtr list, int val, int pos);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_add_bool")]
-                internal static extern int AddBool(IntPtr list, bool val, int pos);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_add_bool", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int AddBool(IntPtr list, [MarshalAs(UnmanagedType.U1)] bool val, int pos);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_add_double")]
-                internal static extern int AddDouble(IntPtr list, double val, int pos);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_add_double", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int AddDouble(IntPtr list, double val, int pos);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_add_str")]
-                internal static extern int AddStr(IntPtr list, string val, int pos);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_add_str", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int AddStr(IntPtr list, string val, int pos);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_add_byte_str")]
-                internal static extern int AddByteStr(IntPtr list, byte[] val, int len, int pos);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_add_byte_str", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int AddByteStr(IntPtr list, byte[] val, int len, int pos);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_add_list")]
-                internal static extern int AddList(IntPtr list, IntPtr val, int pos);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_add_list", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int AddList(IntPtr list, IntPtr val, int pos);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_add_attributes")]
-                internal static extern int AddAttributes(IntPtr list, IntPtr val, int pos);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_add_attributes", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int AddAttributes(IntPtr list, IntPtr val, int pos);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_get_nth_int")]
-                internal static extern int GetNthInt(IntPtr list, int pos, out int val);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_get_nth_int", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetNthInt(IntPtr list, int pos, out int val);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_get_nth_bool")]
-                internal static extern int GetNthBool(IntPtr list, int pos, out bool val);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_get_nth_bool", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetNthBool(IntPtr list, int pos, [MarshalAs(UnmanagedType.U1)] out bool val);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_get_nth_double")]
-                internal static extern int GetNthDouble(IntPtr list, int pos, out double val);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_get_nth_double", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetNthDouble(IntPtr list, int pos, out double val);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_get_nth_str")]
-                internal static extern int GetNthStr(IntPtr list, int pos, out IntPtr val);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_get_nth_str", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetNthStr(IntPtr list, int pos, out IntPtr val);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_get_nth_byte_str")]
-                internal static extern int GetNthByteStr(IntPtr list, int pos, out IntPtr val, out int len);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_get_nth_byte_str", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetNthByteStr(IntPtr list, int pos, out IntPtr val, out int len);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_get_nth_list")]
-                internal static extern int GetNthList(IntPtr src, int pos, out IntPtr dest);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_get_nth_list", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetNthList(IntPtr src, int pos, out IntPtr dest);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_get_nth_attributes")]
-                internal static extern int GetNthAttributes(IntPtr list, int pos, out IntPtr attribs);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_get_nth_attributes", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetNthAttributes(IntPtr list, int pos, out IntPtr attribs);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_remove_nth")]
-                internal static extern int RemoveNth(IntPtr list, int pos);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_remove_nth", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int RemoveNth(IntPtr list, int pos);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_get_type")]
-                internal static extern int GetType(IntPtr list, out int type);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_get_type", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetType(IntPtr list, out int type);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_get_length")]
-                internal static extern int GetLength(IntPtr list, out int length);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_get_length", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetLength(IntPtr list, out int length);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_foreach_int")]
-                internal static extern int ForeachInt(IntPtr list, IntCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_foreach_int", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int ForeachInt(IntPtr list, IntCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_foreach_bool")]
-                internal static extern int ForeachBool(IntPtr list, BoolCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_foreach_bool", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int ForeachBool(IntPtr list, BoolCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_foreach_double")]
-                internal static extern int ForeachDouble(IntPtr list, DoubleCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_foreach_double", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int ForeachDouble(IntPtr list, DoubleCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_foreach_byte_str")]
-                internal static extern int ForeachByteStr(IntPtr list, ByteStrCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_foreach_byte_str", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int ForeachByteStr(IntPtr list, ByteStrCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_foreach_str")]
-                internal static extern int ForeachStr(IntPtr list, StrCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_foreach_str", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int ForeachStr(IntPtr list, StrCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_foreach_list")]
-                internal static extern int ForeachList(IntPtr list, ListCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_foreach_list", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int ForeachList(IntPtr list, ListCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_list_foreach_attributes")]
-                internal static extern int ForeachAttributes(IntPtr list, AttribsCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_list_foreach_attributes", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int ForeachAttributes(IntPtr list, AttribsCallback cb, IntPtr userData);
             }
         }
     }
 }
+
+
+
+

--- a/src/Tizen.Network.IoTConnectivity/Interop/Interop.IoTConnectivity.Server.cs
+++ b/src/Tizen.Network.IoTConnectivity/Interop/Interop.IoTConnectivity.Server.cs
@@ -1,4 +1,4 @@
- /*
+﻿ /*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -17,6 +17,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
@@ -36,14 +37,14 @@ internal static partial class Interop
 
             internal static partial class IoTCon
             {
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_start_presence")]
-                internal static extern int StartPresence(uint time);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_start_presence", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int StartPresence(uint time);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_stop_presence")]
-                internal static extern int StopPresence();
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_stop_presence", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int StopPresence();
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_set_device_name")]
-                internal static extern int SetDeviceName(string deviceName);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_set_device_name", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int SetDeviceName(string deviceName);
             }
 
             internal static partial class Resource
@@ -51,120 +52,123 @@ internal static partial class Interop
                 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
                 internal delegate void RequestHandlerCallback(IntPtr resource, IntPtr request, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_create")]
-                internal static extern int Create(string uriPath, IntPtr resTypes, IntPtr ifaces, int properties, RequestHandlerCallback cb, IntPtr userData, out IntPtr resourceHandle);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_create", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Create(string uriPath, IntPtr resTypes, IntPtr ifaces, int properties, RequestHandlerCallback cb, IntPtr userData, out IntPtr resourceHandle);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_destroy")]
-                internal static extern int Destroy(IntPtr resourceHandle);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_destroy", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Destroy(IntPtr resourceHandle);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_bind_interface")]
-                internal static extern int BindInterface(IntPtr resource, string iface);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_bind_interface", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int BindInterface(IntPtr resource, string iface);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_bind_type")]
-                internal static extern int BindType(IntPtr resourceHandle, string resourceType);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_bind_type", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int BindType(IntPtr resourceHandle, string resourceType);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_set_request_handler")]
-                internal static extern int SetRequestHandler(IntPtr resource, RequestHandlerCallback cb, IntPtr userData);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_set_request_handler", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int SetRequestHandler(IntPtr resource, RequestHandlerCallback cb, IntPtr userData);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_bind_child_resource")]
-                internal static extern int BindChildResource(IntPtr parent, IntPtr child);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_bind_child_resource", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int BindChildResource(IntPtr parent, IntPtr child);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_unbind_child_resource")]
-                internal static extern int UnbindChildResource(IntPtr parent, IntPtr child);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_unbind_child_resource", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int UnbindChildResource(IntPtr parent, IntPtr child);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_notify")]
-                internal static extern int Notify(IntPtr resource, IntPtr repr, IntPtr observers, int qos);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_notify", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Notify(IntPtr resource, IntPtr repr, IntPtr observers, int qos);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_get_number_of_children")]
-                internal static extern int GetNumberOfChildren(IntPtr resource, out int number);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_get_number_of_children", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetNumberOfChildren(IntPtr resource, out int number);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_get_nth_child")]
-                internal static extern int GetNthChild(IntPtr parent, int index, out IntPtr child);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_get_nth_child", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetNthChild(IntPtr parent, int index, out IntPtr child);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_get_uri_path")]
-                internal static extern int GetUriPath(IntPtr resource, out IntPtr uriPath);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_get_uri_path", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetUriPath(IntPtr resource, out IntPtr uriPath);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_get_types")]
-                internal static extern int GetTypes(IntPtr resource, out IntPtr types);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_get_types", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetTypes(IntPtr resource, out IntPtr types);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_get_interfaces")]
-                internal static extern int GetInterfaces(IntPtr resource, out IntPtr ifaces);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_get_interfaces", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetInterfaces(IntPtr resource, out IntPtr ifaces);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_get_properties")]
-                internal static extern int GetProperties(IntPtr resource, out int properties);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_resource_get_properties", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetProperties(IntPtr resource, out int properties);
             }
 
             internal static partial class Request
             {
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_request_get_host_address")]
-                internal static extern int GetHostAddress(IntPtr request, out IntPtr hostAddress);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_request_get_host_address", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetHostAddress(IntPtr request, out IntPtr hostAddress);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_request_get_connectivity_type")]
-                internal static extern int GetConnectivityType(IntPtr request, out int connectivityType);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_request_get_connectivity_type", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetConnectivityType(IntPtr request, out int connectivityType);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_request_get_representation")]
-                internal static extern int GetRepresentation(IntPtr request, out IntPtr repr);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_request_get_representation", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetRepresentation(IntPtr request, out IntPtr repr);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_request_get_request_type")]
-                internal static extern int GetRequestType(IntPtr request, out int type);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_request_get_request_type", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetRequestType(IntPtr request, out int type);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_request_get_options")]
-                internal static extern int GetOptions(IntPtr request, out IntPtr options);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_request_get_options", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetOptions(IntPtr request, out IntPtr options);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_request_get_query")]
-                internal static extern int GetQuery(IntPtr request, out IntPtr query);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_request_get_query", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetQuery(IntPtr request, out IntPtr query);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_request_get_observe_type")]
-                internal static extern int GetObserveType(IntPtr request, out int observeType);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_request_get_observe_type", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetObserveType(IntPtr request, out int observeType);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_request_get_observe_id")]
-                internal static extern int GetObserveId(IntPtr request, out int observeId);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_request_get_observe_id", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetObserveId(IntPtr request, out int observeId);
             }
 
             internal static partial class Response
             {
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_response_create")]
-                internal static extern int Create(IntPtr request, out IntPtr response);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_response_create", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Create(IntPtr request, out IntPtr response);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_response_destroy")]
-                internal static extern void Destroy(IntPtr resp);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_response_destroy", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial void Destroy(IntPtr resp);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_response_get_options")]
-                internal static extern int GetOptions(IntPtr resp, out IntPtr options);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_response_get_options", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetOptions(IntPtr resp, out IntPtr options);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_response_get_representation")]
-                internal static extern int GetRepresentation(IntPtr resp, out IntPtr repr);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_response_get_representation", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetRepresentation(IntPtr resp, out IntPtr repr);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_response_get_result")]
-                internal static extern int GetResult(IntPtr resp, out int result);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_response_get_result", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int GetResult(IntPtr resp, out int result);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_response_set_result")]
-                internal static extern int SetResult(IntPtr resp, int result);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_response_set_result", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int SetResult(IntPtr resp, int result);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_response_set_representation")]
-                internal static extern int SetRepresentation(IntPtr resp, IntPtr repr);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_response_set_representation", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int SetRepresentation(IntPtr resp, IntPtr repr);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_response_set_options")]
-                internal static extern int SetOptions(IntPtr resp, IntPtr options);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_response_set_options", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int SetOptions(IntPtr resp, IntPtr options);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_response_send")]
-                internal static extern int Send(IntPtr resp);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_response_send", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Send(IntPtr resp);
             }
 
             internal static partial class Observers
             {
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_observers_create")]
-                internal static extern int Create(out IntPtr observers);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_observers_create", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Create(out IntPtr observers);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_observers_destroy")]
-                internal static extern void Destroy(IntPtr observers);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_observers_destroy", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial void Destroy(IntPtr observers);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_observers_add")]
-                internal static extern int Add(IntPtr observers, int observeId);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_observers_add", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Add(IntPtr observers, int observeId);
 
-                [DllImport(Libraries.IoTCon, EntryPoint = "iotcon_observers_remove")]
-                internal static extern int Remove(IntPtr observers, int observeId);
+                [LibraryImport(Libraries.IoTCon, EntryPoint = "iotcon_observers_remove", StringMarshalling = StringMarshalling.Utf8)]
+                internal static partial int Remove(IntPtr observers, int observeId);
             }
         }
     }
 }
+
+
+

--- a/src/Tizen.Network.IoTConnectivity/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Network.IoTConnectivity/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
- /*
+﻿ /*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -23,3 +23,6 @@ internal static partial class Interop
         public const string Libc = "libc.so.6";
     }
 }
+
+
+

--- a/src/Tizen.Network.Nfc/Interop/Interop.Glib.cs
+++ b/src/Tizen.Network.Nfc/Interop/Interop.Glib.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,15 +16,20 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
     internal static partial class Glib
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool GSourceFunc(IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool GSourceFunc(IntPtr userData);
 
-        [DllImport(Libraries.Glib, EntryPoint = "g_idle_add", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern uint IdleAdd(GSourceFunc d, IntPtr data);
+        [LibraryImport(Libraries.Glib, EntryPoint = "g_idle_add", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial uint IdleAdd(GSourceFunc d, IntPtr data);
     }
 }
+
+
+
+

--- a/src/Tizen.Network.Nfc/Interop/Interop.Libc.cs
+++ b/src/Tizen.Network.Nfc/Interop/Interop.Libc.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,12 +16,16 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
     internal static partial class Libc
     {
-        [DllImport(Libraries.Libc, EntryPoint = "free", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int Free(IntPtr ptr);
+        [LibraryImport(Libraries.Libc, EntryPoint = "free", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Free(IntPtr ptr);
     }
 }
+
+
+

--- a/src/Tizen.Network.Nfc/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Network.Nfc/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -23,3 +23,6 @@ internal static partial class Interop
         public const string Libc = "libc.so.6";
     }
 }
+
+
+

--- a/src/Tizen.Network.Nfc/Interop/Interop.Nfc.cs
+++ b/src/Tizen.Network.Nfc/Interop/Interop.Nfc.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
@@ -38,7 +39,7 @@ internal static partial class Interop
         internal delegate void VoidCallback(int result, IntPtr userData);
         //nfc_tag_information_cb
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool TagInformationCallback(IntPtr key, IntPtr value, int valueSize, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool TagInformationCallback(IntPtr key, IntPtr value, int valueSize, IntPtr userData);
         //nfc_tag_transceive_completed_cb
         //nfc_mifare_read_block_completed_cb
         //nfc_mifare_read_page_completed_cb
@@ -46,19 +47,19 @@ internal static partial class Interop
         internal delegate void TagTransceiveCompletedCallback(int result, IntPtr value, int bufferSize, IntPtr userData);
         //nfc_tag_read_completed_cb
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool TagReadCompletedCallback(int result, IntPtr message, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool TagReadCompletedCallback(int result, IntPtr message, IntPtr userData);
         //nfc_snep_event_cb
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void SnepEventCallback(IntPtr handle, int snepEvent, int result, IntPtr message, IntPtr userData);
         //nfc_se_registered_aid_cb
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void SecureElementRegisteredAidCallback(int seType, IntPtr aid, bool readOnly, IntPtr userData);
+        internal delegate void SecureElementRegisteredAidCallback(int seType, IntPtr aid, [MarshalAs(UnmanagedType.U1)] bool readOnly, IntPtr userData);
 
 
         //Callback for event
         //nfc_activation_changed_cb
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void ActivationChangedCallback(bool activated, IntPtr userData);
+        internal delegate void ActivationChangedCallback([MarshalAs(UnmanagedType.U1)] bool activated, IntPtr userData);
         //nfc_tag_discovered_cb
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void TagDiscoveredCallback(int type, IntPtr tag, IntPtr userData);
@@ -82,200 +83,208 @@ internal static partial class Interop
         internal delegate void HostCardEmulationEventCallback(IntPtr handle, int eventType, IntPtr apdu, uint apduLen, IntPtr userData);
 
         //capi-network-nfc-0.2.5-6.1.armv7l
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_initialize")]
-        internal static extern int Initialize();
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_deinitialize")]
-        internal static extern int Deinitialize();
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_initialize", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Initialize();
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_deinitialize", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Deinitialize();
 
         ////Nfc Manager
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_is_supported")]
-        internal static extern bool IsSupported();
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_activation")]
-        internal static extern int SetActivation(bool activation, VoidCallback callback, IntPtr userData);
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_is_activated")]
-        internal static extern bool IsActivated();
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_activation_changed_cb")]
-        internal static extern int SetActivationChangedCallback(ActivationChangedCallback callback, IntPtr userData);
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_unset_activation_changed_cb")]
-        internal static extern void UnsetActivationChangedCallback();
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_tag_discovered_cb")]
-        internal static extern int SetTagDiscoveredCallback(TagDiscoveredCallback callback, IntPtr userData);
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_unset_tag_discovered_cb")]
-        internal static extern void UnsetTagDiscoveredCallback();
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_ndef_discovered_cb")]
-        internal static extern int SetNdefDiscoveredCallback(NdefMessageDiscoveredCallback callback, IntPtr userData);
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_unset_ndef_discovered_cb")]
-        internal static extern void UnsetNdefDiscoveredCallback();
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_p2p_target_discovered_cb")]
-        internal static extern int SetP2pTargetDiscoveredCallback(P2pTargetDiscoveredCallback callback, IntPtr userData);
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_unset_p2p_target_discovered_cb")]
-        internal static extern void UnsetP2pTargetDiscoveredCallback();
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_se_event_cb")]
-        internal static extern int SetSecureElementEventCallback(SecureElementEventCallback callback, IntPtr userData);
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_unset_se_event_cb")]
-        internal static extern void UnsetSecureElementEventCallback();
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_se_transaction_event_cb")]
-        internal static extern int SetSecureElementTransactionEventCallback(int setype, SecureElementTransactionEventCallback callback, IntPtr userData);
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_unset_se_transaction_event_cb")]
-        internal static extern int UnsetSecureElementTransactionEventCallback(int setype);
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_hce_event_cb")]
-        internal static extern int SetHostCardEmulationEventCallback(HostCardEmulationEventCallback callback, IntPtr userData);
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_unset_hce_event_cb")]
-        internal static extern void UnsetHostCardEmulationEventCallback();
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_enable_transaction_fg_dispatch")]
-        internal static extern int EnableTransactionForegroundDispatch();
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_disable_transaction_fg_dispatch")]
-        internal static extern int DisableTransactionForegroundDispatch();
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_get_cached_message")]
-        internal static extern int GetCachedMessage(out IntPtr ndefMessage);
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_tag_filter")]
-        internal static extern void SetTagFilter(int filter);
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_get_tag_filter")]
-        internal static extern int GetTagFilter();
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_get_connected_tag")]
-        internal static extern int GetConnectedTag(out IntPtr tag);
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_get_connected_target")]
-        internal static extern int GetConnectedTarget(out IntPtr target);
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_system_handler_enable")]
-        internal static extern int SetSystemHandlerEnable(bool enable);
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_is_system_handler_enabled")]
-        internal static extern bool IsSystemHandlerEnabled();
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_se_type")]
-        internal static extern int SetSecureElementType(int type);
-        [DllImport(Libraries.Nfc, EntryPoint = "nfc_manager_get_se_type")]
-        internal static extern int GetSecureElementType(out int type);
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_is_supported", StringMarshalling = StringMarshalling.Utf8)]
+        [return: MarshalAs(UnmanagedType.U1)]
+        internal static partial bool IsSupported();
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_activation", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetActivation([MarshalAs(UnmanagedType.U1)] bool activation, VoidCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_is_activated", StringMarshalling = StringMarshalling.Utf8)]
+        [return: MarshalAs(UnmanagedType.U1)]
+        internal static partial bool IsActivated();
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_activation_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetActivationChangedCallback(ActivationChangedCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_unset_activation_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void UnsetActivationChangedCallback();
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_tag_discovered_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetTagDiscoveredCallback(TagDiscoveredCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_unset_tag_discovered_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void UnsetTagDiscoveredCallback();
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_ndef_discovered_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetNdefDiscoveredCallback(NdefMessageDiscoveredCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_unset_ndef_discovered_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void UnsetNdefDiscoveredCallback();
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_p2p_target_discovered_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetP2pTargetDiscoveredCallback(P2pTargetDiscoveredCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_unset_p2p_target_discovered_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void UnsetP2pTargetDiscoveredCallback();
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_se_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetSecureElementEventCallback(SecureElementEventCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_unset_se_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void UnsetSecureElementEventCallback();
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_se_transaction_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetSecureElementTransactionEventCallback(int setype, SecureElementTransactionEventCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_unset_se_transaction_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UnsetSecureElementTransactionEventCallback(int setype);
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_hce_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetHostCardEmulationEventCallback(HostCardEmulationEventCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_unset_hce_event_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void UnsetHostCardEmulationEventCallback();
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_enable_transaction_fg_dispatch", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int EnableTransactionForegroundDispatch();
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_disable_transaction_fg_dispatch", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int DisableTransactionForegroundDispatch();
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_get_cached_message", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetCachedMessage(out IntPtr ndefMessage);
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_tag_filter", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial void SetTagFilter(int filter);
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_get_tag_filter", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetTagFilter();
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_get_connected_tag", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetConnectedTag(out IntPtr tag);
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_get_connected_target", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetConnectedTarget(out IntPtr target);
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_system_handler_enable", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetSystemHandlerEnable([MarshalAs(UnmanagedType.U1)] bool enable);
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_is_system_handler_enabled", StringMarshalling = StringMarshalling.Utf8)]
+        [return: MarshalAs(UnmanagedType.U1)]
+        internal static partial bool IsSystemHandlerEnabled();
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_set_se_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetSecureElementType(int type);
+        [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_manager_get_se_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetSecureElementType(out int type);
 
         ////NDEF - NFC Data Exchange Format, TNF - Type Name Format
-        internal static class NdefRecord
+        internal static partial class NdefRecord
         {
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_create")]
-            internal static extern int Create(out IntPtr record, int tnf, byte[] type, int typeSize, byte[] id, int idSize, byte[] payload, uint payloadSize);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_create_text")]
-            internal static extern int CreateText(out IntPtr record, string text, string languageCode, int encode);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_create_uri")]
-            internal static extern int CreateUri(out IntPtr record, string uri);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_create_mime")]
-            internal static extern int CreateMime(out IntPtr record, string mimeType, byte[] data, uint dataSize);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_destroy")]
-            internal static extern int Destroy(IntPtr record);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_set_id")]
-            internal static extern int SetId(IntPtr record, byte[] id, int idSize);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_get_id")]
-            internal static extern int GetId(IntPtr record, out IntPtr id, out int size);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_get_payload")]
-            internal static extern int GetPayload(IntPtr record, out IntPtr payload, out uint size);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_get_type")]
-            internal static extern int GetType(IntPtr record, out IntPtr type, out int size);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_get_tnf")]
-            internal static extern int GetTnf(IntPtr record, out int tnf);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_get_text")]
-            internal static extern int GetText(IntPtr record, out string text);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_get_langcode")]
-            internal static extern int GetLanguageCode(IntPtr record, out string languageCode);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_get_encode_type")]
-            internal static extern int GetEncodeType(IntPtr record, out int encode);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_get_uri")]
-            internal static extern int GetUri(IntPtr record, out string uri);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_get_mime_type")]
-            internal static extern int GetMimeType(IntPtr record, out string mimeType);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Create(out IntPtr record, int tnf, byte[] type, int typeSize, byte[] id, int idSize, byte[] payload, uint payloadSize);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_create_text", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int CreateText(out IntPtr record, string text, string languageCode, int encode);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_create_uri", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int CreateUri(out IntPtr record, string uri);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_create_mime", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int CreateMime(out IntPtr record, string mimeType, byte[] data, uint dataSize);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Destroy(IntPtr record);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_set_id", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetId(IntPtr record, byte[] id, int idSize);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_get_id", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetId(IntPtr record, out IntPtr id, out int size);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_get_payload", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetPayload(IntPtr record, out IntPtr payload, out uint size);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_get_type", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetType(IntPtr record, out IntPtr type, out int size);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_get_tnf", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetTnf(IntPtr record, out int tnf);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_get_text", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetText(IntPtr record, out string text);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_get_langcode", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetLanguageCode(IntPtr record, out string languageCode);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_get_encode_type", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetEncodeType(IntPtr record, out int encode);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_get_uri", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetUri(IntPtr record, out string uri);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_record_get_mime_type", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetMimeType(IntPtr record, out string mimeType);
         }
 
-        internal static class NdefMessage
+        internal static partial class NdefMessage
         {
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_message_create")]
-            internal static extern int Create(out IntPtr ndefMessage);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_message_create_from_rawdata")]
-            internal static extern int CreateRawData(out IntPtr ndefMessage, byte[] rawData, uint rawDataSize);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_message_destroy")]
-            internal static extern int Destroy(IntPtr ndefMessage);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_message_get_record_count")]
-            internal static extern int GetRecordCount(IntPtr ndefMessage, out int count);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_message_get_rawdata")]
-            internal static extern int GetRawData(IntPtr ndefMessage, out IntPtr rawData, out uint rawDataSize);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_message_append_record")]
-            internal static extern int AppendRecord(IntPtr ndefMessage, IntPtr record);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_message_insert_record")]
-            internal static extern int InsertRecord(IntPtr ndefMessage, int index, IntPtr record);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_message_remove_record")]
-            internal static extern int RemoveRecord(IntPtr ndefMessage, int index);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_ndef_message_get_record")]
-            internal static extern int GetRecord(IntPtr ndefMessage, int index, out IntPtr record);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_message_create", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Create(out IntPtr ndefMessage);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_message_create_from_rawdata", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int CreateRawData(out IntPtr ndefMessage, byte[] rawData, uint rawDataSize);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_message_destroy", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Destroy(IntPtr ndefMessage);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_message_get_record_count", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetRecordCount(IntPtr ndefMessage, out int count);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_message_get_rawdata", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetRawData(IntPtr ndefMessage, out IntPtr rawData, out uint rawDataSize);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_message_append_record", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int AppendRecord(IntPtr ndefMessage, IntPtr record);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_message_insert_record", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int InsertRecord(IntPtr ndefMessage, int index, IntPtr record);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_message_remove_record", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int RemoveRecord(IntPtr ndefMessage, int index);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_ndef_message_get_record", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetRecord(IntPtr ndefMessage, int index, out IntPtr record);
         }
 
-        internal static class Tag
+        internal static partial class Tag
         {
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_tag_get_type")]
-            internal static extern int GetType(IntPtr tag, out int type);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_tag_is_support_ndef")]
-            internal static extern int IsSupportNdef(IntPtr tag, out bool isSupported);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_tag_get_maximum_ndef_size")]
-            internal static extern int GetMaximumNdefSize(IntPtr tag, out uint maximunNdefBytesSize);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_tag_get_ndef_size")]
-            internal static extern int GetNdefSize(IntPtr tag, out uint ndefBytesSize);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_tag_foreach_information")]
-            internal static extern int ForeachInformation(IntPtr tag, TagInformationCallback callback, IntPtr userData);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_tag_transceive")]
-            internal static extern int Transceive(IntPtr tag, byte[] buffer, int bufferSize, TagTransceiveCompletedCallback callback, IntPtr userData);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_tag_read_ndef")]
-            internal static extern int ReadNdef(IntPtr tag, TagReadCompletedCallback callback, IntPtr userData);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_tag_write_ndef")]
-            internal static extern int WriteNdef(IntPtr tag, IntPtr ndefMessage, VoidCallback callback, IntPtr userData);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_tag_format_ndef")]
-            internal static extern int FormatNdef(IntPtr tag, byte[] key, int kyeSize, VoidCallback callback, IntPtr userData);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_tag_get_type", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetType(IntPtr tag, out int type);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_tag_is_support_ndef", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int IsSupportNdef(IntPtr tag, [MarshalAs(UnmanagedType.U1)] out bool isSupported);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_tag_get_maximum_ndef_size", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetMaximumNdefSize(IntPtr tag, out uint maximunNdefBytesSize);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_tag_get_ndef_size", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetNdefSize(IntPtr tag, out uint ndefBytesSize);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_tag_foreach_information", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int ForeachInformation(IntPtr tag, TagInformationCallback callback, IntPtr userData);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_tag_transceive", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Transceive(IntPtr tag, byte[] buffer, int bufferSize, TagTransceiveCompletedCallback callback, IntPtr userData);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_tag_read_ndef", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int ReadNdef(IntPtr tag, TagReadCompletedCallback callback, IntPtr userData);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_tag_write_ndef", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int WriteNdef(IntPtr tag, IntPtr ndefMessage, VoidCallback callback, IntPtr userData);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_tag_format_ndef", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int FormatNdef(IntPtr tag, byte[] key, int kyeSize, VoidCallback callback, IntPtr userData);
 
             ////Mifare
         }
 
         ////SNEP - Simple NDEF Exchange Protocol
-        internal static class P2p
+        internal static partial class P2p
         {
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_p2p_set_data_received_cb")]
-            internal static extern int SetDataReceivedCallback(IntPtr target, P2pDataReceivedCallback callback, IntPtr userData);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_p2p_unset_data_received_cb")]
-            internal static extern int UnsetDataReceivedCallback(IntPtr target);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_p2p_send")]
-            internal static extern int Send(IntPtr target, IntPtr ndefMessage, VoidCallback callback, IntPtr userData);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_snep_start_server")]
-            internal static extern int SnepStartServer(IntPtr target, string san, int sap, SnepEventCallback callback, IntPtr userData);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_snep_start_client")]
-            internal static extern int SnepStartClient(IntPtr target, string san, int sap, SnepEventCallback callback, IntPtr userData);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_snep_send_client_request")]
-            internal static extern int SnepSendClientRequest(IntPtr snepHandle, int type, IntPtr ndefMessage, SnepEventCallback callback, IntPtr userData);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_snep_stop_service")]
-            internal static extern int SnepStopService(IntPtr target, IntPtr snepHandle);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_snep_register_server")]
-            internal static extern int SnepRegisterServer(string san, int sap, SnepEventCallback callback, IntPtr userData);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_snep_unregister_server")]
-            internal static extern int SnepUnregisterServer(string sam, int sap);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_p2p_set_data_received_cb", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetDataReceivedCallback(IntPtr target, P2pDataReceivedCallback callback, IntPtr userData);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_p2p_unset_data_received_cb", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int UnsetDataReceivedCallback(IntPtr target);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_p2p_send", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Send(IntPtr target, IntPtr ndefMessage, VoidCallback callback, IntPtr userData);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_snep_start_server", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SnepStartServer(IntPtr target, string san, int sap, SnepEventCallback callback, IntPtr userData);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_snep_start_client", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SnepStartClient(IntPtr target, string san, int sap, SnepEventCallback callback, IntPtr userData);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_snep_send_client_request", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SnepSendClientRequest(IntPtr snepHandle, int type, IntPtr ndefMessage, SnepEventCallback callback, IntPtr userData);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_snep_stop_service", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SnepStopService(IntPtr target, IntPtr snepHandle);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_snep_register_server", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SnepRegisterServer(string san, int sap, SnepEventCallback callback, IntPtr userData);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_snep_unregister_server", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SnepUnregisterServer(string sam, int sap);
         }
 
         ////SE - Secure Element, HCE - Host Card Emulation, APDU - Application Protocol Data Unit, AID - Application Identifier
-        internal static class CardEmulation
+        internal static partial class CardEmulation
         {
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_se_enable_card_emulation")]
-            internal static extern int EnableCardEmulation();
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_se_disable_card_emulation")]
-            internal static extern int DisableCardEmulatiion();
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_se_get_card_emulation_mode")]
-            internal static extern int GetCardEmulationMode(out int type);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_hce_send_apdu_response")]
-            internal static extern int HceSendApduRespondse(IntPtr seHandle, byte[] response, uint responseLength);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_se_set_default_route")]
-            internal static extern int SetDefaultRoute(int poweredOnStatus, int poweredOffStatus, int lowBatteryStatus);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_se_is_activated_handler_for_aid")]
-            internal static extern int IsActivatedHandlerForAid(int seType, string aid, out bool isActivatedHandler);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_se_is_activated_handler_for_category")]
-            internal static extern int IsActivatedHandlerForCategory(int seType, int category, out bool isActivatedHandler);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_se_register_aid")]
-            internal static extern int RegisterAid(int seType, int category, string aid);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_se_unregister_aid")]
-            internal static extern int UnregisterAid(int seType, int category, string aid);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_se_foreach_registered_aids")]
-            internal static extern int ForeachRegisterdAids(int seType, int category, SecureElementRegisteredAidCallback callback, IntPtr userData);
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_se_set_preferred_handler")]
-            internal static extern int SetPreferredHandler();
-            [DllImport(Libraries.Nfc, EntryPoint = "nfc_se_unset_preferred_handler")]
-            internal static extern int UnsetPreferredHandler();
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_se_enable_card_emulation", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int EnableCardEmulation();
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_se_disable_card_emulation", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int DisableCardEmulatiion();
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_se_get_card_emulation_mode", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetCardEmulationMode(out int type);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_hce_send_apdu_response", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int HceSendApduRespondse(IntPtr seHandle, byte[] response, uint responseLength);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_se_set_default_route", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetDefaultRoute(int poweredOnStatus, int poweredOffStatus, int lowBatteryStatus);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_se_is_activated_handler_for_aid", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int IsActivatedHandlerForAid(int seType, string aid, [MarshalAs(UnmanagedType.U1)] out bool isActivatedHandler);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_se_is_activated_handler_for_category", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int IsActivatedHandlerForCategory(int seType, int category, [MarshalAs(UnmanagedType.U1)] out bool isActivatedHandler);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_se_register_aid", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int RegisterAid(int seType, int category, string aid);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_se_unregister_aid", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int UnregisterAid(int seType, int category, string aid);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_se_foreach_registered_aids", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int ForeachRegisterdAids(int seType, int category, SecureElementRegisteredAidCallback callback, IntPtr userData);
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_se_set_preferred_handler", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetPreferredHandler();
+            [LibraryImport(Libraries.Nfc, EntryPoint = "nfc_se_unset_preferred_handler", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int UnsetPreferredHandler();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.Network.Nsd/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Network.Nsd/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -24,3 +24,6 @@ internal static partial class Interop
         public const string Libc = "libc.so.6";
     }
 }
+
+
+

--- a/src/Tizen.Network.Nsd/Interop/Interop.Nsd.cs
+++ b/src/Tizen.Network.Nsd/Interop/Interop.Nsd.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Network.Nsd;
 
 /// <summary>
@@ -28,7 +29,7 @@ internal static partial class Interop
     /// </summary>
     internal static partial class Nsd
     {
-        internal static class Dnssd
+        internal static partial class Dnssd
         {
             //Callback for event
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -37,49 +38,49 @@ internal static partial class Interop
             internal delegate void ServiceFoundCallback(DnssdServiceState state, uint service, IntPtr userData);
 
             //Dns-sd
-            [DllImport(Libraries.Dnssd, EntryPoint = "dnssd_initialize")]
-            internal static extern int Initialize();
-            [DllImport(Libraries.Dnssd, EntryPoint = "dnssd_deinitialize")]
-            internal static extern int Deinitialize();
-            [DllImport(Libraries.Dnssd, EntryPoint = "dnssd_create_local_service")]
-            internal static extern int CreateService(string type, out uint service);
-            [DllImport(Libraries.Dnssd, EntryPoint = "dnssd_destroy_local_service")]
-            internal static extern int DestroyService(uint service);
-            [DllImport(Libraries.Dnssd, EntryPoint = "dnssd_service_set_name")]
-            internal static extern int SetName(uint service, string name);
-            [DllImport(Libraries.Dnssd, EntryPoint = "dnssd_service_set_port")]
-            internal static extern int SetPort(uint service, int port);
-            [DllImport(Libraries.Dnssd, EntryPoint = "dnssd_service_add_txt_record")]
-            internal static extern int AddTxtRecord(uint service, string key, ushort length, byte[] value);
-            [DllImport(Libraries.Dnssd, EntryPoint = "dnssd_service_remove_txt_record")]
-            internal static extern int RemoveTxtRecord(uint service, string key);
-            [DllImport(Libraries.Dnssd, EntryPoint = "dnssd_service_set_record")]
-            internal static extern int SetRecord(uint service, ushort type, ushort length, byte[] data);
-            [DllImport(Libraries.Dnssd, EntryPoint = "dnssd_service_unset_record")]
-            internal static extern int UnsetRecord(uint service, ushort type);
-            [DllImport(Libraries.Dnssd, EntryPoint = "dnssd_register_local_service")]
-            internal static extern int RegisterService(uint service, ServiceRegisteredCallback callback, IntPtr userData);
-            [DllImport(Libraries.Dnssd, EntryPoint = "dnssd_deregister_local_service")]
-            internal static extern int DeregisterService(uint service);
-            [DllImport(Libraries.Dnssd, EntryPoint = "dnssd_start_browsing_service")]
-            internal static extern int StartBrowsing(string type, out uint browser, ServiceFoundCallback callback, IntPtr userData);
-            [DllImport(Libraries.Dnssd, EntryPoint = "dnssd_stop_browsing_service")]
-            internal static extern int StopBrowsing(uint browser);
-            [DllImport(Libraries.Dnssd, EntryPoint = "dnssd_service_get_type")]
-            internal static extern int GetType(uint service, out string type);
-            [DllImport(Libraries.Dnssd, EntryPoint = "dnssd_service_get_name")]
-            internal static extern int GetName(uint service, out string name);
-            [DllImport(Libraries.Dnssd, EntryPoint = "dnssd_service_get_ip")]
-            internal static extern int GetIP(uint service, out string ipV4, out string ipV6);
-            [DllImport(Libraries.Dnssd, EntryPoint = "dnssd_service_get_port")]
-            internal static extern int GetPort(uint service, out int port);
-            [DllImport(Libraries.Dnssd, EntryPoint = "dnssd_service_get_all_txt_record")]
-            internal static extern int GetAllTxtRecord(uint service, out ushort length, out IntPtr value);
+            [LibraryImport(Libraries.Dnssd, EntryPoint = "dnssd_initialize", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Initialize();
+            [LibraryImport(Libraries.Dnssd, EntryPoint = "dnssd_deinitialize", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Deinitialize();
+            [LibraryImport(Libraries.Dnssd, EntryPoint = "dnssd_create_local_service", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int CreateService(string type, out uint service);
+            [LibraryImport(Libraries.Dnssd, EntryPoint = "dnssd_destroy_local_service", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int DestroyService(uint service);
+            [LibraryImport(Libraries.Dnssd, EntryPoint = "dnssd_service_set_name", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetName(uint service, string name);
+            [LibraryImport(Libraries.Dnssd, EntryPoint = "dnssd_service_set_port", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetPort(uint service, int port);
+            [LibraryImport(Libraries.Dnssd, EntryPoint = "dnssd_service_add_txt_record", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int AddTxtRecord(uint service, string key, ushort length, byte[] value);
+            [LibraryImport(Libraries.Dnssd, EntryPoint = "dnssd_service_remove_txt_record", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int RemoveTxtRecord(uint service, string key);
+            [LibraryImport(Libraries.Dnssd, EntryPoint = "dnssd_service_set_record", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetRecord(uint service, ushort type, ushort length, byte[] data);
+            [LibraryImport(Libraries.Dnssd, EntryPoint = "dnssd_service_unset_record", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int UnsetRecord(uint service, ushort type);
+            [LibraryImport(Libraries.Dnssd, EntryPoint = "dnssd_register_local_service", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int RegisterService(uint service, ServiceRegisteredCallback callback, IntPtr userData);
+            [LibraryImport(Libraries.Dnssd, EntryPoint = "dnssd_deregister_local_service", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int DeregisterService(uint service);
+            [LibraryImport(Libraries.Dnssd, EntryPoint = "dnssd_start_browsing_service", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int StartBrowsing(string type, out uint browser, ServiceFoundCallback callback, IntPtr userData);
+            [LibraryImport(Libraries.Dnssd, EntryPoint = "dnssd_stop_browsing_service", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int StopBrowsing(uint browser);
+            [LibraryImport(Libraries.Dnssd, EntryPoint = "dnssd_service_get_type", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetType(uint service, out string type);
+            [LibraryImport(Libraries.Dnssd, EntryPoint = "dnssd_service_get_name", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetName(uint service, out string name);
+            [LibraryImport(Libraries.Dnssd, EntryPoint = "dnssd_service_get_ip", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetIP(uint service, out string ipV4, out string ipV6);
+            [LibraryImport(Libraries.Dnssd, EntryPoint = "dnssd_service_get_port", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetPort(uint service, out int port);
+            [LibraryImport(Libraries.Dnssd, EntryPoint = "dnssd_service_get_all_txt_record", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetAllTxtRecord(uint service, out ushort length, out IntPtr value);
         }
 
         // Deprecated since API13
         // ssdp
-        internal static class Ssdp
+        internal static partial class Ssdp
         {
             //Callback for event
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -88,43 +89,46 @@ internal static partial class Interop
             internal delegate void ServiceFoundCallback(SsdpServiceState state, uint service, IntPtr userData);
 
             //Ssdp
-            [DllImport(Libraries.Ssdp, EntryPoint = "ssdp_initialize")]
-            internal static extern int Initialize();
-            [DllImport(Libraries.Ssdp, EntryPoint = "ssdp_deinitialize")]
-            internal static extern int Deinitialize();
-            [DllImport(Libraries.Ssdp, EntryPoint = "ssdp_create_local_service")]
-            internal static extern int CreateService(string target, out uint service);
-            [DllImport(Libraries.Ssdp, EntryPoint = "ssdp_destroy_local_service")]
-            internal static extern int DestroyService(uint service);
-            [DllImport(Libraries.Ssdp, EntryPoint = "ssdp_service_set_usn")]
-            internal static extern int SetUsn(uint service, string usn);
-            [DllImport(Libraries.Ssdp, EntryPoint = "ssdp_service_set_url")]
-            internal static extern int SetUrl(uint service, string url);
-            [DllImport(Libraries.Ssdp, EntryPoint = "ssdp_service_get_target")]
-            internal static extern int GetTarget(uint service, out string target);
-            [DllImport(Libraries.Ssdp, EntryPoint = "ssdp_service_get_usn")]
-            internal static extern int GetUsn(uint service, out string usn);
-            [DllImport(Libraries.Ssdp, EntryPoint = "ssdp_service_get_url")]
-            internal static extern int GetUrl(uint service, out string url);
-            [DllImport(Libraries.Ssdp, EntryPoint = "ssdp_register_local_service")]
-            internal static extern int RegisterService(uint service, ServiceRegisteredCallback callback, IntPtr userData);
-            [DllImport(Libraries.Ssdp, EntryPoint = "ssdp_deregister_local_service")]
-            internal static extern int DeregisterService(uint service);
-            [DllImport(Libraries.Ssdp, EntryPoint = "ssdp_start_browsing_service")]
-            internal static extern int StartBrowsing(string target, out uint browser, ServiceFoundCallback callback, IntPtr userData);
-            [DllImport(Libraries.Ssdp, EntryPoint = "ssdp_stop_browsing_service")]
-            internal static extern int StopBrowsing(uint browser);
+            [LibraryImport(Libraries.Ssdp, EntryPoint = "ssdp_initialize", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Initialize();
+            [LibraryImport(Libraries.Ssdp, EntryPoint = "ssdp_deinitialize", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int Deinitialize();
+            [LibraryImport(Libraries.Ssdp, EntryPoint = "ssdp_create_local_service", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int CreateService(string target, out uint service);
+            [LibraryImport(Libraries.Ssdp, EntryPoint = "ssdp_destroy_local_service", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int DestroyService(uint service);
+            [LibraryImport(Libraries.Ssdp, EntryPoint = "ssdp_service_set_usn", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetUsn(uint service, string usn);
+            [LibraryImport(Libraries.Ssdp, EntryPoint = "ssdp_service_set_url", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SetUrl(uint service, string url);
+            [LibraryImport(Libraries.Ssdp, EntryPoint = "ssdp_service_get_target", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetTarget(uint service, out string target);
+            [LibraryImport(Libraries.Ssdp, EntryPoint = "ssdp_service_get_usn", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetUsn(uint service, out string usn);
+            [LibraryImport(Libraries.Ssdp, EntryPoint = "ssdp_service_get_url", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetUrl(uint service, out string url);
+            [LibraryImport(Libraries.Ssdp, EntryPoint = "ssdp_register_local_service", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int RegisterService(uint service, ServiceRegisteredCallback callback, IntPtr userData);
+            [LibraryImport(Libraries.Ssdp, EntryPoint = "ssdp_deregister_local_service", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int DeregisterService(uint service);
+            [LibraryImport(Libraries.Ssdp, EntryPoint = "ssdp_start_browsing_service", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int StartBrowsing(string target, out uint browser, ServiceFoundCallback callback, IntPtr userData);
+            [LibraryImport(Libraries.Ssdp, EntryPoint = "ssdp_stop_browsing_service", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int StopBrowsing(uint browser);
         }
     }
     internal static partial class Libc
     {
-        [DllImport(Libraries.Libc, EntryPoint = "free")]
-        public static extern void Free(IntPtr userData);
+        [LibraryImport(Libraries.Libc, EntryPoint = "free", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial void Free(IntPtr userData);
     }
 
     internal static partial class Glib
     {
-        [DllImport(Libraries.Glib, EntryPoint = "g_free", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void Free(IntPtr userData);
+        [LibraryImport(Libraries.Glib, EntryPoint = "g_free", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial void Free(IntPtr userData);
     }
 }
+
+
+

--- a/src/Tizen.Network.Smartcard/Interop/Interop.Glib.cs
+++ b/src/Tizen.Network.Smartcard/Interop/Interop.Glib.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,15 +16,20 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
     internal static partial class Glib
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool GSourceFunc(IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool GSourceFunc(IntPtr userData);
 
-        [DllImport(Libraries.Glib, EntryPoint = "g_idle_add", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern uint IdleAdd(GSourceFunc d, IntPtr data);
+        [LibraryImport(Libraries.Glib, EntryPoint = "g_idle_add", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial uint IdleAdd(GSourceFunc d, IntPtr data);
     }
 }
+
+
+
+

--- a/src/Tizen.Network.Smartcard/Interop/Interop.Libc.cs
+++ b/src/Tizen.Network.Smartcard/Interop/Interop.Libc.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,12 +16,16 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
     internal static partial class Libc
     {
-        [DllImport(Libraries.Libc, EntryPoint = "free", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int Free(IntPtr ptr);
+        [LibraryImport(Libraries.Libc, EntryPoint = "free", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Free(IntPtr ptr);
     }
 }
+
+
+

--- a/src/Tizen.Network.Smartcard/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Network.Smartcard/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -23,3 +23,6 @@ internal static partial class Interop
         public const string Libc = "libc.so.6";
     }
 }
+
+
+

--- a/src/Tizen.Network.Smartcard/Interop/Interop.Smartcard.cs
+++ b/src/Tizen.Network.Smartcard/Interop/Interop.Smartcard.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
@@ -23,61 +24,65 @@ internal static partial class Interop
     {
         //capi-network-smartcard-0.0.6-2.1.armv7l.rpm
         //Smartcard Manager
-        [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_initialize")]
-        internal static extern int Initialize();
-        [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_deinitialize")]
-        internal static extern int Deinitialize();
-        [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_get_readers")]
-        internal static extern int GetReaders(out IntPtr readers, out int len);
+        [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_initialize", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Initialize();
+        [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_deinitialize", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Deinitialize();
+        [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_get_readers", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetReaders(out IntPtr readers, out int len);
 
-        internal static class Reader
+        internal static partial class Reader
         {
-            [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_reader_get_name")]
-            internal static extern int ReaderGetName(int reader, out IntPtr readerName);
-            [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_reader_is_secure_element_present")]
-            internal static extern int ReaderIsSecureElementPresent(int reader, out bool present);
-            [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_reader_open_session")]
-            internal static extern int ReaderOpenSession(int reader, out int session);
-            [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_reader_close_sessions")]
-            internal static extern int ReaderCloseSessions(int reader);
+            [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_reader_get_name", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int ReaderGetName(int reader, out IntPtr readerName);
+            [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_reader_is_secure_element_present", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int ReaderIsSecureElementPresent(int reader, [MarshalAs(UnmanagedType.U1)] out bool present);
+            [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_reader_open_session", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int ReaderOpenSession(int reader, out int session);
+            [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_reader_close_sessions", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int ReaderCloseSessions(int reader);
         }
 
-        internal static class Session
+        internal static partial class Session
         {
-            [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_session_get_reader")]
-            internal static extern int SessionGetReader(int session, out int reader);
-            [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_session_get_atr")]
-            internal static extern int SessionGetAtr(int session, out IntPtr atr, out int len);
-            [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_session_close")]
-            internal static extern int SessionClose(int session);
-            [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_session_is_closed")]
-            internal static extern int SessionIsClosed(int session, out bool closed);
-            [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_session_close_channels")]
-            internal static extern int SessionCloseChannels(int session);
-            [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_session_open_basic_channel")]
-            internal static extern int SessionOpenBasicChannel(int session, byte[] aid, int aidLen, byte p2, out int channel);
-            [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_session_open_logical_channel")]
-            internal static extern int SessionOpenLogicalChannel(int session, byte[] aid, int aidLen, byte p2, out int channel);
+            [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_session_get_reader", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SessionGetReader(int session, out int reader);
+            [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_session_get_atr", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SessionGetAtr(int session, out IntPtr atr, out int len);
+            [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_session_close", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SessionClose(int session);
+            [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_session_is_closed", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SessionIsClosed(int session, [MarshalAs(UnmanagedType.U1)] out bool closed);
+            [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_session_close_channels", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SessionCloseChannels(int session);
+            [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_session_open_basic_channel", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SessionOpenBasicChannel(int session, byte[] aid, int aidLen, byte p2, out int channel);
+            [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_session_open_logical_channel", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int SessionOpenLogicalChannel(int session, byte[] aid, int aidLen, byte p2, out int channel);
         }
 
-        internal static class Channel
+        internal static partial class Channel
         {
-            [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_channel_close")]
-            internal static extern int ChannelClose(int channel);
-            [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_channel_is_basic_channel")]
-            internal static extern int ChannelIsBasicChannel(int channel, out bool basicChannel);
-            [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_channel_is_closed")]
-            internal static extern int ChannelIsClosed(int channel, out bool closed);
-            [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_channel_get_select_response")]
-            internal static extern int ChannelGetSelectResponse(int channel, out IntPtr selectResp, out int len);
-            [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_channel_get_session")]
-            internal static extern int ChannelGetSession(int channel, out int session);
-            [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_channel_transmit")]
-            internal static extern int ChannelTransmit(int channel, byte[] cmd, int cmdLen, out IntPtr resp, out int len);
-            [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_channel_transmit_retrieve_response")]
-            internal static extern int ChannelTransmitRetrieveResponse(int channel, out IntPtr name, out int len);
-            [DllImport(Libraries.Smartcard, EntryPoint = "smartcard_channel_select_next")]
-            internal static extern int ChannelSelectNext(int channel, out bool success);
+            [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_channel_close", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int ChannelClose(int channel);
+            [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_channel_is_basic_channel", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int ChannelIsBasicChannel(int channel, [MarshalAs(UnmanagedType.U1)] out bool basicChannel);
+            [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_channel_is_closed", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int ChannelIsClosed(int channel, [MarshalAs(UnmanagedType.U1)] out bool closed);
+            [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_channel_get_select_response", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int ChannelGetSelectResponse(int channel, out IntPtr selectResp, out int len);
+            [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_channel_get_session", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int ChannelGetSession(int channel, out int session);
+            [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_channel_transmit", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int ChannelTransmit(int channel, byte[] cmd, int cmdLen, out IntPtr resp, out int len);
+            [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_channel_transmit_retrieve_response", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int ChannelTransmitRetrieveResponse(int channel, out IntPtr name, out int len);
+            [LibraryImport(Libraries.Smartcard, EntryPoint = "smartcard_channel_select_next", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int ChannelSelectNext(int channel, [MarshalAs(UnmanagedType.U1)] out bool success);
         }
     }
 }
+
+
+
+

--- a/src/Tizen.Network.Stc/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Network.Stc/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -23,3 +23,6 @@ internal static partial class Interop
         public const string Libc = "libc.so.6";
     }
 }
+
+
+

--- a/src/Tizen.Network.Stc/Interop/Interop.Stc.cs
+++ b/src/Tizen.Network.Stc/Interop/Interop.Stc.cs
@@ -18,6 +18,7 @@ using System;
 using Tizen;
 using Tizen.Network.Stc;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 /// <summary>
 /// The Interop class for Stc.
@@ -28,7 +29,7 @@ internal static partial class Interop
     /// The Stc native APIs.
     /// </summary>
     // Deprecated since API13
-    internal static class Stc
+    internal static partial class Stc
     {
         // Callback for Statistics Information
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -48,7 +49,7 @@ internal static partial class Interop
         [DllImport(Libraries.Stc,EntryPoint = "stc_foreach_all_stats")]
         internal static extern int ForeachAllStats(IntPtr infoList, StatsInfoCallback infoCb, IntPtr userData);
 
-        internal static class Filter {
+        internal static partial class Filter {
             [DllImport(Libraries.Stc,EntryPoint = "stc_stats_rule_create")]
             internal static extern int Create(SafeStcHandle stc, out SafeFilterHandle filter);
             [DllImport(Libraries.Stc,EntryPoint = "stc_stats_rule_destroy")]
@@ -65,7 +66,7 @@ internal static partial class Interop
             internal static extern int SetTimePeriod(SafeFilterHandle filter, NativeTimePeriodType timePeriod);
         }
 
-        internal static class Info {
+        internal static partial class Info {
             [DllImport(Libraries.Stc,EntryPoint = "stc_stats_info_clone")]
             internal static extern int StatsClone(IntPtr info, out SafeStatsHandle cloned);
             [DllImport(Libraries.Stc,EntryPoint = "stc_stats_info_destroy")]
@@ -99,16 +100,14 @@ internal static partial class Interop
             public SafeFilterHandle(IntPtr handle) : base(handle, true)
             {
             }
-
-            public override bool IsInvalid
+        public override bool IsInvalid
             {
                 get
                 {
                     return this.handle == IntPtr.Zero;
                 }
             }
-
-            protected override bool ReleaseHandle()
+        protected override bool ReleaseHandle()
             {
                 int ret = Interop.Stc.Filter.Destroy(this.handle);
                 if (ret != (int)StcError.None)
@@ -129,16 +128,14 @@ internal static partial class Interop
             public SafeStatsHandle(IntPtr handle) : base(handle, true)
             {
             }
-
-            public override bool IsInvalid
+        public override bool IsInvalid
             {
                 get
                 {
                     return this.handle == IntPtr.Zero;
                 }
             }
-
-            protected override bool ReleaseHandle()
+        protected override bool ReleaseHandle()
             {
                 int ret = Interop.Stc.Info.StatsDestroy(this.handle);
                 if (ret != (int)StcError.None)
@@ -175,3 +172,10 @@ internal static partial class Interop
         return epoch.AddSeconds(timestamp).ToLocalTime();
     }
 }
+
+
+
+
+
+
+

--- a/src/Tizen.Network.WiFi/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Network.WiFi/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -23,3 +23,6 @@ internal static partial class Interop
         public const string Libc = "libc.so.6";
     }
 }
+
+
+

--- a/src/Tizen.Network.WiFi/Interop/Interop.WiFi.cs
+++ b/src/Tizen.Network.WiFi/Interop/Interop.WiFi.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Network.WiFi;
 using Tizen.Network.Connection;
 
@@ -27,7 +28,7 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void VoidCallback(int result, IntPtr userData);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool HandleCallback(IntPtr handle, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool HandleCallback(IntPtr handle, IntPtr userData);
 
         //Callback for event
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -53,7 +54,7 @@ internal static partial class Interop
         [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_deactivate")]
         internal static extern int Deactivate(SafeWiFiManagerHandle wifi, VoidCallback callback, IntPtr userData);
         [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_is_activated")]
-        internal static extern int IsActive(SafeWiFiManagerHandle wifi, out bool activated);
+        internal static extern int IsActive(SafeWiFiManagerHandle wifi, [MarshalAs(UnmanagedType.U1)] out bool activated);
         [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_get_mac_address")]
         internal static extern int GetMacAddress(SafeWiFiManagerHandle wifi, out string macAddress);
         [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_get_network_interface_name")]
@@ -135,10 +136,10 @@ internal static partial class Interop
         [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_tdls_get_connected_peer")]
         internal static extern int GetTdlsConnectedPeer(SafeWiFiManagerHandle wifi, out IntPtr peerMacAddress);
 
-        internal static class AP
+        internal static partial class AP
         {
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-            internal delegate bool FoundBssidCallback(string bssid, int rssi, int freq, IntPtr userData);
+            [return: MarshalAs(UnmanagedType.U1)] internal delegate bool FoundBssidCallback(string bssid, int rssi, int freq, IntPtr userData);
 
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_ap_create")]
             internal static extern int Create(SafeWiFiManagerHandle wifi, string essid, out IntPtr ap);
@@ -169,9 +170,9 @@ internal static partial class Interop
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_ap_get_max_speed")]
             internal static extern int GetMaxSpeed(SafeWiFiAPHandle ap, out int maxSpeed);
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_ap_is_favorite")]
-            internal static extern int IsFavorite(SafeWiFiAPHandle ap, out bool isFavorite);
+            internal static extern int IsFavorite(SafeWiFiAPHandle ap, [MarshalAs(UnmanagedType.U1)] out bool isFavorite);
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_ap_is_passpoint")]
-            internal static extern int IsPasspoint(SafeWiFiAPHandle ap, out bool isPasspoint);
+            internal static extern int IsPasspoint(SafeWiFiAPHandle ap, [MarshalAs(UnmanagedType.U1)] out bool isPasspoint);
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_ap_get_connection_state")]
             internal static extern int GetConnectionState(SafeWiFiAPHandle ap, out int connectionState);
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_ap_get_ip_config_type")]
@@ -229,17 +230,17 @@ internal static partial class Interop
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_ap_set_encryption_type")]
             internal static extern int SetEncryptionType(SafeWiFiAPHandle ap, int encryptionType);
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_ap_is_passphrase_required")]
-            internal static extern int IsPassphraseRequired(SafeWiFiAPHandle ap, out bool required);
+            internal static extern int IsPassphraseRequired(SafeWiFiAPHandle ap, [MarshalAs(UnmanagedType.U1)] out bool required);
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_ap_set_passphrase")]
             internal static extern int SetPassphrase(SafeWiFiAPHandle ap, string passphrase);
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_ap_is_wps_supported")]
-            internal static extern int IsWpsSupported(SafeWiFiAPHandle ap, out bool supported);
+            internal static extern int IsWpsSupported(SafeWiFiAPHandle ap, [MarshalAs(UnmanagedType.U1)] out bool supported);
 
             ////EAP
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_ap_set_eap_passphrase")]
             internal static extern int SetEapPassphrase(SafeWiFiAPHandle ap, string userName, string password);
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_ap_get_eap_passphrase")]
-            internal static extern int GetEapPassphrase(SafeWiFiAPHandle ap, out IntPtr userName, out bool isPasswordSet);
+            internal static extern int GetEapPassphrase(SafeWiFiAPHandle ap, out IntPtr userName, [MarshalAs(UnmanagedType.U1)] out bool isPasswordSet);
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_ap_get_eap_ca_cert_file")]
             internal static extern int GetEapCaCertFile(SafeWiFiAPHandle ap, out IntPtr file);
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_ap_set_eap_ca_cert_file")]
@@ -262,7 +263,7 @@ internal static partial class Interop
             internal static extern int SetEapAuthType(SafeWiFiAPHandle ap, int file);
         }
 
-        internal static class Config
+        internal static partial class Config
         {
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_config_create")]
             internal static extern int Create(SafeWiFiManagerHandle wifi, string name, string passPhrase, int securityType, out IntPtr config);
@@ -285,9 +286,9 @@ internal static partial class Interop
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_config_get_proxy_address")]
             internal static extern int GetProxyAddress(IntPtr config, out int addressFamily, out IntPtr proxyAddress);
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_config_set_hidden_ap_property")]
-            internal static extern int SetHiddenAPProperty(IntPtr config, bool isHidden);
+            internal static extern int SetHiddenAPProperty(IntPtr config, [MarshalAs(UnmanagedType.U1)] bool isHidden);
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_config_get_hidden_ap_property")]
-            internal static extern int GetHiddenAPProperty(IntPtr config, out bool isHidden);
+            internal static extern int GetHiddenAPProperty(IntPtr config, [MarshalAs(UnmanagedType.U1)] out bool isHidden);
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_config_get_eap_anonymous_identity")]
             internal static extern int GetEapAnonymousIdentity(SafeWiFiConfigHandle config, out IntPtr anonymousIdentify);
             [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_config_set_eap_anonymous_identity")]
@@ -329,16 +330,14 @@ internal static partial class Interop
             public SafeWiFiAPHandle(IntPtr handle) : base(handle, true)
             {
             }
-
-            public override bool IsInvalid
+        public override bool IsInvalid
             {
                 get
                 {
                     return this.handle == IntPtr.Zero;
                 }
             }
-
-            protected override bool ReleaseHandle()
+        protected override bool ReleaseHandle()
             {
                 this.SetHandle(IntPtr.Zero);
                 return true;
@@ -354,16 +353,14 @@ internal static partial class Interop
             public SafeWiFiConfigHandle(IntPtr handle) : base(handle, true)
             {
             }
-
-            public override bool IsInvalid
+        public override bool IsInvalid
             {
                 get
                 {
                     return this.handle == IntPtr.Zero;
                 }
             }
-
-            protected override bool ReleaseHandle()
+        protected override bool ReleaseHandle()
             {
                 this.SetHandle(IntPtr.Zero);
                 return true;
@@ -374,7 +371,7 @@ internal static partial class Interop
 
     internal static partial class Glib
     {
-        [DllImport(Libraries.Glib, EntryPoint = "g_free", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.Glib, EntryPoint = "g_free")]
         public static extern void Free(IntPtr userData);
     }
 
@@ -384,3 +381,10 @@ internal static partial class Interop
         public static extern void Free(IntPtr userData);
     }
 }
+
+
+
+
+
+
+

--- a/src/Tizen.Network.WiFiDirect/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Network.WiFiDirect/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -23,3 +23,6 @@ internal static partial class Interop
         public const string Libc = "libc.so.6";
     }
 }
+
+
+

--- a/src/Tizen.Network.WiFiDirect/Interop/Interop.WiFiDirect.cs
+++ b/src/Tizen.Network.WiFiDirect/Interop/Interop.WiFiDirect.cs
@@ -17,6 +17,7 @@
 using System;
 using Tizen.Network.WiFiDirect;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 /// <summary>
 /// The Interop class for Wi-Fi Direct.
@@ -44,204 +45,208 @@ internal static partial class Interop
         internal delegate void StateChangedCallback(WiFiDirectState state, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool DiscoveredPeerCallback(ref DiscoveredPeerStruct peer, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool DiscoveredPeerCallback(ref DiscoveredPeerStruct peer, IntPtr userData);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool ConnectedPeerCallback(ref ConnectedPeerStruct peer, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool ConnectedPeerCallback(ref ConnectedPeerStruct peer, IntPtr userData);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool WpsTypeCallback(WiFiDirectWpsType type, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool WpsTypeCallback(WiFiDirectWpsType type, IntPtr userData);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool PersistentGroupCallback(string address, string ssid, IntPtr userData);
+        [return: MarshalAs(UnmanagedType.U1)] internal delegate bool PersistentGroupCallback(string address, string ssid, IntPtr userData);
 
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_state_changed_cb")]
-        internal static extern int SetStateChangedCallback(StateChangedCallback stateChangedCb, IntPtr userData);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_unset_state_changed_cb")]
-        internal static extern int UnsetStateChangedCallback();
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetStateChangedCallback(StateChangedCallback stateChangedCb, IntPtr userData);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_unset_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UnsetStateChangedCallback();
 
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_device_state_changed_cb")]
-        internal static extern int SetDeviceStateChangedCallback(DeviceStateChangedCallback deviceChangedCb, IntPtr userData);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_unset_device_state_changed_cb")]
-        internal static extern int UnsetDeviceStateChangedCallback();
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_device_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetDeviceStateChangedCallback(DeviceStateChangedCallback deviceChangedCb, IntPtr userData);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_unset_device_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UnsetDeviceStateChangedCallback();
 
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_discovery_state_changed_cb")]
-        internal static extern int SetDiscoveryStateChangedCallback(DiscoveryStateChangedCallback discoveryStateChangedCb, IntPtr userData);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_unset_discovery_state_changed_cb")]
-        internal static extern int UnsetDiscoveryStateChangedCallback();
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_discovery_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetDiscoveryStateChangedCallback(DiscoveryStateChangedCallback discoveryStateChangedCb, IntPtr userData);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_unset_discovery_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UnsetDiscoveryStateChangedCallback();
 
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_peer_found_cb")]
-        internal static extern int SetPeerFoundCallback(PeerFoundCallback peerFoundCb, IntPtr userData);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_unset_peer_found_cb")]
-        internal static extern int UnsetPeerFoundCallback();
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_peer_found_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetPeerFoundCallback(PeerFoundCallback peerFoundCb, IntPtr userData);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_unset_peer_found_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UnsetPeerFoundCallback();
 
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_connection_state_changed_cb")]
-        internal static extern int SetConnectionChangedCallback(ConnectionStateChangedCallback connectionCb, IntPtr userData);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_unset_connection_state_changed_cb")]
-        internal static extern int UnsetConnectionChangedCallback();
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_connection_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetConnectionChangedCallback(ConnectionStateChangedCallback connectionCb, IntPtr userData);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_unset_connection_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UnsetConnectionChangedCallback();
 
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_client_ip_address_assigned_cb")]
-        internal static extern int SetIpAddressAssignedCallback(ClientIpAddressAssignedCallback callback, IntPtr userData);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_unset_client_ip_address_assigned_cb")]
-        internal static extern int UnsetIpAddressAssignedCallback();
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_client_ip_address_assigned_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetIpAddressAssignedCallback(ClientIpAddressAssignedCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_unset_client_ip_address_assigned_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UnsetIpAddressAssignedCallback();
 
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_service_state_changed_cb")]
-        internal static extern int SetServiceStateChangedCallback(ServiceStateChangedCallback serviceStateChangedCb, IntPtr userData);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_unset_service_state_changed_cb")]
-        internal static extern int UnsetServiceStateChangedCallback();
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_service_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetServiceStateChangedCallback(ServiceStateChangedCallback serviceStateChangedCb, IntPtr userData);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_unset_service_state_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UnsetServiceStateChangedCallback();
 
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_initialize")]
-        internal static extern int Initialize();
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_deinitialize")]
-        internal static extern int Deinitialize();
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_activate")]
-        internal static extern int Activate();
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_deactivate")]
-        internal static extern int Deactivate();
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_start_discovery_specific_channel")]
-        internal static extern int StartDiscoveryInChannel(bool listenOnly, int timeout, WiFiDirectDiscoveryChannel channel);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_cancel_discovery")]
-        internal static extern int StopDiscovery();
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_foreach_discovered_peers")]
-        internal static extern int GetDiscoveredPeers(DiscoveredPeerCallback callback, IntPtr userData);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_connect")]
-        internal static extern int Connect(string address);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_cancel_connection")]
-        internal static extern int CancelConnection(string address);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_disconnect_all")]
-        internal static extern int DisconnectAll();
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_disconnect")]
-        internal static extern int Disconnect(string address);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_foreach_connected_peers")]
-        internal static extern int GetConnectedPeers(ConnectedPeerCallback callback, IntPtr userData);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_create_group")]
-        internal static extern int CreateGroup();
-        [DllImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_create_group_with_ssid")]
-        internal static extern int CreateGroupWithSsid(string ssid);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_destroy_group")]
-        internal static extern int DestroyGroup();
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_is_group_owner")]
-        internal static extern int IsGroupOwner(out bool isGroupOwner);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_is_autonomous_group")]
-        internal static extern int IsAutonomousGroup(out bool isAutonomous);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_device_name")]
-        internal static extern int SetName(string name);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_device_name")]
-        internal static extern int GetName(out string name);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_ssid")]
-        internal static extern int GetSsid(out string ssid);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_network_interface_name")]
-        internal static extern int GetInterfaceName(out string name);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_ip_address")]
-        internal static extern int GetIpAddress(out string address);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_subnet_mask")]
-        internal static extern int GetSubnetMask(out string mask);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_gateway_address")]
-        internal static extern int GetGatewayAddress(out string address);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_mac_address")]
-        internal static extern int GetMacAddress(out string address);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_state")]
-        internal static extern int GetState(out WiFiDirectState state);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_is_discoverable")]
-        internal static extern int IsDiscoverable(out bool isDiscoverable);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_is_listening_only")]
-        internal static extern int IsListeningOnly(out bool listenOnly);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_primary_device_type")]
-        internal static extern int GetPrimaryType(out WiFiDirectPrimaryDeviceType type);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_secondary_device_type")]
-        internal static extern int GetSecondaryType(out WiFiDirectSecondaryDeviceType type);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_activate_pushbutton")]
-        internal static extern int ActivatePushButton();
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_wps_pin")]
-        internal static extern int SetWpsPin(string pin);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_wps_pin")]
-        internal static extern int GetWpsPin(out string pin);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_supported_wps_mode")]
-        internal static extern int GetWpsMode(out int mode);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_foreach_supported_wps_types")]
-        internal static extern int GetWpsTypes(WpsTypeCallback callback, IntPtr userData);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_local_wps_type")]
-        internal static extern int GetLocalWpsType(out WiFiDirectWpsType type);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_req_wps_type")]
-        internal static extern int SetReqWpsType(WiFiDirectWpsType type);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_req_wps_type")]
-        internal static extern int GetReqWpsType(out WiFiDirectWpsType type);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_group_owner_intent")]
-        internal static extern int SetIntent(int intent);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_group_owner_intent")]
-        internal static extern int GetIntent(out int intent);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_max_clients")]
-        internal static extern int SetMaxClients(int max);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_max_clients")]
-        internal static extern int GetMaxClients(out int max);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_passphrase")]
-        internal static extern int SetPassPhrase(string passphrase);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_passphrase")]
-        internal static extern int GetPassPhrase(out string passphrase);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_operating_channel")]
-        internal static extern int GetChannel(out int channel);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_autoconnection_mode")]
-        internal static extern int SetAutoConnectionMode(bool mode);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_is_autoconnection_mode")]
-        internal static extern int GetAutoConnectionMode(out bool mode);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_autoconnection_peer")]
-        internal static extern int SetAutoConnectionPeer(string address);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_persistent_group_enabled")]
-        internal static extern int SetPersistentGroupState(bool enabled);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_is_persistent_group_enabled")]
-        internal static extern int GetPersistentGroupState(out bool enabled);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_foreach_persistent_groups")]
-        internal static extern int GetPersistentGroups(PersistentGroupCallback callback, IntPtr userData);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_remove_persistent_group")]
-        internal static extern int RemovePersistentGroup(string address, string ssid);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_start_service_discovery")]
-        internal static extern int StartServiceDiscovery(string address, WiFiDirectServiceType type);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_cancel_service_discovery")]
-        internal static extern int StopServiceDiscovery(string address, WiFiDirectServiceType type);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_register_service")]
-        internal static extern int RegisterService(WiFiDirectServiceType type, string info1, string info2, out uint serviceId);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_deregister_service")]
-        internal static extern int DeregisterService(uint serviceId);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_init_miracast")]
-        internal static extern int InitMiracast(bool enable);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_peer_info")]
-        internal static extern int GetDiscoveredPeerInfo(string address, out IntPtr peer);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_init_display")]
-        internal static extern int InitDisplay();
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_deinit_display")]
-        internal static extern int DeinitDisplay();
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_display")]
-        internal static extern int SetDisplay(WiFiDirectDisplayType type, int port, int hdcp);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_display_availability")]
-        internal static extern int SetDisplayAvailability(bool availability);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_peer_display_type")]
-        internal static extern int GetDisplayType(string address, out WiFiDirectDisplayType type);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_peer_display_availability")]
-        internal static extern int GetDisplayAvailability(string address, out bool availability);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_peer_display_hdcp")]
-        internal static extern int GetDisplayHdcp(string address, out int hdcp);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_peer_display_port")]
-        internal static extern int GetDisplayPort(string address, out int port);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_peer_display_throughput")]
-        internal static extern int GetDisplayThroughput(string address, out int throughput);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_peer_rssi")]
-        internal static extern int GetRssi(string address, out int rssi);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_session_timer")]
-        internal static extern int GetSessionTimer(out int seconds);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_session_timer")]
-        internal static extern int SetSessionTimer(int seconds);
-        [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_auto_group_removal")]
-        internal static extern int SetAutoGroupRemoval(bool enable);
-        [DllImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_add_vsie")]
-        internal static extern int AddVsie(WiFiDirectVsieFrameType frameType, string vsie);
-        [DllImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_get_vsie")]
-        internal static extern int GetVsie(WiFiDirectVsieFrameType frameType, out string vsie);
-        [DllImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_remove_vsie")]
-        internal static extern int RemoveVsie(WiFiDirectVsieFrameType frameType, string vsie);
-        [DllImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_get_connecting_peer_info")]
-        internal static extern int GetConnectingPeerInfo(out IntPtr peer);
-        [DllImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_get_peer_vsie")]
-        internal static extern int GetPeerVsie(string macAddress, out string vsie);
-        [DllImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_accept_connection")]
-        internal static extern int AcceptConnection(string macAddress);
-        [DllImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_reject_connection")]
-        internal static extern int RejectConnection(string macAddress);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_initialize", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Initialize();
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_deinitialize", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Deinitialize();
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_activate", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Activate();
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_deactivate", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Deactivate();
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_start_discovery_specific_channel", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int StartDiscoveryInChannel([MarshalAs(UnmanagedType.U1)] bool listenOnly, int timeout, WiFiDirectDiscoveryChannel channel);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_cancel_discovery", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int StopDiscovery();
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_foreach_discovered_peers", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetDiscoveredPeers(DiscoveredPeerCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_connect", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Connect(string address);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_cancel_connection", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CancelConnection(string address);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_disconnect_all", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int DisconnectAll();
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_disconnect", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Disconnect(string address);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_foreach_connected_peers", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetConnectedPeers(ConnectedPeerCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_create_group", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CreateGroup();
+        [LibraryImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_create_group_with_ssid", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CreateGroupWithSsid(string ssid);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_destroy_group", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int DestroyGroup();
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_is_group_owner", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int IsGroupOwner([MarshalAs(UnmanagedType.U1)] out bool isGroupOwner);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_is_autonomous_group", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int IsAutonomousGroup([MarshalAs(UnmanagedType.U1)] out bool isAutonomous);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_device_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetName(string name);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_device_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetName(out string name);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_ssid", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetSsid(out string ssid);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_network_interface_name", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetInterfaceName(out string name);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_ip_address", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetIpAddress(out string address);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_subnet_mask", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetSubnetMask(out string mask);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_gateway_address", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetGatewayAddress(out string address);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_mac_address", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetMacAddress(out string address);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetState(out WiFiDirectState state);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_is_discoverable", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int IsDiscoverable([MarshalAs(UnmanagedType.U1)] out bool isDiscoverable);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_is_listening_only", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int IsListeningOnly([MarshalAs(UnmanagedType.U1)] out bool listenOnly);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_primary_device_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetPrimaryType(out WiFiDirectPrimaryDeviceType type);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_secondary_device_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetSecondaryType(out WiFiDirectSecondaryDeviceType type);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_activate_pushbutton", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int ActivatePushButton();
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_wps_pin", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetWpsPin(string pin);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_wps_pin", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetWpsPin(out string pin);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_supported_wps_mode", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetWpsMode(out int mode);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_foreach_supported_wps_types", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetWpsTypes(WpsTypeCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_local_wps_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetLocalWpsType(out WiFiDirectWpsType type);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_req_wps_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetReqWpsType(WiFiDirectWpsType type);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_req_wps_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetReqWpsType(out WiFiDirectWpsType type);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_group_owner_intent", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetIntent(int intent);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_group_owner_intent", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetIntent(out int intent);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_max_clients", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetMaxClients(int max);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_max_clients", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetMaxClients(out int max);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_passphrase", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetPassPhrase(string passphrase);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_passphrase", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetPassPhrase(out string passphrase);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_operating_channel", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetChannel(out int channel);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_autoconnection_mode", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAutoConnectionMode([MarshalAs(UnmanagedType.U1)] bool mode);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_is_autoconnection_mode", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetAutoConnectionMode([MarshalAs(UnmanagedType.U1)] out bool mode);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_autoconnection_peer", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAutoConnectionPeer(string address);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_persistent_group_enabled", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetPersistentGroupState([MarshalAs(UnmanagedType.U1)] bool enabled);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_is_persistent_group_enabled", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetPersistentGroupState([MarshalAs(UnmanagedType.U1)] out bool enabled);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_foreach_persistent_groups", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetPersistentGroups(PersistentGroupCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_remove_persistent_group", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RemovePersistentGroup(string address, string ssid);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_start_service_discovery", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int StartServiceDiscovery(string address, WiFiDirectServiceType type);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_cancel_service_discovery", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int StopServiceDiscovery(string address, WiFiDirectServiceType type);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_register_service", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RegisterService(WiFiDirectServiceType type, string info1, string info2, out uint serviceId);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_deregister_service", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int DeregisterService(uint serviceId);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_init_miracast", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int InitMiracast([MarshalAs(UnmanagedType.U1)] bool enable);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_peer_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetDiscoveredPeerInfo(string address, out IntPtr peer);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_init_display", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int InitDisplay();
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_deinit_display", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int DeinitDisplay();
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_display", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetDisplay(WiFiDirectDisplayType type, int port, int hdcp);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_display_availability", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetDisplayAvailability([MarshalAs(UnmanagedType.U1)] bool availability);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_peer_display_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetDisplayType(string address, out WiFiDirectDisplayType type);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_peer_display_availability", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetDisplayAvailability(string address, [MarshalAs(UnmanagedType.U1)] out bool availability);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_peer_display_hdcp", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetDisplayHdcp(string address, out int hdcp);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_peer_display_port", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetDisplayPort(string address, out int port);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_peer_display_throughput", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetDisplayThroughput(string address, out int throughput);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_peer_rssi", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetRssi(string address, out int rssi);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_get_session_timer", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetSessionTimer(out int seconds);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_session_timer", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetSessionTimer(int seconds);
+        [LibraryImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_auto_group_removal", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetAutoGroupRemoval([MarshalAs(UnmanagedType.U1)] bool enable);
+        [LibraryImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_add_vsie", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int AddVsie(WiFiDirectVsieFrameType frameType, string vsie);
+        [LibraryImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_get_vsie", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetVsie(WiFiDirectVsieFrameType frameType, out string vsie);
+        [LibraryImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_remove_vsie", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RemoveVsie(WiFiDirectVsieFrameType frameType, string vsie);
+        [LibraryImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_get_connecting_peer_info", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetConnectingPeerInfo(out IntPtr peer);
+        [LibraryImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_get_peer_vsie", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetPeerVsie(string macAddress, out string vsie);
+        [LibraryImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_accept_connection", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int AcceptConnection(string macAddress);
+        [LibraryImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_reject_connection", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RejectConnection(string macAddress);
     }
 }
+
+
+
+

--- a/src/Tizen.Security.DevicePolicyManager/Interop/Interop.DevicePolicyManager.cs
+++ b/src/Tizen.Security.DevicePolicyManager/Interop/Interop.DevicePolicyManager.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
@@ -35,96 +36,99 @@ internal static partial class Interop
         internal delegate void PolicyChangedCallback(string name, string state, IntPtr userData);
         // void (* dpm_policy_changed_cb)(const char* name, const char* state, void* user_data);
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_add_policy_changed_cb", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int AddPolicyChangedCallback(IntPtr handle, string name, PolicyChangedCallback callback, IntPtr userData, out int callbackId);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_add_policy_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int AddPolicyChangedCallback(IntPtr handle, string name, PolicyChangedCallback callback, IntPtr userData, out int callbackId);
         // int dpm_add_policy_changed_cb(device_policy_manager_h handle, const char* name, dpm_policy_changed_cb callback, void* user_data, int* id)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_remove_policy_changed_cb", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int RemovePolicyChangedCallback(IntPtr handle, int callbackId);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_remove_policy_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RemovePolicyChangedCallback(IntPtr handle, int callbackId);
         // int dpm_remove_policy_changed_cb(device_policy_manager_h handle, int id)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_manager_create", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr CreateHandle();
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_manager_create", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial IntPtr CreateHandle();
         // device_policy_manager_h dpm_manager_create(void)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_manager_destroy", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int DestroyHandle(IntPtr handle);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_manager_destroy", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int DestroyHandle(IntPtr handle);
         // int dpm_manager_destroy(device_policy_manager_h handle)
 
         [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_password_get_expires", CallingConvention = CallingConvention.Cdecl), ]
         internal static extern int PasswordGetExpires(IntPtr handle, out int value);
         // int dpm_password_get_expires(device_policy_manager_h handle, int* value)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_password_get_history", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PasswordGetHistory(IntPtr handle, out int value);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_password_get_history", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int PasswordGetHistory(IntPtr handle, out int value);
         // int dpm_password_get_history(device_policy_manager_h handle, int* value)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_password_get_max_inactivity_time_device_lock", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PasswordGetMaxInactivityTimeDeviceLock(IntPtr handle, out int value);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_password_get_max_inactivity_time_device_lock", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int PasswordGetMaxInactivityTimeDeviceLock(IntPtr handle, out int value);
         // int dpm_password_get_max_inactivity_time_device_lock(device_policy_manager_h handle, int* value)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_password_get_maximum_failed_attempts_for_wipe", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PasswordGetMaximumFailedAttemptsForWipe(IntPtr handle, out int value);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_password_get_maximum_failed_attempts_for_wipe", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int PasswordGetMaximumFailedAttemptsForWipe(IntPtr handle, out int value);
         // int dpm_password_get_maximum_failed_attempts_for_wipe(device_policy_manager_h handle, int* value)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_password_get_min_complex_chars", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PasswordGetMinComplexChars(IntPtr handle, out int value);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_password_get_min_complex_chars", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int PasswordGetMinComplexChars(IntPtr handle, out int value);
         // int dpm_password_get_min_complex_chars(device_policy_manager_h handle, int* value)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_password_get_minimum_length", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PasswordGetMinimumLength(IntPtr handle, out int value);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_password_get_minimum_length", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int PasswordGetMinimumLength(IntPtr handle, out int value);
         // int dpm_password_get_minimum_length(device_policy_manager_h handle, int* value)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_password_get_quality", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int PasswordGetQuality(IntPtr handle, out int quality);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_password_get_quality", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int PasswordGetQuality(IntPtr handle, out int quality);
         // int dpm_password_get_quality(device_policy_manager_h handle, int* quality)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_messaging_state", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int RestrictionGetMessagingState(IntPtr handle, string simId, out int allowed);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_messaging_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RestrictionGetMessagingState(IntPtr handle, string simId, out int allowed);
         // int dpm_restriction_get_messaging_state(device_policy_manager_h handle, const char* sim_id, int* is_allowed)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_popimap_email_state", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int RestrictionGetPopimapEmailState(IntPtr handle, out int allowed);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_popimap_email_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RestrictionGetPopimapEmailState(IntPtr handle, out int allowed);
         // int dpm_restriction_get_popimap_email_state(device_policy_manager_h handle, int* is_allowed)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_wifi_state", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int RestrictionGetWifiState(IntPtr handle, out int allowed);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_wifi_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RestrictionGetWifiState(IntPtr handle, out int allowed);
         // int dpm_restriction_get_wifi_state(device_policy_manager_h handle, int* is_allowed)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_wifi_hotspot_state", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int RestrictionGetWifiHotspotState(IntPtr handle, out int allowed);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_wifi_hotspot_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RestrictionGetWifiHotspotState(IntPtr handle, out int allowed);
         // int dpm_restriction_get_wifi_hotspot_state(device_policy_manager_h handle, int* is_allowed)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_bluetooth_mode_change_state", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int RestrictionGetBluetoothModeChangeState(IntPtr handle, out int allowed);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_bluetooth_mode_change_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RestrictionGetBluetoothModeChangeState(IntPtr handle, out int allowed);
         // int dpm_restriction_get_bluetooth_mode_change_state(device_policy_manager_h handle, int* is_allowed)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_bluetooth_tethering_state", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int RestrictionGetBluetoothTetheringState(IntPtr handle, out int allowed);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_bluetooth_tethering_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RestrictionGetBluetoothTetheringState(IntPtr handle, out int allowed);
         // int dpm_restriction_get_bluetooth_tethering_state(device_policy_manager_h handle, int* is_allowed)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_browser_state", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int RestrictionGetBrowserState(IntPtr handle, out int allowed);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_browser_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RestrictionGetBrowserState(IntPtr handle, out int allowed);
         // int dpm_restriction_get_browser_state(device_policy_manager_h handle, int* is_allowed)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_camera_state", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int RestrictionGetCameraState(IntPtr handle, out int allowed);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_camera_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RestrictionGetCameraState(IntPtr handle, out int allowed);
         // int dpm_restriction_get_camera_state(device_policy_manager_h handle, int* is_allowed)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_microphone_state", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int RestrictionGetMicrophoneState(IntPtr handle, out int allowed);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_microphone_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RestrictionGetMicrophoneState(IntPtr handle, out int allowed);
         // int dpm_restriction_get_microphone_state(device_policy_manager_h handle, int* is_allowed)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_location_state", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int RestrictionGetLocationState(IntPtr handle, out int allowed);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_location_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RestrictionGetLocationState(IntPtr handle, out int allowed);
         // int dpm_restriction_get_location_state(device_policy_manager_h handle, int* is_allowed)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_external_storage_state", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int RestrictionGetExternalStorageState(IntPtr handle, out int allowed);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_external_storage_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RestrictionGetExternalStorageState(IntPtr handle, out int allowed);
         // int dpm_restriction_get_external_storage_state(device_policy_manager_h handle, int* is_allowed)
 
-        [DllImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_usb_tethering_state", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int RestrictionGetUsbTetheringState(IntPtr handle, out int allowed);
+        [LibraryImport(Libraries.DevicePolicyManager, EntryPoint = "dpm_restriction_get_usb_tethering_state", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RestrictionGetUsbTetheringState(IntPtr handle, out int allowed);
         // int dpm_restriction_get_usb_tethering_state(device_policy_manager_h handle, int* is_allowed)
     }
 }
+
+
+

--- a/src/Tizen.Security.DevicePolicyManager/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Security.DevicePolicyManager/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  *  Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string DevicePolicyManager = "libdpm.so.0";
     }
 }
+
+
+

--- a/src/Tizen.Security.PrivacyPrivilegeManager/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Security.PrivacyPrivilegeManager/Interop/Interop.Libraries.cs
@@ -21,3 +21,6 @@ internal static partial class Interop
         internal const string PrivacyPrivilegeManager = "libcapi-privacy-privilege-manager.so.0";
     }
 }
+
+
+

--- a/src/Tizen.Security.PrivacyPrivilegeManager/Interop/Interop.PrivacyPrivilegeManager.cs
+++ b/src/Tizen.Security.PrivacyPrivilegeManager/Interop/Interop.PrivacyPrivilegeManager.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
@@ -59,21 +60,24 @@ internal static partial class Interop
                                                                [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] string[] privileges,
                                                                uint privilegesCount, IntPtr userData);
 
-        [DllImport(Libraries.PrivacyPrivilegeManager, EntryPoint = "ppm_check_permission")]
-        internal static extern ErrorCode CheckPermission(string privilege, out CheckResult result);
+        [LibraryImport(Libraries.PrivacyPrivilegeManager, EntryPoint = "ppm_check_permission", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CheckPermission(string privilege, out CheckResult result);
 
-        [DllImport(Libraries.PrivacyPrivilegeManager, EntryPoint = "ppm_check_permissions")]
-        internal static extern ErrorCode CheckPermissions([MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]string[] privileges,
+        [LibraryImport(Libraries.PrivacyPrivilegeManager, EntryPoint = "ppm_check_permissions", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode CheckPermissions([MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]string[] privileges,
                                                           uint privilegesCount,
                                                           [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] CheckResult[] results);
 
 
-        [DllImport(Libraries.PrivacyPrivilegeManager, EntryPoint = "ppm_request_permission")]
-        internal static extern ErrorCode RequestPermission(string privilege, RequestResponseCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.PrivacyPrivilegeManager, EntryPoint = "ppm_request_permission", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode RequestPermission(string privilege, RequestResponseCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.PrivacyPrivilegeManager, EntryPoint = "ppm_request_permissions")]
-        internal static extern ErrorCode RequestPermissions([MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] string[] privileges,
+        [LibraryImport(Libraries.PrivacyPrivilegeManager, EntryPoint = "ppm_request_permissions", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode RequestPermissions([MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] string[] privileges,
                                                             uint privilegesCount, RequestMultipleResponseCallback callback, IntPtr userData);
 
     }
 }
+
+
+

--- a/src/Tizen.Security.SecureRepository/Interop/Interop.CkmcErrors.cs
+++ b/src/Tizen.Security.SecureRepository/Interop/Interop.CkmcErrors.cs
@@ -46,3 +46,6 @@ internal static partial class Interop
         }
     }
 }
+
+
+

--- a/src/Tizen.Security.SecureRepository/Interop/Interop.CkmcManager.cs
+++ b/src/Tizen.Security.SecureRepository/Interop/Interop.CkmcManager.cs
@@ -16,125 +16,132 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
     internal static partial class CkmcManager
     {
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_save_key", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_save_key")]
         public static extern int SaveKey(string alias, CkmcKey key, CkmcPolicy policy);
         // int ckmc_save_key(const char *alias, const ckmc_key_s key, const ckmc_policy_s policy);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_get_key", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_get_key")]
         public static extern int GetKey(string alias, string password, out IntPtr key);
         // int ckmc_get_key(const char *alias, const char *password, ckmc_key_s **ppkey);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_get_key_alias_list", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_get_key_alias_list")]
         public static extern int GetKeyAliasList(out IntPtr aliases);
         // int ckmc_get_key_alias_list(ckmc_alias_list_s **ppalias_list);
 
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_save_cert", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_save_cert")]
         public static extern int SaveCert(string alias, CkmcCert cert, CkmcPolicy policy);
         // int ckmc_save_cert(const char *alias, const ckmc_cert_s cert, const ckmc_policy_s policy);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_get_cert", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_get_cert")]
         public static extern int GetCert(string alias, string password, out IntPtr data);
         // int ckmc_get_cert(const char *alias, const char *password, ckmc_cert_s** ppcert);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_get_cert_alias_list", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_get_cert_alias_list")]
         public static extern int GetCertAliasList(out IntPtr aliases);
         // int ckmc_get_cert_alias_list(ckmc_alias_list_s **ppalias_list);
 
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_save_data", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_save_data")]
         public static extern int SaveData(string alias, CkmcRawBuffer data, CkmcPolicy policy);
         // int ckmc_save_data(const char *alias, ckmc_raw_buffer_s data, const ckmc_policy_s policy);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_get_data", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_get_data")]
         public static extern int GetData(string alias, string password, out IntPtr data);
         // int ckmc_get_data(const char* alias, const char* password, ckmc_raw_buffer_s **ppdata);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_get_data_alias_list", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_get_data_alias_list")]
         public static extern int GetDataAliasList(out IntPtr aliases);
         // int ckmc_get_data_alias_list(ckmc_alias_list_s **ppalias_list);
 
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_remove_alias", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_remove_alias")]
         public static extern int RemoveAlias(string alias);
         // int ckmc_remove_alias(const char *alias);
 
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_save_pkcs12", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_save_pkcs12")]
         public static extern int SavePkcs12(string alias, IntPtr p12, CkmcPolicy keyPolicy, CkmcPolicy certPolicy);
         // int ckmc_save_pkcs12(const char *alias, const ckmc_pkcs12_s* pkcs, const ckmc_policy_s key_policy, const ckmc_policy_s cert_policy);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_get_pkcs12", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_get_pkcs12")]
         public static extern int GetPkcs12(string alias, string keyPassword, string certPassword, out IntPtr pkcs12);
         // int ckmc_get_pkcs12(const char *alias, const char *key_password, const char* cert_password, ckmc_pkcs12_s **pkcs12);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_set_permission", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_set_permission")]
         public static extern int SetPermission(string alias, string accessor, int permissions);
         // int ckmc_set_permission(const char *alias, const char *accessor, int permissions);
 
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_create_key_pair_rsa", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_create_key_pair_rsa")]
         public static extern int CreateKeyPairRsa(UIntPtr size, string privateKeyAlias, string publicKeyAlias,
                                                   CkmcPolicy privateKeyPolicy, CkmcPolicy publicKeyPolicy);
         // int ckmc_create_key_pair_rsa(const size_t size, const char* private_key_alias, const char* public_key_alias,
         //                              const ckmc_policy_s policy_private_key, const ckmc_policy_s policy_public_key);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_create_key_pair_dsa", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_create_key_pair_dsa")]
         public static extern int CreateKeyPairDsa(UIntPtr size, string privateKeyAlias, string publicKeyAlias,
                                                   CkmcPolicy privateKeyPolicy, CkmcPolicy publicKeyPolicy);
         // int ckmc_create_key_pair_dsa(const size_t size, const char* private_key_alias, const char* public_key_alias,
         //                              const ckmc_policy_s policy_private_key, const ckmc_policy_s policy_public_key);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_create_key_pair_ecdsa", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_create_key_pair_ecdsa")]
         public static extern int CreateKeyPairEcdsa(int ecType, string privateKeyAlias, string publicKeyAlias,
                                                         CkmcPolicy privateKeyPolicy, CkmcPolicy publicKeyPolicy);
         // int ckmc_create_key_pair_ecdsa(const ckmc_ec_type_e type, const char* private_key_alias, const char* public_key_alias,
         //                                const ckmc_policy_s policy_private_key, const ckmc_policy_s policy_public_key);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_create_key_aes", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_create_key_aes")]
         public static extern int CreateKeyAes(UIntPtr size, string ceyAlias, CkmcPolicy keyPolicy);
         // int ckmc_create_key_aes(size_t size, const char* key_alias, ckmc_policy_s key_policy);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_create_signature", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_create_signature")]
         public static extern int CreateSignature(string privateKeyAlias, string password, CkmcRawBuffer message,
                                                  int hashAlgorithm, int paddingAlgorithm, out IntPtr signature);
         // int ckmc_create_signature(const char *private_key_alias, const char* password, const ckmc_raw_buffer_s message,
         //                           const ckmc_hash_algo_e hash, const ckmc_rsa_padding_algo_e padding, ckmc_raw_buffer_s **ppsignature);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_verify_signature", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_verify_signature")]
         public static extern int VerifySignature(string publicKeyAlias, string password, CkmcRawBuffer message,
                                                  CkmcRawBuffer signature, int hashAlgorithm, int paddingAlgorithm);
         // int ckmc_verify_signature(const char *public_key_alias, const char* password, const ckmc_raw_buffer_s message,
         //           const ckmc_raw_buffer_s signature, const ckmc_hash_algo_e hash, const ckmc_rsa_padding_algo_e padding);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_encrypt_data", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_encrypt_data")]
         public static extern int EncryptData(IntPtr parameters, string keyAlias, string password, CkmcRawBuffer plainText, out IntPtr cipherText);
         // int ckmc_encrypt_data(ckmc_param_list_h params, const char* key_alias, const char* password,
         //                       const ckmc_raw_buffer_s decrypted, ckmc_raw_buffer_s **ppencrypted);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_decrypt_data", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_decrypt_data")]
         public static extern int DecryptData(IntPtr parameters, string keyAlias, string password, CkmcRawBuffer cipherText, out IntPtr plainText);
         // int ckmc_decrypt_data(ckmc_param_list_h params, const char* key_alias, const char* password,
         //                       const ckmc_raw_buffer_s encrypted, ckmc_raw_buffer_s **ppdecrypted);
 
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_get_cert_chain", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_get_cert_chain")]
         public static extern int GetCertChain(IntPtr cert, IntPtr untrustedCerts, out IntPtr certChain);
         // int ckmc_get_cert_chain(const ckmc_cert_s *cert, const ckmc_cert_list_s* untrustedcerts, ckmc_cert_list_s **ppcert_chain_list);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_get_cert_chain_with_trustedcert", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_get_cert_chain_with_trustedcert")]
         public static extern int GetCertChainWithTrustedCerts(IntPtr cert, IntPtr untrustedCerts, IntPtr trustedCerts,
-                                                              bool useTrustedSystemCerts, out IntPtr certChain);
+                                                              [MarshalAs(UnmanagedType.U1)] bool useTrustedSystemCerts, out IntPtr certChain);
         // int ckmc_get_cert_chain_with_trustedcert(const ckmc_cert_s *cert, const ckmc_cert_list_s* untrustedcerts,
-        //       const ckmc_cert_list_s* trustedcerts, const bool use_trustedsystemcerts, ckmc_cert_list_s **ppcert_chain_list);
+        //       const ckmc_cert_list_s* trustedcerts, const [MarshalAs(UnmanagedType.U1)] bool use_trustedsystemcerts, ckmc_cert_list_s **ppcert_chain_list);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_ocsp_check", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_ocsp_check")]
         public static extern int OcspCheck(IntPtr certChain, ref int ocspStatus);
         // int ckmc_ocsp_check(const ckmc_cert_list_s *pcert_chain_list, ckmc_ocsp_status_e* ocsp_status);
     }
 }
+
+
+
+
+
+

--- a/src/Tizen.Security.SecureRepository/Interop/Interop.CkmcTypes.cs
+++ b/src/Tizen.Security.SecureRepository/Interop/Interop.CkmcTypes.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Internals;
 
 internal static partial class Interop
@@ -24,7 +25,7 @@ internal static partial class Interop
     [StructLayout(LayoutKind.Sequential)]
     internal struct CkmcPolicy
     {
-        public CkmcPolicy(string password, bool extractable)
+        public CkmcPolicy(string password, [MarshalAs(UnmanagedType.U1)] bool extractable)
         {
             this.password = password;
             this.extractable = extractable;
@@ -119,104 +120,108 @@ internal static partial class Interop
 
     internal static partial class CkmcTypes
     {
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_key_new", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int KeyNew(byte[] rawKey, UIntPtr size, int keyType, string password, out IntPtr cert);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_key_new", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int KeyNew(byte[] rawKey, UIntPtr size, int keyType, string password, out IntPtr cert);
         // int ckmc_key_new(unsigned char *raw_key, size_t key_size, ckmc_key_type_e key_type, char *password, ckmc_key_s **ppkey);
         //
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_key_free", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void KeyFree(IntPtr buffer);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_key_free", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial void KeyFree(IntPtr buffer);
         // void ckmc_key_free(ckmc_key_s *key);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_buffer_new", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int BufferNew(byte[] data, UIntPtr size, out IntPtr buffer);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_buffer_new", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int BufferNew(byte[] data, UIntPtr size, out IntPtr buffer);
         // int ckmc_buffer_new(unsigned char *data, size_t size, ckmc_raw_buffer_s** ppbuffer);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_buffer_free", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void BufferFree(IntPtr buffer);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_buffer_free", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial void BufferFree(IntPtr buffer);
         // void ckmc_buffer_free(ckmc_raw_buffer_s* buffer);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_cert_new", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int CertNew(byte[] rawCert, UIntPtr size, int dataFormat, out IntPtr cert);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_cert_new", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int CertNew(byte[] rawCert, UIntPtr size, int dataFormat, out IntPtr cert);
         // int ckmc_cert_new(unsigned char *raw_cert, size_t cert_size, ckmc_data_format_e data_format, ckmc_cert_s** ppcert);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_cert_free", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void CertFree(IntPtr buffer);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_cert_free", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial void CertFree(IntPtr buffer);
         // void ckmc_cert_free(ckmc_cert_s *cert);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_load_cert_from_file", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int LoadCertFromFile(string filePath, out IntPtr cert);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_load_cert_from_file", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int LoadCertFromFile(string filePath, out IntPtr cert);
         // int ckmc_load_cert_from_file(const char *file_path, ckmc_cert_s **cert);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_pkcs12_new", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int Pkcs12New(IntPtr key, IntPtr cert, IntPtr caCerts, out IntPtr p12_bundle);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_pkcs12_new", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int Pkcs12New(IntPtr key, IntPtr cert, IntPtr caCerts, out IntPtr p12_bundle);
         // int ckmc_pkcs12_new(ckmc_key_s *private_key, ckmc_cert_s* cert, ckmc_cert_list_s *ca_cert_list, ckmc_pkcs12_s** pkcs12_bundle);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_pkcs12_load", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int Pkcs12Load(string filePath, string password, out IntPtr pkcs12);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_pkcs12_load", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int Pkcs12Load(string filePath, string password, out IntPtr pkcs12);
         // int ckmc_pkcs12_load(const char *file_path, const char* passphrase, ckmc_pkcs12_s **pkcs12_bundle);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_pkcs12_free", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void Pkcs12Free(IntPtr pkcs12);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_pkcs12_free", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial void Pkcs12Free(IntPtr pkcs12);
         // void ckmc_pkcs12_free(ckmc_pkcs12_s *pkcs12);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_alias_list_new", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int AliasListNew(string alias, out IntPtr aliasList);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_alias_list_new", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int AliasListNew(string alias, out IntPtr aliasList);
         // int ckmc_alias_list_new(char *alias, ckmc_alias_list_s **ppalias_list);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_alias_list_add", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int AliasListAdd(IntPtr previous, string alias, out IntPtr aliasList);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_alias_list_add", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int AliasListAdd(IntPtr previous, string alias, out IntPtr aliasList);
         // int ckmc_alias_list_add(ckmc_alias_list_s *previous, char* alias, ckmc_alias_list_s **pplast);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_alias_list_free", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void AliasListFree(IntPtr first);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_alias_list_free", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial void AliasListFree(IntPtr first);
         // void ckmc_alias_list_free(ckmc_alias_list_s* first);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_alias_list_all_free", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void AliasListAllFree(IntPtr first);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_alias_list_all_free", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial void AliasListAllFree(IntPtr first);
         // void ckmc_alias_list_all_free(ckmc_alias_list_s* first);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_cert_list_new", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int CertListNew(IntPtr cert, out IntPtr certList);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_cert_list_new", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int CertListNew(IntPtr cert, out IntPtr certList);
         // int ckmc_cert_list_new(ckmc_cert_s *cert, ckmc_cert_list_s **ppcert_list);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_cert_list_add", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int CertListAdd(IntPtr previous, IntPtr cert, out IntPtr certList);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_cert_list_add", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int CertListAdd(IntPtr previous, IntPtr cert, out IntPtr certList);
         // int ckmc_cert_list_add(ckmc_cert_list_s *previous, ckmc_cert_s *cert, ckmc_cert_list_s** pplast);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_cert_list_free", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void CertListFree(IntPtr first);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_cert_list_free", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial void CertListFree(IntPtr first);
         // void ckmc_cert_list_free(ckmc_cert_list_s *first);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_cert_list_all_free", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void CertListAllFree(IntPtr first);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_cert_list_all_free", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial void CertListAllFree(IntPtr first);
         // void ckmc_cert_list_all_free(ckmc_cert_list_s *first);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_param_list_new", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int ParamListNew(out IntPtr paramList);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_param_list_new", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int ParamListNew(out IntPtr paramList);
         // int ckmc_param_list_new(ckmc_param_list_h *pparams);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_param_list_set_integer", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int ParamListSetInteger(IntPtr paramList, int name, long value);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_param_list_set_integer", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int ParamListSetInteger(IntPtr paramList, int name, long value);
         // int ckmc_param_list_set_integer(ckmc_param_list_h params, ckmc_param_name_e name, uint64_t value);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_param_list_set_buffer", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int ParamListSetBuffer(IntPtr paramList, int name, IntPtr buffer);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_param_list_set_buffer", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int ParamListSetBuffer(IntPtr paramList, int name, IntPtr buffer);
         // int ckmc_param_list_set_buffer(ckmc_param_list_h params, ckmc_param_name_e name, const ckmc_raw_buffer_s* buffer);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_param_list_get_integer", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int ParamListGetInteger(IntPtr paramList, int name, out long value);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_param_list_get_integer", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int ParamListGetInteger(IntPtr paramList, int name, out long value);
         // int ckmc_param_list_get_integer(ckmc_param_list_h params, ckmc_param_name_e name, uint64_t *pvalue);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_param_list_get_buffer", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int ParamListGetBuffer(IntPtr paramList, int name, out IntPtr buffer);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_param_list_get_buffer", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int ParamListGetBuffer(IntPtr paramList, int name, out IntPtr buffer);
         // int ckmc_param_list_get_buffer(ckmc_param_list_h params, ckmc_param_name_e name, ckmc_raw_buffer_s **ppbuffer);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_param_list_free", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void ParamListFree(IntPtr first);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_param_list_free", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial void ParamListFree(IntPtr first);
         // void ckmc_param_list_free(ckmc_param_list_h params);
 
-        [DllImport(Libraries.KeyManager, EntryPoint = "ckmc_generate_new_params", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int GenerateNewParam(int algoType, out IntPtr paramList);
+        [LibraryImport(Libraries.KeyManager, EntryPoint = "ckmc_generate_new_params", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int GenerateNewParam(int algoType, out IntPtr paramList);
         // int ckmc_generate_new_params(ckmc_algo_type_e type, ckmc_param_list_h *pparams);
     }
 }
+
+
+
+

--- a/src/Tizen.Security.SecureRepository/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Security.SecureRepository/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  *  Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string KeyManager = "libkey-manager-client.so.1";
     }
 }
+
+
+

--- a/src/Tizen.Security.TEEC/Interop/Interop.Errors.cs
+++ b/src/Tizen.Security.TEEC/Interop/Interop.Errors.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Interop.Errors.cs
  *
  *  Created on: Apr 4, 2017
@@ -41,3 +41,6 @@ internal static partial class Interop
         }
     }
 }
+
+
+

--- a/src/Tizen.Security.TEEC/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Security.TEEC/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  *  Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string Libteec = "libteec.so";
     }
 }
+
+
+

--- a/src/Tizen.Security.TEEC/Interop/Interop.Libteec.cs
+++ b/src/Tizen.Security.TEEC/Interop/Interop.Libteec.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  *  Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -128,3 +128,6 @@ internal static partial class Interop
         static public extern void RequestCancellation(IntPtr operation);
     }
 }
+
+
+

--- a/src/Tizen.Security.TEEC/Interop/Interop.Types.cs
+++ b/src/Tizen.Security.TEEC/Interop/Interop.Types.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  *  Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -164,4 +164,7 @@ internal static partial class Interop
         public IntPtr imp;
     }
 }
+
+
+
 

--- a/src/Tizen.Security.WebAuthn/Interop/Interop.Libweabuthn.cs
+++ b/src/Tizen.Security.WebAuthn/Interop/Interop.Libweabuthn.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  *  Copyright (c) 2024 Samsung Electronics Co., Ltd All Rights Reserved
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
@@ -26,24 +27,27 @@ internal static partial class Interop
 
     internal static partial class Libwebauthn
     {
-        [DllImport(Libraries.Libwebauthn, EntryPoint = "wauthn_set_api_version", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int SetApiVersion(int apiVersionNumber);
+        [LibraryImport(Libraries.Libwebauthn, EntryPoint = "wauthn_set_api_version", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SetApiVersion(int apiVersionNumber);
         // int wauthn_set_api_version(int api_version_number);
 
-        [DllImport(Libraries.Libwebauthn, EntryPoint = "wauthn_supported_authenticators", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int SupportedAuthenticators(out uint supported);
+        [LibraryImport(Libraries.Libwebauthn, EntryPoint = "wauthn_supported_authenticators", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int SupportedAuthenticators(out uint supported);
         // int wauthn_supported_authenticators(unsigned int *supported);
 
-        [DllImport(Libraries.Libwebauthn, EntryPoint = "wauthn_make_credential", CallingConvention = CallingConvention.Cdecl)]
+        
         public static extern int MakeCredential([In] WauthnClientData clientData, [In] WauthnPubkeyCredCreationOptions options, [In, Out] WauthnMcCallbacks callbacks);
         // int wauthn_make_credential( const wauthn_client_data_s *client_data, const wauthn_pubkey_cred_creation_options_s *options, wauthn_mc_callbacks_s *callbacks);
 
-        [DllImport(Libraries.Libwebauthn, EntryPoint = "wauthn_get_assertion", CallingConvention = CallingConvention.Cdecl)]
+        
         public static extern int GetAssertion([In] WauthnClientData clientData, [In] WauthnPubkeyCredRequestOptions options, [In, Out] WauthnGaCallbacks callbacks);
         // int wauthn_get_assertion( const wauthn_client_data_s *client_data, const wauthn_pubkey_cred_request_options_s *options, wauthn_ga_callbacks_s *callbacks);
 
-        [DllImport(Libraries.Libwebauthn, EntryPoint = "wauthn_cancel", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int Cancel();
+        [LibraryImport(Libraries.Libwebauthn, EntryPoint = "wauthn_cancel", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int Cancel();
         // int wauthn_cancel();
     }
 }
+
+
+

--- a/src/Tizen.Security.WebAuthn/Interop/Interop.Types.cs
+++ b/src/Tizen.Security.WebAuthn/Interop/Interop.Types.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  *  Copyright (c) 2024 Samsung Electronics Co., Ltd All Rights Reserved
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -519,3 +519,6 @@ internal static partial class Interop
 
     #endregion
 }
+
+
+

--- a/src/Tizen.Security/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Security/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  *  Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,3 +21,6 @@ internal static partial class Interop
         public const string Privilege = "libprivilege-info.so.1";
     }
 }
+
+
+

--- a/src/Tizen.Security/Interop/Interop.Privilege.cs
+++ b/src/Tizen.Security/Interop/Interop.Privilege.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  *  Copyright (c) 2016-2020 Samsung Electronics Co., Ltd All Rights Reserved
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Tizen.Security;
 
@@ -25,20 +26,20 @@ internal static partial class Interop
     {
         internal static string LogTag = "Tizen.Security.Privilege";
 
-        [DllImport(Libraries.Privilege, EntryPoint = "privilege_info_get_display_name")]
-            internal static extern int GetDisplayName(string apiVersion, string privilege, out string displayName);
+        [LibraryImport(Libraries.Privilege, EntryPoint = "privilege_info_get_display_name", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetDisplayName(string apiVersion, string privilege, out string displayName);
 
-        [DllImport(Libraries.Privilege, EntryPoint = "privilege_info_get_description")]
-            internal static extern int GetDescription(string apiVersion, string privilege, out string description);
+        [LibraryImport(Libraries.Privilege, EntryPoint = "privilege_info_get_description", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetDescription(string apiVersion, string privilege, out string description);
 
-        [DllImport(Libraries.Privilege, EntryPoint = "privilege_info_get_display_name_by_pkgtype")]
-            internal static extern int GetDisplayNameByPkgtype(string packageType, string apiVersion, string privilege, out string displayName);
+        [LibraryImport(Libraries.Privilege, EntryPoint = "privilege_info_get_display_name_by_pkgtype", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetDisplayNameByPkgtype(string packageType, string apiVersion, string privilege, out string displayName);
 
-        [DllImport(Libraries.Privilege, EntryPoint = "privilege_info_get_description_by_pkgtype")]
-            internal static extern int GetDescriptionByPkgtype(string packageType, string apiVersion, string privilege, out string description);
+        [LibraryImport(Libraries.Privilege, EntryPoint = "privilege_info_get_description_by_pkgtype", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetDescriptionByPkgtype(string packageType, string apiVersion, string privilege, out string description);
 
-        [DllImport(Libraries.Privilege, EntryPoint = "privilege_info_get_privacy_display_name")]
-            internal static extern int GetPrivacyDisplayName(string privilege, out string displayName);
+        [LibraryImport(Libraries.Privilege, EntryPoint = "privilege_info_get_privacy_display_name", StringMarshalling = StringMarshalling.Utf8)]
+            internal static partial int GetPrivacyDisplayName(string privilege, out string displayName);
 
         internal enum ErrorCode
         {
@@ -46,3 +47,6 @@ internal static partial class Interop
         }
     }
 }
+
+
+

--- a/src/Tizen.System.Information/Interop/Interop.RuntimeInfo.cs
+++ b/src/Tizen.System.Information/Interop/Interop.RuntimeInfo.cs
@@ -17,6 +17,7 @@
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Internals;
 using Tizen.System;
 
@@ -116,46 +117,46 @@ internal static partial class Interop
             GemRss = 1000
         }
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_value_int")]
-        public static extern InformationError GetValue(RuntimeInfoKey key, out int status);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_value_int")]
+        public static partial InformationError GetValue(RuntimeInfoKey key, out int status);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_value_bool")]
-        public static extern InformationError GetValue(RuntimeInfoKey key, out bool status);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_value_bool")]
+        public static partial InformationError GetValue(RuntimeInfoKey key, [MarshalAs(UnmanagedType.U1)] out bool status);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_value_double")]
-        public static extern InformationError GetValue(RuntimeInfoKey key, out double status);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_value_double")]
+        public static partial InformationError GetValue(RuntimeInfoKey key, out double status);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_value_string")]
-        public static extern InformationError GetValue(RuntimeInfoKey key, out string status);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_value_string")]
+        public static partial InformationError GetValue(RuntimeInfoKey key, [MarshalAs(UnmanagedType.LPStr)] out string status);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_system_memory_info")]
-        public static extern InformationError GetSystemMemoryInfo(out MemoryInfo memoryInfo);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_system_memory_info")]
+        public static partial InformationError GetSystemMemoryInfo(out MemoryInfo memoryInfo);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_process_memory_info")]
-        public static extern InformationError GetProcessMemoryInfo(int[] pid, int size, ref IntPtr array);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_process_memory_info")]
+        public static partial InformationError GetProcessMemoryInfo(int[] pid, int size, ref IntPtr array);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_cpu_usage")]
-        public static extern InformationError GetCpuUsage(out CpuUsage cpuUsage);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_cpu_usage")]
+        public static partial InformationError GetCpuUsage(out CpuUsage cpuUsage);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_process_cpu_usage")]
-        public static extern InformationError GetProcessCpuUsage(int[] pid, int size, ref IntPtr array);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_process_cpu_usage")]
+        public static partial InformationError GetProcessCpuUsage(int[] pid, int size, ref IntPtr array);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_processor_count")]
-        public static extern InformationError GetProcessorCount(out int processorCount);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_processor_count")]
+        public static partial InformationError GetProcessorCount(out int processorCount);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_processor_current_frequency")]
-        public static extern InformationError GetProcessorCurrentFrequency(int coreId, out int cpuFreq);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_processor_current_frequency")]
+        public static partial InformationError GetProcessorCurrentFrequency(int coreId, out int cpuFreq);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_processor_max_frequency")]
-        public static extern InformationError GetProcessorMaxFrequency(int coreId, out int cpuFreq);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_processor_max_frequency")]
+        public static partial InformationError GetProcessorMaxFrequency(int coreId, out int cpuFreq);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_set_changed_cb")]
-        public static extern InformationError SetRuntimeInfoChangedCallback(RuntimeInfoKey runtimeInfoKey, RuntimeInformationChangedCallback cb, IntPtr userData);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_set_changed_cb")]
+        public static partial InformationError SetRuntimeInfoChangedCallback(RuntimeInfoKey runtimeInfoKey, RuntimeInformationChangedCallback cb, IntPtr userData);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_unset_changed_cb")]
-        public static extern InformationError UnsetRuntimeInfoChangedCallback(RuntimeInfoKey runtimeInfoKey);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_unset_changed_cb")]
+        public static partial InformationError UnsetRuntimeInfoChangedCallback(RuntimeInfoKey runtimeInfoKey);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_process_memory_value_int")]
-        public static extern InformationError GetProcessMemoryValueInt(int[] pid, int size, ProcessMemoryInfoKey memoryInfoKey, out IntPtr array);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_process_memory_value_int")]
+        public static partial InformationError GetProcessMemoryValueInt(int[] pid, int size, ProcessMemoryInfoKey memoryInfoKey, out IntPtr array);
     }
 }

--- a/src/Tizen.System.Information/Interop/Interop.SystemInfo.cs
+++ b/src/Tizen.System.Information/Interop/Interop.SystemInfo.cs
@@ -16,6 +16,7 @@
 
 using Tizen.System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
@@ -36,34 +37,34 @@ internal static partial class Interop
             None,
         }
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_type")]
-        internal static extern InformationError SystemInfoGetPlatformType(string key, out SystemInfoValueType type);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetPlatformType(string key, out SystemInfoValueType type);
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_type")]
-        internal static extern InformationError SystemInfoGetCustomType(string key, out SystemInfoValueType type);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetCustomType(string key, out SystemInfoValueType type);
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_bool")]
-        internal static extern InformationError SystemInfoGetPlatformBool(string key, out bool value);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_bool", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetPlatformBool(string key, [MarshalAs(UnmanagedType.U1)] out bool value);
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_int")]
-        internal static extern InformationError SystemInfoGetPlatformInt(string key, out int value);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_int", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetPlatformInt(string key, out int value);
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_double")]
-        internal static extern InformationError SystemInfoGetPlatformDouble(string key, out double value);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_double", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetPlatformDouble(string key, out double value);
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_string")]
-        internal static extern InformationError SystemInfoGetPlatformString(string key, out string value);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_string", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetPlatformString(string key, out string value);
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_bool")]
-        internal static extern InformationError SystemInfoGetCustomBool(string key, out bool value);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_bool", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetCustomBool(string key, [MarshalAs(UnmanagedType.U1)] out bool value);
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_int")]
-        internal static extern InformationError SystemInfoGetCustomInt(string key, out int value);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_int", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetCustomInt(string key, out int value);
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_double")]
-        internal static extern InformationError SystemInfoGetCustomDouble(string key, out double value);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_double", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetCustomDouble(string key, out double value);
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_string")]
-        internal static extern InformationError SystemInfoGetCustomString(string key, out string value);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_string", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetCustomString(string key, out string value);
     }
 }

--- a/src/Tizen/Interop/Interop.CommonError.cs
+++ b/src/Tizen/Interop/Interop.CommonError.cs
@@ -21,10 +21,10 @@ internal static partial class Interop
 {
     internal static partial class CommonError
     {
-        [DllImport(Libraries.Base, EntryPoint = "get_last_result")]
-        internal static extern int GetLastResult();
+        [LibraryImport(Libraries.Base, EntryPoint = "get_last_result")]
+        internal static partial int GetLastResult();
 
-        [DllImport(Libraries.Base, EntryPoint = "get_error_message")]
-        internal static extern IntPtr GetErrorMessage(int errorCode);
+        [LibraryImport(Libraries.Base, EntryPoint = "get_error_message")]
+        internal static partial IntPtr GetErrorMessage(int errorCode);
     }
 }

--- a/src/Tizen/Interop/Interop.Dlog.cs
+++ b/src/Tizen/Interop/Interop.Dlog.cs
@@ -15,6 +15,7 @@
  */
 
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
@@ -38,11 +39,11 @@ internal static partial class Interop
             DLOG_SILENT,
             DLOG_PRIO_MAX,
         }
-        [DllImportAttribute(Libraries.Dlog, EntryPoint = "dlog_print_dotnet", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int Print(LogPriority prio, string tag, string fmt, string msg);
+        [LibraryImport(Libraries.Dlog, EntryPoint = "dlog_print_dotnet", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Print(LogPriority prio, string tag, string fmt, string msg);
 
-        [DllImportAttribute(Libraries.Dlog, EntryPoint = "dlog_print_dotnet", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int Print(LogPriority prio, string tag, string fmt, string file, string func, int line, string msg);
+        [LibraryImport(Libraries.Dlog, EntryPoint = "dlog_print_dotnet", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Print(LogPriority prio, string tag, string fmt, string file, string func, int line, string msg);
     }
 }
 

--- a/src/Tizen/Interop/Interop.DotnetUtil.cs
+++ b/src/Tizen/Interop/Interop.DotnetUtil.cs
@@ -16,12 +16,13 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
     internal static partial class DotnetUtil
     {
-        [DllImport(Libraries.Vconf, EntryPoint = "vconf_get_int")]
-        internal static extern int GetVconfInt(string key, out int value);
+        [LibraryImport(Libraries.Vconf, EntryPoint = "vconf_get_int", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetVconfInt(string key, out int value);
     }
 }


### PR DESCRIPTION
### Description of Change ###
This draft PR is about to migrate our P/Invoke declaration from `[DllImport]` to the modern `[LibraryImport]` source generator.

The main goal of this refactoring is to:
1. Reduce Marshalling Overhead: Shift runtime marshalling work to compile-time generated C# code.
2. NativeAOT Compatibility: Future-proof our core modules to be compatible with .NET Native AOT.


### What is included in the PR?
- Applied `[LibraryImport]` with `partial` modifiers to safe, core platform modules.
- Explicitly defined `StringMarshalling = StringMarshalling.Utf8` for generated interoperability.


### What is excluded in the PR and Why?
1. Tizen.NUI (and related sub-modules)
  Reason for Exclusion: Lack of support for HandleRef marshaling and the constraints of the SWIG auto-generated structure.
2. Certain Callback/Delegate Methods (Specific files in Tizen.Multimedia, etc.)
  While most of the Tizen.Multimedia namespace has been successfully converted, some methods in specific files such as `Interop.Volume.cs` and `Interop.Device.cs` still utilize [DllImport].
Reason for Exclusion: Requirements for CallingConvention.Cdecl and the inherent complexity of delegate marshaling.
3. Other Domain Projects (Excluding Core Modules)
  Reason for Omission: Projects including Tizen.Uix.* (Voice Index, TTS models), Tizen.Telephony.*, and Tizen.Pims.Contacts are currently out of scope due to the priority.
