### PR TITLE
[NUI][WIP] Migrate DllImport to LibraryImport in NUI modules

### DIFF
--- a/src/Tizen.NUI/src/internal/Application/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application/Application.cs
@@ -566,7 +566,7 @@ namespace Tizen.NUI
         }
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
-            Interop.Application.DeleteApplication(swigCPtr);
+            Interop.Application.DeleteApplication(swigCPtr.Handle);
         }
 
         public enum BatteryStatus
@@ -1788,9 +1788,9 @@ namespace Tizen.NUI
             {
                 rootIdleCallback = RootIdleCallback;
                 System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(rootIdleCallback);
-                System.IntPtr ip2 = Interop.Application.MakeCallback(new System.Runtime.InteropServices.HandleRef(this, ip));
+                System.IntPtr ip2 = Interop.Application.MakeCallback((new System.Runtime.InteropServices.HandleRef(this, ip)).Handle);
 
-                bool ret = Interop.Application.AddIdle(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip2));
+                bool ret = Interop.Application.AddIdle(SwigCPtr.Handle, (new System.Runtime.InteropServices.HandleRef(this, ip2)).Handle);
                 NDalicPINVOKE.ThrowExceptionIfExists();
                 if (!ret)
                 {
@@ -1905,7 +1905,7 @@ namespace Tizen.NUI
 
         public static Application New(int argc, string stylesheet, NUIApplication.WindowMode windowMode, Rectangle positionSize)
         {
-            Application ret = new Application(Interop.Application.New(argc, stylesheet, (int)windowMode, Rectangle.getCPtr(positionSize)), true);
+            Application ret = new Application(Interop.Application.New(argc, stylesheet, (int)windowMode, Rectangle.getCPtr(positionSize).Handle), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -1954,7 +1954,7 @@ namespace Tizen.NUI
             // It will be removed until dali APIs are prepared.
             using Rectangle initRectangle = new Rectangle(0, 0, 0, 0);
 
-            Application ret = new Application(Interop.Application.New(argc, argvStr, stylesheet, (int)windowMode, Rectangle.getCPtr(initRectangle), (int)type), true);
+            Application ret = new Application(Interop.Application.New(argc, argvStr, stylesheet, (int)windowMode, Rectangle.getCPtr(initRectangle).Handle, (int)type), true);
             return ret;
         }
 
@@ -1968,7 +1968,7 @@ namespace Tizen.NUI
                 argc = args.Length;
                 argvStr = string.Join(" ", args);
 
-                ret = new Application(Interop.Application.New(argc, argvStr, stylesheet, (int)windowMode, Rectangle.getCPtr(positionSize), useUIThread), true);
+                ret = new Application(Interop.Application.New(argc, argvStr, stylesheet, (int)windowMode, Rectangle.getCPtr(positionSize).Handle, useUIThread), true);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
             catch (Exception exception)
@@ -1992,7 +1992,7 @@ namespace Tizen.NUI
                 argc = args.Length;
                 argvStr = string.Join(" ", args);
 
-                ret = new Application(Interop.Application.New(argc, argvStr, stylesheet, useUIThread, WindowData.getCPtr(windowData)), true);
+                ret = new Application(Interop.Application.New(argc, argvStr, stylesheet, useUIThread, WindowData.getCPtr(windowData).Handle), true);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
             catch (Exception exception)
@@ -2011,14 +2011,14 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        public Application(Application application) : this(Interop.Application.NewApplication(Application.getCPtr(application)), true)
+        public Application(Application application) : this(Interop.Application.NewApplication(Application.getCPtr(application).Handle), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public Application Assign(Application application)
         {
-            Application ret = new Application(Interop.Application.Assign(SwigCPtr, Application.getCPtr(application)), false);
+            Application ret = new Application(Interop.Application.Assign(SwigCPtr.Handle, Application.getCPtr(application).Handle), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -2031,13 +2031,13 @@ namespace Tizen.NUI
 
         public void Lower()
         {
-            Interop.Application.Lower(SwigCPtr);
+            Interop.Application.Lower(SwigCPtr.Handle);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public void Quit()
         {
-            Interop.Application.Quit(SwigCPtr);
+            Interop.Application.Quit(SwigCPtr.Handle);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -2048,7 +2048,7 @@ namespace Tizen.NUI
                 return window;
             }
 
-            var nativeWindow = Interop.Application.GetWindow(SwigCPtr);
+            var nativeWindow = Interop.Application.GetWindow(SwigCPtr.Handle);
             window = Registry.GetManagedBaseHandleFromNativePtr(nativeWindow) as Window;
             if (window != null)
             {
@@ -2076,27 +2076,27 @@ namespace Tizen.NUI
 
         public string GetLanguage()
         {
-            string ret = Interop.Application.GetLanguage(SwigCPtr);
+            string ret = Interop.Application.GetLanguage(SwigCPtr.Handle);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 
         public string GetRegion()
         {
-            string ret = Interop.Application.GetRegion(SwigCPtr);
+            string ret = Interop.Application.GetRegion(SwigCPtr.Handle);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 
         public void FlushUpdateMessages()
         {
-            Interop.Application.FlushUpdateMessages(SwigCPtr);
+            Interop.Application.FlushUpdateMessages(SwigCPtr.Handle);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public void SetApplicationLocale(string locale)
         {
-            Interop.Application.SetApplicationLocale(SwigCPtr, locale);
+            Interop.Application.SetApplicationLocale(SwigCPtr.Handle, locale);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 

--- a/src/Tizen.NUI/src/internal/Application/ApplicationControlSignal.cs
+++ b/src/Tizen.NUI/src/internal/Application/ApplicationControlSignal.cs
@@ -37,7 +37,7 @@ namespace Tizen.NUI
 
         public uint GetConnectionCount()
         {
-            uint ret = Interop.ApplicationControlSignal.GetConnectionCount(SwigCPtr);
+            uint ret = Interop.ApplicationControlSignal.GetConnectionCount(SwigCPtr.Handle);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -46,7 +46,7 @@ namespace Tizen.NUI
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
             {
-                Interop.ApplicationControlSignal.Connect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                Interop.ApplicationControlSignal.Connect(SwigCPtr.Handle, ip);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
         }
@@ -55,14 +55,14 @@ namespace Tizen.NUI
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
             {
-                Interop.ApplicationControlSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                Interop.ApplicationControlSignal.Disconnect(SwigCPtr.Handle, ip);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
         }
 
         public void Emit(Application arg1, System.IntPtr arg2)
         {
-            Interop.ApplicationControlSignal.Emit(SwigCPtr, Application.getCPtr(arg1), arg2);
+            Interop.ApplicationControlSignal.Emit(SwigCPtr.Handle, Application.getCPtr(arg1).Handle, arg2);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 

--- a/src/Tizen.NUI/src/internal/Application/ApplicationSignal.cs
+++ b/src/Tizen.NUI/src/internal/Application/ApplicationSignal.cs
@@ -39,7 +39,7 @@ namespace Tizen.NUI
 
         public uint GetConnectionCount()
         {
-            uint ret = Interop.ApplicationSignal.GetConnectionCount(SwigCPtr);
+            uint ret = Interop.ApplicationSignal.GetConnectionCount(SwigCPtr.Handle);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -48,7 +48,7 @@ namespace Tizen.NUI
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
             {
-                Interop.ApplicationSignal.Connect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                Interop.ApplicationSignal.Connect(SwigCPtr.Handle, ip);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
         }
@@ -57,14 +57,14 @@ namespace Tizen.NUI
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
             {
-                Interop.ApplicationSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                Interop.ApplicationSignal.Disconnect(SwigCPtr.Handle, ip);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
         }
 
         public void Emit(Application arg)
         {
-            Interop.ApplicationSignal.Emit(SwigCPtr, Application.getCPtr(arg));
+            Interop.ApplicationSignal.Emit(SwigCPtr.Handle, Application.getCPtr(arg).Handle);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 

--- a/src/Tizen.NUI/src/internal/Application/WatchBoolSignal.cs
+++ b/src/Tizen.NUI/src/internal/Application/WatchBoolSignal.cs
@@ -37,7 +37,7 @@ namespace Tizen.NUI
 
         public uint GetConnectionCount()
         {
-            uint ret = Interop.Watch.WatchBoolSignalGetConnectionCount(SwigCPtr);
+            uint ret = Interop.Watch.WatchBoolSignalGetConnectionCount(SwigCPtr.Handle);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -46,7 +46,7 @@ namespace Tizen.NUI
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(func);
             {
-                Interop.Watch.WatchBoolSignalConnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                Interop.Watch.WatchBoolSignalConnect(SwigCPtr.Handle, ip);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
         }
@@ -55,14 +55,14 @@ namespace Tizen.NUI
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(func);
             {
-                Interop.Watch.WatchBoolSignalDisconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                Interop.Watch.WatchBoolSignalDisconnect(SwigCPtr.Handle, ip);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
         }
 
         public void Emit(Application arg1, bool arg2)
         {
-            Interop.Watch.WatchBoolSignalEmit(SwigCPtr, Application.getCPtr(arg1), arg2);
+            Interop.Watch.WatchBoolSignalEmit(SwigCPtr.Handle, Application.getCPtr(arg1).Handle, arg2);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 

--- a/src/Tizen.NUI/src/internal/Application/WatchTimeSignal.cs
+++ b/src/Tizen.NUI/src/internal/Application/WatchTimeSignal.cs
@@ -37,7 +37,7 @@ namespace Tizen.NUI
 
         public uint GetConnectionCount()
         {
-            uint ret = Interop.Watch.WatchTimeSignalGetConnectionCount(SwigCPtr);
+            uint ret = Interop.Watch.WatchTimeSignalGetConnectionCount(SwigCPtr.Handle);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -46,7 +46,7 @@ namespace Tizen.NUI
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(func);
             {
-                Interop.Watch.WatchTimeSignalConnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                Interop.Watch.WatchTimeSignalConnect(SwigCPtr.Handle, ip);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
         }
@@ -55,14 +55,14 @@ namespace Tizen.NUI
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(func);
             {
-                Interop.Watch.WatchTimeSignalDisconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                Interop.Watch.WatchTimeSignalDisconnect(SwigCPtr.Handle, ip);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
         }
 
         public void Emit(Application arg1, WatchTime arg2)
         {
-            Interop.Watch.WatchTimeSignalEmit(SwigCPtr, Application.getCPtr(arg1), WatchTime.getCPtr(arg2));
+            Interop.Watch.WatchTimeSignalEmit(SwigCPtr.Handle, Application.getCPtr(arg1).Handle, WatchTime.getCPtr(arg2).Handle);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Accessibility.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Accessibility.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2019 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,8 +15,9 @@
  *
  */
 
-using System;
-using System.Runtime.InteropServices;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -27,41 +28,44 @@ namespace Tizen.NUI
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void SayCallback(string status);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_say")]
-            public static extern void Say(string arg1_text, bool arg2_discardable, SayCallback arg3_callback);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_say", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Say(string arg1_text, [MarshalAs(UnmanagedType.U1)] bool arg2_discardable, SayCallback arg3_callback);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_pause_resume")]
-            public static extern void PauseResume(bool jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_pause_resume", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PauseResume([MarshalAs(UnmanagedType.U1)] bool jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_stop_reading")]
-            public static extern void StopReading(bool jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_stop_reading", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void StopReading([MarshalAs(UnmanagedType.U1)] bool jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_suppress_screen_reader")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_suppress_screen_reader", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool SuppressScreenReader(bool jarg1);
+            public static partial bool SuppressScreenReader([MarshalAs(UnmanagedType.U1)] bool jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_BridgeEnableAutoInit")]
-            public static extern void BridgeEnableAutoInit();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_BridgeEnableAutoInit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void BridgeEnableAutoInit();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_BridgeDisableAutoInit")]
-            public static extern void BridgeDisableAutoInit();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_BridgeDisableAutoInit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void BridgeDisableAutoInit();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_IsEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_IsEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool IsEnabled();
+            public static partial bool IsEnabled();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_IsScreenReaderEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_IsScreenReaderEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool IsScreenReaderEnabled();
+            public static partial bool IsScreenReaderEnabled();
 
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void EnabledDisabledSignalHandler();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_RegisterEnabledDisabledSignalHandler")]
-            public static extern void RegisterEnabledDisabledSignalHandler(EnabledDisabledSignalHandler enabledSignalHandler, EnabledDisabledSignalHandler disabledSignalHandler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_RegisterEnabledDisabledSignalHandler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterEnabledDisabledSignalHandler(EnabledDisabledSignalHandler enabledSignalHandler, EnabledDisabledSignalHandler disabledSignalHandler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_RegisterScreenReaderEnabledDisabledSignalHandler")]
-            public static extern void RegisterScreenReaderEnabledDisabledSignalHandler(EnabledDisabledSignalHandler enabledSignalHandler, EnabledDisabledSignalHandler disabledSignalHandler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_RegisterScreenReaderEnabledDisabledSignalHandler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterScreenReaderEnabledDisabledSignalHandler(EnabledDisabledSignalHandler enabledSignalHandler, EnabledDisabledSignalHandler disabledSignalHandler);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.AccessibilitySignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.AccessibilitySignal.cs
@@ -15,123 +15,132 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static class AccessibilitySignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityDoGestureSignal_Connect")]
-            public static extern void AccessibilityDoGestureConnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityDoGestureSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityDoGestureConnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityDoGestureSignal_Disconnect")]
-            public static extern void AccessibilityDoGestureDisconnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityDoGestureSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityDoGestureDisconnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityGetNameSignal_Connect")]
-            public static extern void AccessibilityGetNameConnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityGetNameSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityGetNameConnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityGetNameSignal_Disconnect")]
-            public static extern void AccessibilityGetNameDisconnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityGetNameSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityGetNameDisconnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityGetNameSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityGetNameSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AccessibilityGetNameEmpty(BaseComponents.View.ControlHandle jarg1);
+            public static partial bool AccessibilityGetNameEmpty(BaseComponents.View.ControlHandle jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityGetDescriptionSignal_Connect")]
-            public static extern void AccessibilityGetDescriptionConnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityGetDescriptionSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityGetDescriptionConnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityGetDescriptionSignal_Disconnect")]
-            public static extern void AccessibilityGetDescriptionDisconnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityGetDescriptionSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityGetDescriptionDisconnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityActivateSignal_Connect")]
-            public static extern void AccessibilityActivateConnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityActivateSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityActivateConnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityActivateSignal_Disconnect")]
-            public static extern void AccessibilityActivateDisconnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityActivateSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityActivateDisconnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityActivateSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityActivateSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AccessibilityActivateEmpty(BaseComponents.View.ControlHandle jarg1);
+            public static partial bool AccessibilityActivateEmpty(BaseComponents.View.ControlHandle jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityActivateSignal_Emit")]
-            public static extern void AccessibilityActivateEmit(BaseComponents.View.ControlHandle jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityActivateSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityActivateEmit(BaseComponents.View.ControlHandle jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingSkippedSignal_Connect")]
-            public static extern void AccessibilityReadingSkippedConnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingSkippedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityReadingSkippedConnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingSkippedSignal_Disconnect")]
-            public static extern void AccessibilityReadingSkippedDisconnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingSkippedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityReadingSkippedDisconnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingSkippedSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingSkippedSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AccessibilityReadingSkippedEmpty(BaseComponents.View.ControlHandle jarg1);
+            public static partial bool AccessibilityReadingSkippedEmpty(BaseComponents.View.ControlHandle jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingSkippedSignal_Emit")]
-            public static extern void AccessibilityReadingSkippedEmit(BaseComponents.View.ControlHandle jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingSkippedSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityReadingSkippedEmit(BaseComponents.View.ControlHandle jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingPausedSignal_Connect")]
-            public static extern void AccessibilityReadingPausedConnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingPausedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityReadingPausedConnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingPausedSignal_Disconnect")]
-            public static extern void AccessibilityReadingPausedDisconnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingPausedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityReadingPausedDisconnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingPausedSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingPausedSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AccessibilityReadingPausedEmpty(BaseComponents.View.ControlHandle jarg1);
+            public static partial bool AccessibilityReadingPausedEmpty(BaseComponents.View.ControlHandle jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingPausedSignal_Emit")]
-            public static extern void AccessibilityReadingPausedEmit(BaseComponents.View.ControlHandle jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingPausedSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityReadingPausedEmit(BaseComponents.View.ControlHandle jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingResumedSignal_Connect")]
-            public static extern void AccessibilityReadingResumedConnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingResumedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityReadingResumedConnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingResumedSignal_Disconnect")]
-            public static extern void AccessibilityReadingResumedDisconnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingResumedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityReadingResumedDisconnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingResumedSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingResumedSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AccessibilityReadingResumedEmpty(BaseComponents.View.ControlHandle jarg1);
+            public static partial bool AccessibilityReadingResumedEmpty(BaseComponents.View.ControlHandle jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingResumedSignal_Emit")]
-            public static extern void AccessibilityReadingResumedEmit(BaseComponents.View.ControlHandle jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingResumedSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityReadingResumedEmit(BaseComponents.View.ControlHandle jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingCancelledSignal_Connect")]
-            public static extern void AccessibilityReadingCancelledConnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingCancelledSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityReadingCancelledConnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingCancelledSignal_Disconnect")]
-            public static extern void AccessibilityReadingCancelledDisconnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingCancelledSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityReadingCancelledDisconnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingCancelledSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingCancelledSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AccessibilityReadingCancelledEmpty(BaseComponents.View.ControlHandle jarg1);
+            public static partial bool AccessibilityReadingCancelledEmpty(BaseComponents.View.ControlHandle jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingCancelledSignal_Emit")]
-            public static extern void AccessibilityReadingCancelledEmit(BaseComponents.View.ControlHandle jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingCancelledSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityReadingCancelledEmit(BaseComponents.View.ControlHandle jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingStoppedSignal_Connect")]
-            public static extern void AccessibilityReadingStoppedConnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingStoppedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityReadingStoppedConnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingStoppedSignal_Disconnect")]
-            public static extern void AccessibilityReadingStoppedDisconnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingStoppedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityReadingStoppedDisconnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingStoppedSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingStoppedSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AccessibilityReadingStoppedEmpty(BaseComponents.View.ControlHandle jarg1);
+            public static partial bool AccessibilityReadingStoppedEmpty(BaseComponents.View.ControlHandle jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingStoppedSignal_Emit")]
-            public static extern void AccessibilityReadingStoppedEmit(BaseComponents.View.ControlHandle jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityReadingStoppedSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityReadingStoppedEmit(BaseComponents.View.ControlHandle jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityActionSignal_Connect")]
-            public static extern void AccessibilityActionConnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityActionSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityActionConnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityActionSignal_Disconnect")]
-            public static extern void AccessibilityActionDisconnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityActionSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityActionDisconnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityHighlightedSignal_Connect")]
-            public static extern void AccessibilityHighlightedConnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityHighlightedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityHighlightedConnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityHighlightedSignal_Disconnect")]
-            public static extern void AccessibilityHighlightedDisconnect(BaseComponents.View.ControlHandle jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityHighlightedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AccessibilityHighlightedDisconnect(BaseComponents.View.ControlHandle jarg1, IntPtr jarg2);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActivatedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActivatedSignalType.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class ActivatedSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ActivatedSignalType_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ActivatedSignalType_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ActivatedSignalType_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ActivatedSignalType_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ActivatedSignalType_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ActivatedSignalType_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ActivatedSignalType_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ActivatedSignalType_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ActivatedSignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ActivatedSignalType_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ActivatedSignalType")]
-            public static extern global::System.IntPtr NewActivatedSignalType();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ActivatedSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewActivatedSignalType();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ActivatedSignalType")]
-            public static extern void DeleteActivatedSignalType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ActivatedSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteActivatedSignalType(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Actor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Actor.cs
@@ -15,7 +15,9 @@
  *
  */
 
+using global::System;
 using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -24,183 +26,188 @@ namespace Tizen.NUI
         internal static partial class Actor
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Actor")]
-            public static extern void DeleteActor(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Actor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteActor(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetName")]
-            public static extern string GetName(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetName(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetName")]
-            public static extern void SetName(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetName(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetId")]
-            public static extern uint GetId(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetId", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetId(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_OnStage")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_OnStage", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool OnStage(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool OnStage(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetLayer")]
-            public static extern global::System.IntPtr GetLayer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetLayer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetLayer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Add")]
-            public static extern void Add(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Add", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Add(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Remove")]
-            public static extern void Remove(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Remove", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Remove(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetCurrentSize")]
-            public static extern global::System.IntPtr GetCurrentSize(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetCurrentSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetCurrentSize(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetParent")]
-            public static extern global::System.IntPtr GetParent(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetParent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetParent(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_FindChildByName")]
-            public static extern global::System.IntPtr FindChildByName(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_FindChildByName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr FindChildByName(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetAnchorPoint")]
-            public static extern void SetAnchorPoint(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetAnchorPoint", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetAnchorPoint(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_FindChildById")]
-            public static extern global::System.IntPtr FindChildById(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_FindChildById", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr FindChildById(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetNaturalSize")]
-            public static extern global::System.IntPtr GetNaturalSize(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetNaturalSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetNaturalSize(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetVisible")]
-            public static extern void SetVisible(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetVisible", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetVisible(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_ScreenToLocal")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_ScreenToLocal", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool ScreenToLocal(global::System.Runtime.InteropServices.HandleRef jarg1, out float jarg2, out float jarg3, float jarg4, float jarg5);
+            public static partial bool ScreenToLocal(IntPtr jarg1, out float jarg2, out float jarg3, float jarg4, float jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetResizePolicy")]
-            public static extern void SetResizePolicy(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetResizePolicy", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetResizePolicy(IntPtr jarg1, int jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetResizePolicy")]
-            public static extern int GetResizePolicy(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetResizePolicy", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetResizePolicy(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetSizeModeFactor")]
-            public static extern void SetSizeModeFactor(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetSizeModeFactor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetSizeModeFactor(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetHeightForWidth")]
-            public static extern float GetHeightForWidth(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetHeightForWidth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetHeightForWidth(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetWidthForHeight")]
-            public static extern float GetWidthForHeight(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetWidthForHeight", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetWidthForHeight(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetRelayoutSize")]
-            public static extern float GetRelayoutSize(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetRelayoutSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetRelayoutSize(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetIgnored")]
-            public static extern void SetIgnored(global::System.Runtime.InteropServices.HandleRef actor, bool ignored);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetIgnored", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetIgnored(IntPtr actor, [MarshalAs(UnmanagedType.U1)] bool ignored);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsIgnored")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsIgnored", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsIgnored(global::System.Runtime.InteropServices.HandleRef actor);
+            public static partial bool IsIgnored(IntPtr actor);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetPadding")]
-            public static extern void SetPadding(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetPadding", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPadding(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetPadding")]
-            public static extern void GetPadding(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetPadding", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GetPadding(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetHierarchyDepth")]
-            public static extern int GetHierarchyDepth(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetHierarchyDepth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetHierarchyDepth(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_AddRenderer")]
-            public static extern uint AddRenderer(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_AddRenderer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint AddRenderer(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetRendererCount")]
-            public static extern uint GetRendererCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetRendererCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetRendererCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetRendererAt")]
-            public static extern global::System.IntPtr GetRendererAt(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetRendererAt", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetRendererAt(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RemoveRenderer__SWIG_0")]
-            public static extern void RemoveRenderer(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RemoveRenderer__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemoveRenderer(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RemoveRenderer__SWIG_1")]
-            public static extern void RemoveRenderer(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RemoveRenderer__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemoveRenderer(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetSuggestedMinimumWidth")]
-            public static extern float GetSuggestedMinimumWidth(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetSuggestedMinimumWidth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetSuggestedMinimumWidth(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetSuggestedMinimumHeight")]
-            public static extern float GetSuggestedMinimumHeight(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetSuggestedMinimumHeight", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetSuggestedMinimumHeight(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetNeedGesturePropagation")]
-            public static extern float SetNeedGesturePropagation(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetNeedGesturePropagation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float SetNeedGesturePropagation(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_CalculateScreenPosition")]
-            public static extern global::System.IntPtr CalculateScreenPosition(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_CalculateScreenPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CalculateScreenPosition(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_CalculateScreenExtents")]
-            public static extern global::System.IntPtr CalculateScreenExtents(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_CalculateScreenExtents", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CalculateScreenExtents(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_CurrentScreenExtents")]
-            public static extern global::System.IntPtr CurrentScreenExtents(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_CurrentScreenExtents", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CurrentScreenExtents(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetVisiblityChangedActor")]
-            public static extern global::System.IntPtr GetVisiblityChangedActor();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetVisiblityChangedActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetVisiblityChangedActor();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingPropertyVector2")]
-            public static extern int InternalRetrievingPropertyVector2(HandleRef actor, int propertyType, HandleRef retrievingVector2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingPropertyVector2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalRetrievingPropertyVector2(IntPtr actor, int propertyType, IntPtr retrievingVector2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyVector2")]
-            public static extern int InternalSetPropertyVector2(HandleRef actor, int propertyType, HandleRef vector2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyVector2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalSetPropertyVector2(IntPtr actor, int propertyType, IntPtr vector2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingPropertyVector3")]
-            public static extern int InternalRetrievingPropertyVector3(HandleRef actor, int propertyType, HandleRef retrievingVector3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingPropertyVector3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalRetrievingPropertyVector3(IntPtr actor, int propertyType, IntPtr retrievingVector3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyVector3")]
-            public static extern int InternalSetPropertyVector3(HandleRef actor, int propertyType, HandleRef vector3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyVector3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalSetPropertyVector3(IntPtr actor, int propertyType, IntPtr vector3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingPropertyVector4")]
-            public static extern int InternalRetrievingPropertyVector4(HandleRef actor, int propertyType, HandleRef retrievingVector4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingPropertyVector4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalRetrievingPropertyVector4(IntPtr actor, int propertyType, IntPtr retrievingVector4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyVector4")]
-            public static extern int InternalSetPropertyVector4(HandleRef actor, int propertyType, HandleRef vector4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyVector4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalSetPropertyVector4(IntPtr actor, int propertyType, IntPtr vector4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingPropertyExtents")]
-            public static extern int InternalRetrievingPropertyExtents(HandleRef actor, int propertyType, HandleRef extents);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingPropertyExtents", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalRetrievingPropertyExtents(IntPtr actor, int propertyType, IntPtr extents);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyExtents")]
-            public static extern int InternalSetPropertyExtents(HandleRef actor, int propertyType, HandleRef extents);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyExtents", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalSetPropertyExtents(IntPtr actor, int propertyType, IntPtr extents);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingPropertyVector2ActualVector3")]
-            public static extern int InternalRetrievingPropertyVector2ActualVector3(HandleRef actor, int propertyType, HandleRef retrievingVector2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingPropertyVector2ActualVector3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalRetrievingPropertyVector2ActualVector3(IntPtr actor, int propertyType, IntPtr retrievingVector2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyVector2ActualVector3")]
-            public static extern int InternalSetPropertyVector2ActualVector3(HandleRef actor, int propertyType, HandleRef vector2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyVector2ActualVector3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalSetPropertyVector2ActualVector3(IntPtr actor, int propertyType, IntPtr vector2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalGetPropertyFloat")]
-            public static extern float InternalGetPropertyFloat(HandleRef actor, int propertyType);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalGetPropertyFloat", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float InternalGetPropertyFloat(IntPtr actor, int propertyType);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyFloat")]
-            public static extern int InternalSetPropertyFloat(HandleRef actor, int propertyType, float valFloat);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyFloat", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalSetPropertyFloat(IntPtr actor, int propertyType, float valFloat);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalGetPropertyBool")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalGetPropertyBool", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool InternalGetPropertyBool(HandleRef actor, int propertyType);
+            public static partial bool InternalGetPropertyBool(IntPtr actor, int propertyType);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyBool")]
-            public static extern int InternalSetPropertyBool(HandleRef actor, int propertyType, bool valBool);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyBool", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalSetPropertyBool(IntPtr actor, int propertyType, [MarshalAs(UnmanagedType.U1)] bool valBool);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalGetPropertyString")]
-            public static extern string InternalGetPropertyString(HandleRef actor, int propertyType);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalGetPropertyString", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string InternalGetPropertyString(IntPtr actor, int propertyType);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyString")]
-            public static extern int InternalSetPropertyString(HandleRef actor, int propertyType, string valString);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyString", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalSetPropertyString(IntPtr actor, int propertyType, string valString);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalGetPropertyInt")]
-            public static extern int InternalGetPropertyInt(HandleRef actor, int propertyType);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalGetPropertyInt", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalGetPropertyInt(IntPtr actor, int propertyType);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyInt")]
-            public static extern int InternalSetPropertyInt(HandleRef actor, int propertyType, int valInt);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyInt", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalSetPropertyInt(IntPtr actor, int propertyType, int valInt);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyMap")]
-            public static extern int InternalSetPropertyMap(HandleRef actor, int propertyType, HandleRef valInt);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyMap", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalSetPropertyMap(IntPtr actor, int propertyType, IntPtr valInt);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorContainer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorContainer.cs
@@ -24,3 +24,5 @@ namespace Tizen.NUI
         }
     }
 }
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorInternal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorInternal.cs
@@ -15,188 +15,196 @@
  *
  */
 
+using global::System;
 using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class ActorInternal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsRoot")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsRoot", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsRoot(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsRoot(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetChildAt")]
-            public static extern global::System.IntPtr GetChildAt(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetChildAt", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetChildAt(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetParentOrigin")]
-            public static extern void SetParentOrigin(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetParentOrigin", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetParentOrigin(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetSize__SWIG_0")]
-            public static extern void SetSize(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetSize__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetSize(IntPtr jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetSize__SWIG_1")]
-            public static extern void SetSize(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetSize__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetSize(IntPtr jarg1, float jarg2, float jarg3, float jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetSize__SWIG_2")]
-            public static extern void SetSizeVector2(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetSize__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetSizeVector2(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetSize__SWIG_3")]
-            public static extern void SetSizeVector3(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetSize__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetSizeVector3(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetPosition__SWIG_0")]
-            public static extern void SetPosition(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetPosition__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPosition(IntPtr jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetPosition__SWIG_1")]
-            public static extern void SetPosition(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetPosition__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPosition(IntPtr jarg1, float jarg2, float jarg3, float jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetPosition__SWIG_2")]
-            public static extern void SetPosition(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetPosition__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPosition(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetX")]
-            public static extern void SetX(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetX", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetX(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetY")]
-            public static extern void SetY(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetY", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetY(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetZ")]
-            public static extern void SetZ(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetZ", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetZ(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_TranslateBy")]
-            public static extern void TranslateBy(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_TranslateBy", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TranslateBy(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetInheritPosition")]
-            public static extern void SetInheritPosition(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetInheritPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetInheritPosition(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsPositionInherited")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsPositionInherited", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsPositionInherited(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsPositionInherited(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetOrientation__SWIG_0")]
-            public static extern void SetOrientationDegree(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetOrientation__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetOrientationDegree(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetOrientation__SWIG_1")]
-            public static extern void SetOrientationRadian(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetOrientation__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetOrientationRadian(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetOrientation__SWIG_2")]
-            public static extern void SetOrientationQuaternion(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetOrientation__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetOrientationQuaternion(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RotateBy__SWIG_0")]
-            public static extern void RotateByDegree(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RotateBy__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RotateByDegree(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RotateBy__SWIG_1")]
-            public static extern void RotateByRadian(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RotateBy__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RotateByRadian(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RotateBy__SWIG_2")]
-            public static extern void RotateByQuaternion(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RotateBy__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RotateByQuaternion(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetCurrentOrientation")]
-            public static extern global::System.IntPtr GetCurrentOrientation(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetCurrentOrientation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetCurrentOrientation(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetInheritOrientation")]
-            public static extern void SetInheritOrientation(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetInheritOrientation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetInheritOrientation(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsOrientationInherited")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsOrientationInherited", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsOrientationInherited(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsOrientationInherited(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetCurrentWorldOrientation")]
-            public static extern global::System.IntPtr GetCurrentWorldOrientation(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetCurrentWorldOrientation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetCurrentWorldOrientation(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetScale__SWIG_0")]
-            public static extern void SetScale(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetScale__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetScale(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetScale__SWIG_1")]
-            public static extern void SetScale(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetScale__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetScale(IntPtr jarg1, float jarg2, float jarg3, float jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetScale__SWIG_2")]
-            public static extern void SetScale(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetScale__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetScale(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_ScaleBy")]
-            public static extern void ScaleBy(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_ScaleBy", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ScaleBy(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_LookAt")]
-            public static extern void LookAt(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, global::System.Runtime.InteropServices.HandleRef jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_LookAt", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LookAt(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4, IntPtr jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetInheritScale")]
-            public static extern void SetInheritScale(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetInheritScale", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetInheritScale(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsScaleInherited")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsScaleInherited", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsScaleInherited(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsScaleInherited(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetCurrentWorldMatrix")]
-            public static extern global::System.IntPtr GetCurrentWorldMatrix(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetCurrentWorldMatrix", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetCurrentWorldMatrix(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsVisible")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsVisible", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsVisible(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsVisible(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetOpacity")]
-            public static extern void SetOpacity(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetOpacity", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetOpacity(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetCurrentOpacity")]
-            public static extern float GetCurrentOpacity(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetCurrentOpacity", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetCurrentOpacity(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetColor")]
-            public static extern void SetColor(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetColor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetColor(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetColorMode")]
-            public static extern void SetColorMode(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetColorMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetColorMode(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetColorMode")]
-            public static extern int GetColorMode(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetColorMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetColorMode(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetDrawMode")]
-            public static extern void SetDrawMode(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetDrawMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetDrawMode(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetDrawMode")]
-            public static extern int GetDrawMode(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetDrawMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetDrawMode(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetKeyboardFocusable")]
-            public static extern void SetKeyboardFocusable(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetKeyboardFocusable", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetKeyboardFocusable(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsKeyboardFocusable")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsKeyboardFocusable", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsKeyboardFocusable(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsKeyboardFocusable(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetKeyboardFocusableChildren")]
-            public static extern void SetKeyboardFocusableChildren(global::System.Runtime.InteropServices.HandleRef manager, bool focusable);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetKeyboardFocusableChildren", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetKeyboardFocusableChildren(IntPtr manager, [MarshalAs(UnmanagedType.U1)] bool focusable);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_AreChildrenKeyBoardFocusable")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_AreChildrenKeyBoardFocusable", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AreChildrenKeyBoardFocusable(global::System.Runtime.InteropServices.HandleRef manager);
+            public static partial bool AreChildrenKeyBoardFocusable(IntPtr manager);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetTouchFocusable")]
-            public static extern void SetFocusableInTouch(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetTouchFocusable", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFocusableInTouch(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsTouchFocusable")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsTouchFocusable", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsFocusableInTouch(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsFocusableInTouch(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetMinimumSize")]
-            public static extern void SetMinimumSize(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetMinimumSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMinimumSize(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetMaximumSize")]
-            public static extern void SetMaximumSize(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetMaximumSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMaximumSize(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_DevelActor_Property_SetTouchAreaOffset")]
-            public static extern void SetTouchAreaOffset(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3, int jarg4, int jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_DevelActor_Property_SetTouchAreaOffset", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTouchAreaOffset(IntPtr jarg1, int jarg2, int jarg3, int jarg4, int jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_DevelActor_Property_GetTouchAreaOffset")]
-            public static extern void GetTouchAreaOffset(global::System.Runtime.InteropServices.HandleRef jarg1, out int jarg2, out int jarg3, out int jarg4, out int jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_DevelActor_Property_GetTouchAreaOffset", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GetTouchAreaOffset(IntPtr jarg1, out int jarg2, out int jarg3, out int jarg4, out int jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RetrieveTargetSize")]
-            public static extern int RetrieveTargetSize(HandleRef actor, HandleRef retrievingVector3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RetrieveTargetSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RetrieveTargetSize(IntPtr actor, IntPtr retrievingVector3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RetrieveCurrentPropertyVector3")]
-            public static extern int RetrieveCurrentPropertyVector3(HandleRef actor, int propertyType, HandleRef retrievingVector3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RetrieveCurrentPropertyVector3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RetrieveCurrentPropertyVector3(IntPtr actor, int propertyType, IntPtr retrievingVector3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RetrieveCurrentPropertyVector2ActualVector3")]
-            public static extern int RetrieveCurrentPropertyVector2ActualVector3(HandleRef actor, int propertyType, HandleRef retrievingVector2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RetrieveCurrentPropertyVector2ActualVector3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RetrieveCurrentPropertyVector2ActualVector3(IntPtr actor, int propertyType, IntPtr retrievingVector2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RetrieveCurrentPropertyVector4")]
-            public static extern int RetrieveCurrentPropertyVector4(HandleRef actor, int propertyType, HandleRef retrievingVector4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RetrieveCurrentPropertyVector4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RetrieveCurrentPropertyVector4(IntPtr actor, int propertyType, IntPtr retrievingVector4);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorProperty.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorProperty.cs
@@ -15,212 +15,221 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class ActorProperty
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_INHERIT_LAYOUT_DIRECTION_get")]
-            public static extern int InheritLayoutDirectionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_INHERIT_LAYOUT_DIRECTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InheritLayoutDirectionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_LAYOUT_DIRECTION_get")]
-            public static extern int LayoutDirectionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_LAYOUT_DIRECTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LayoutDirectionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_SIBLING_ORDER_get")]
-            public static extern int SiblingOrderGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_SIBLING_ORDER_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SiblingOrderGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_OPACITY_get")]
-            public static extern int OpacityGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_OPACITY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int OpacityGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_SCREEN_POSITION_get")]
-            public static extern int ScreenPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_SCREEN_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScreenPositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_POSITION_USES_ANCHOR_POINT_get")]
-            public static extern int PositionUsesAnchorPointGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_POSITION_USES_ANCHOR_POINT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PositionUsesAnchorPointGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_PARENT_ORIGIN_get")]
-            public static extern int ParentOriginGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_PARENT_ORIGIN_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ParentOriginGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_PARENT_ORIGIN_X_get")]
-            public static extern int ParentOriginXGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_PARENT_ORIGIN_X_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ParentOriginXGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_PARENT_ORIGIN_Y_get")]
-            public static extern int ParentOriginYGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_PARENT_ORIGIN_Y_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ParentOriginYGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_PARENT_ORIGIN_Z_get")]
-            public static extern int ParentOriginZGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_PARENT_ORIGIN_Z_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ParentOriginZGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_ANCHOR_POINT_get")]
-            public static extern int AnchorPointGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_ANCHOR_POINT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AnchorPointGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_ANCHOR_POINT_X_get")]
-            public static extern int AnchorPointXGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_ANCHOR_POINT_X_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AnchorPointXGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_ANCHOR_POINT_Y_get")]
-            public static extern int AnchorPointYGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_ANCHOR_POINT_Y_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AnchorPointYGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_ANCHOR_POINT_Z_get")]
-            public static extern int AnchorPointZGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_ANCHOR_POINT_Z_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AnchorPointZGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SIZE_get")]
-            public static extern int SizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SIZE_WIDTH_get")]
-            public static extern int SizeWidthGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SIZE_WIDTH_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SizeWidthGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SIZE_HEIGHT_get")]
-            public static extern int SizeHeightGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SIZE_HEIGHT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SizeHeightGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SIZE_DEPTH_get")]
-            public static extern int SizeDepthGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SIZE_DEPTH_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SizeDepthGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_POSITION_get")]
-            public static extern int PositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_POSITION_X_get")]
-            public static extern int PositionXGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_POSITION_X_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PositionXGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_POSITION_Y_get")]
-            public static extern int PositionYGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_POSITION_Y_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PositionYGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_POSITION_Z_get")]
-            public static extern int PositionZGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_POSITION_Z_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PositionZGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WORLD_POSITION_get")]
-            public static extern int WorldPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WORLD_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WorldPositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WORLD_POSITION_X_get")]
-            public static extern int WorldPositionXGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WORLD_POSITION_X_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WorldPositionXGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WORLD_POSITION_Y_get")]
-            public static extern int WorldPositionYGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WORLD_POSITION_Y_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WorldPositionYGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WORLD_POSITION_Z_get")]
-            public static extern int WorldPositionZGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WORLD_POSITION_Z_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WorldPositionZGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_ORIENTATION_get")]
-            public static extern int OrientationGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_ORIENTATION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int OrientationGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WORLD_ORIENTATION_get")]
-            public static extern int WorldOrientationGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WORLD_ORIENTATION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WorldOrientationGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SCALE_get")]
-            public static extern int ScaleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SCALE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScaleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SCALE_X_get")]
-            public static extern int ScaleXGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SCALE_X_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScaleXGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SCALE_Y_get")]
-            public static extern int ScaleYGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SCALE_Y_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScaleYGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SCALE_Z_get")]
-            public static extern int ScaleZGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SCALE_Z_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScaleZGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WORLD_SCALE_get")]
-            public static extern int WorldScaleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WORLD_SCALE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WorldScaleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_VISIBLE_get")]
-            public static extern int VisibleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_VISIBLE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int VisibleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_COLOR_get")]
-            public static extern int ColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_COLOR_RED_get")]
-            public static extern int ColorRedGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_COLOR_RED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ColorRedGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_COLOR_GREEN_get")]
-            public static extern int ColorGreenGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_COLOR_GREEN_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ColorGreenGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_COLOR_BLUE_get")]
-            public static extern int ColorBlueGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_COLOR_BLUE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ColorBlueGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WORLD_COLOR_get")]
-            public static extern int WorldColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WORLD_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WorldColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WORLD_MATRIX_get")]
-            public static extern int WorldMatrixGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WORLD_MATRIX_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WorldMatrixGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_NAME_get")]
-            public static extern int NameGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_NAME_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int NameGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SENSITIVE_get")]
-            public static extern int SensitiveGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SENSITIVE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SensitiveGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_USER_INTERACTION_ENABLED_get")]
-            public static extern int UserInteractionEnabledGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_USER_INTERACTION_ENABLED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int UserInteractionEnabledGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_LEAVE_REQUIRED_get")]
-            public static extern int LeaveRequiredGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_LEAVE_REQUIRED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LeaveRequiredGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_INHERIT_ORIENTATION_get")]
-            public static extern int InheritOrientationGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_INHERIT_ORIENTATION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InheritOrientationGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_INHERIT_SCALE_get")]
-            public static extern int InheritScaleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_INHERIT_SCALE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InheritScaleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_DRAW_MODE_get")]
-            public static extern int DrawModeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_DRAW_MODE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DrawModeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SIZE_MODE_FACTOR_get")]
-            public static extern int SizeModeFactorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SIZE_MODE_FACTOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SizeModeFactorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WIDTH_RESIZE_POLICY_get")]
-            public static extern int WidthResizePolicyGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WIDTH_RESIZE_POLICY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WidthResizePolicyGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_HEIGHT_RESIZE_POLICY_get")]
-            public static extern int HeightResizePolicyGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_HEIGHT_RESIZE_POLICY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int HeightResizePolicyGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SIZE_SCALE_POLICY_get")]
-            public static extern int SizeScalePolicyGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SIZE_SCALE_POLICY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SizeScalePolicyGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WIDTH_FOR_HEIGHT_get")]
-            public static extern int WidthForHeightGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_WIDTH_FOR_HEIGHT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WidthForHeightGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_HEIGHT_FOR_WIDTH_get")]
-            public static extern int HeightForWidthGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_HEIGHT_FOR_WIDTH_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int HeightForWidthGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_MINIMUM_SIZE_get")]
-            public static extern int MinimumSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_MINIMUM_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MinimumSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_MAXIMUM_SIZE_get")]
-            public static extern int MaximumSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_MAXIMUM_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MaximumSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_INHERIT_POSITION_get")]
-            public static extern int InheritPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_INHERIT_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InheritPositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_CLIPPING_MODE_get")]
-            public static extern int ClippingModeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_CLIPPING_MODE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ClippingModeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_CAPTURE_ALL_TOUCH_AFTER_START_get")]
-            public static extern int CaptureAllTouchAfterStartGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_CAPTURE_ALL_TOUCH_AFTER_START_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CaptureAllTouchAfterStartGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_ALLOW_ONLY_OWN_TOUCH_get")]
-            public static extern int AllowOnlyOwnTouchGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_ALLOW_ONLY_OWN_TOUCH_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AllowOnlyOwnTouchGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_BLEND_EQUATION_get")]
-            public static extern int BlendEquationGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_BLEND_EQUATION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BlendEquationGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_CULLED_get")]
-            public static extern int CulledGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_CULLED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CulledGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_UPDATE_AREA_HINT_get")]
-            public static extern int UpdateAreaHintGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_UPDATE_AREA_HINT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int UpdateAreaHintGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_DISPATCH_TOUCH_MOTION_get")]
-            public static extern int DispatchTouchMotionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_DISPATCH_TOUCH_MOTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DispatchTouchMotionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_DISPATCH_HOVER_MOTION_get")]
-            public static extern int DispatchHoverMotionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_DISPATCH_HOVER_MOTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DispatchHoverMotionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_CHILDREN_DEPTH_INDEX_POLICY_get")]
-            public static extern int ChildrenDepthIndexPolicyGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_CHILDREN_DEPTH_INDEX_POLICY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ChildrenDepthIndexPolicyGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_IGNORED_get")]
-            public static extern int IgnoredGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_IGNORED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int IgnoredGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_WORLD_IGNORED_get")]
-            public static extern int WorldIgnoredGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_WORLD_IGNORED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WorldIgnoredGet();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorSignal.cs
@@ -14,7 +14,10 @@
  * limitations under the License.
  *
  */
-using System.Runtime.InteropServices;
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -22,77 +25,80 @@ namespace Tizen.NUI
     {
         internal static partial class ActorSignal
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_HitTestResultSignal_Connect")]
-            public static extern void HitTestResultConnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_HitTestResultSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void HitTestResultConnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_HitTestResultSignal_Disconnect")]
-            public static extern void HitTestResultDisconnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_HitTestResultSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void HitTestResultDisconnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InterceptTouchedSignal_Connect")]
-            public static extern void InterceptTouchConnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InterceptTouchedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void InterceptTouchConnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InterceptTouchedSignal_Disconnect")]
-            public static extern void InterceptTouchDisconnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InterceptTouchedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void InterceptTouchDisconnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_TouchedSignal_Connect")]
-            public static extern void TouchConnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_TouchedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TouchConnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_TouchedSignal_Disconnect")]
-            public static extern void TouchDisconnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_TouchedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TouchDisconnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_HoveredSignal_Connect")]
-            public static extern void HoveredConnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_HoveredSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void HoveredConnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_HoveredSignal_Disconnect")]
-            public static extern void HoveredDisconnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_HoveredSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void HoveredDisconnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_WheelEventSignal_Connect")]
-            public static extern void WheelEventConnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_WheelEventSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void WheelEventConnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_WheelEventSignal_Disconnect")]
-            public static extern void WheelEventDisconnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_WheelEventSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void WheelEventDisconnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InterceptWheelSignal_Connect")]
-            public static extern void InterceptWheelConnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InterceptWheelSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void InterceptWheelConnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InterceptWheelSignal_Disconnect")]
-            public static extern void InterceptWheelDisconnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InterceptWheelSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void InterceptWheelDisconnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_OnSceneSignal_Connect")]
-            public static extern void OnSceneConnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_OnSceneSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void OnSceneConnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_OnSceneSignal_Disconnect")]
-            public static extern void OnSceneDisconnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_OnSceneSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void OnSceneDisconnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_OffSceneSignal_Connect")]
-            public static extern void OffSceneConnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_OffSceneSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void OffSceneConnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_OffSceneSignal_Disconnect")]
-            public static extern void OffSceneDisconnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_OffSceneSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void OffSceneDisconnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_OnRelayoutSignal_Connect")]
-            public static extern void OnRelayoutConnect(HandleRef actor, HandleRef hanlder);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_OnRelayoutSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void OnRelayoutConnect(IntPtr actor, IntPtr hanlder);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_OnRelayoutSignal_Disconnect")]
-            public static extern void OnRelayoutDisconnect(HandleRef actor, HandleRef hanlder);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_OnRelayoutSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void OnRelayoutDisconnect(IntPtr actor, IntPtr hanlder);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_VisibilityChangedSignal_Connect")]
-            public static extern void VisibilityChangedConnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_VisibilityChangedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void VisibilityChangedConnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_VisibilityChangedSignal_Disconnect")]
-            public static extern void VisibilityChangedDisconnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_VisibilityChangedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void VisibilityChangedDisconnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InheritedVisibilityChangedSignal_Connect")]
-            public static extern void AggregatedVisibilityChangedConnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InheritedVisibilityChangedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AggregatedVisibilityChangedConnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InheritedVisibilityChangedSignal_Disconnect")]
-            public static extern void AggregatedVisibilityChangedDisconnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InheritedVisibilityChangedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AggregatedVisibilityChangedDisconnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_LayoutDirectionChangedSignal_Connect")]
-            public static extern void LayoutDirectionChangedConnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_LayoutDirectionChangedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LayoutDirectionChangedConnect(IntPtr actor, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_LayoutDirectionChangedSignal_Disconnect")]
-            public static extern void LayoutDirectionChangedDisconnect(HandleRef actor, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_LayoutDirectionChangedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LayoutDirectionChangedDisconnect(IntPtr actor, IntPtr handler);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Adaptor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Adaptor.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,23 +26,28 @@ namespace Tizen.NUI
         internal static partial class Adaptor
         {
             //For Adaptor
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Adaptor")]
-            public static extern void DeleteAdaptor(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Adaptor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteAdaptor(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Adaptor_SetRenderRefreshRate")]
-            public static extern void SetRenderRefreshRate(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Adaptor_SetRenderRefreshRate", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetRenderRefreshRate(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Adaptor_SetMaximumRenderFrameRate")]
-            public static extern void SetMaximumRenderFrameRate(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Adaptor_SetMaximumRenderFrameRate", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMaximumRenderFrameRate(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Adaptor_Get")]
-            public static extern global::System.IntPtr Get();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Adaptor_Get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Get();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Adaptor_FeedWheelEvent")]
-            public static extern void FeedWheelEvent(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Adaptor_FeedWheelEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FeedWheelEvent(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Adaptor_FeedKeyEvent")]
-            public static extern void FeedKeyEvent(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Adaptor_FeedKeyEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FeedKeyEvent(IntPtr jarg1, IntPtr jarg2);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.AlphaFunction.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.AlphaFunction.cs
@@ -15,41 +15,50 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class AlphaFunction
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AlphaFunction_0")]
-            public static extern global::System.IntPtr NewAlphaFunction();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AlphaFunction_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewAlphaFunction();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AlphaFunction_BuiltInFunction")]
-            public static extern global::System.IntPtr NewAlphaFunction(int builtInFunction);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AlphaFunction_BuiltInFunction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewAlphaFunction(int builtInFunction);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AlphaFunction_CustomAlphaFunction")]
-            public static extern global::System.IntPtr NewAlphaFunction(global::System.Runtime.InteropServices.HandleRef alphaFunction);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AlphaFunction_CustomAlphaFunction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewAlphaFunction(IntPtr alphaFunction);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AlphaFunction_Bezier")]
-            public static extern global::System.IntPtr NewAlphaFunction(global::System.Runtime.InteropServices.HandleRef controlPoint0, global::System.Runtime.InteropServices.HandleRef controlPoint1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AlphaFunction_Bezier", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewAlphaFunction(IntPtr controlPoint0, IntPtr controlPoint1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AlphaFunction_BuiltInSpring")]
-            public static extern global::System.IntPtr NewAlphaFunctionSpringType(int springType);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AlphaFunction_BuiltInSpring", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewAlphaFunctionSpringType(int springType);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AlphaFunction_CustomSpring")]
-            public static extern global::System.IntPtr NewAlphaFunctionSpringData(float stiffness, float damping, float mass);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AlphaFunction_CustomSpring", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewAlphaFunctionSpringData(float stiffness, float damping, float mass);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AlphaFunction_GetBezierControlPoints")]
-            public static extern global::System.IntPtr GetBezierControlPoints(global::System.Runtime.InteropServices.HandleRef alphaFunction);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AlphaFunction_GetBezierControlPoints", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetBezierControlPoints(IntPtr alphaFunction);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AlphaFunction_GetBuiltinFunction")]
-            public static extern int GetBuiltinFunction(global::System.Runtime.InteropServices.HandleRef alphaFunction);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AlphaFunction_GetBuiltinFunction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetBuiltinFunction(IntPtr alphaFunction);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AlphaFunction_GetMode")]
-            public static extern int GetMode(global::System.Runtime.InteropServices.HandleRef alphaFunction);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AlphaFunction_GetMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetMode(IntPtr alphaFunction);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_AlphaFunction")]
-            public static extern void DeleteAlphaFunction(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_AlphaFunction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteAlphaFunction(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.AlphaFunctionSpringData.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.AlphaFunctionSpringData.cs
@@ -15,14 +15,23 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class AlphaFunctionSpringData
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AlphaFunctionSpringData_GetDuration")]
-            public static extern float GetDuration(float stiffness, float damping, float mass);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AlphaFunctionSpringData_GetDuration", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetDuration(float stiffness, float damping, float mass);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Angle.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Angle.cs
@@ -24,3 +24,5 @@ namespace Tizen.NUI
         }
     }
 }
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.AngleAxis.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.AngleAxis.cs
@@ -15,32 +15,41 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class AngleAxis
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AngleAxis__SWIG_0")]
-            public static extern global::System.IntPtr NewAngleAxis();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AngleAxis__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewAngleAxis();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AngleAxis__SWIG_1")]
-            public static extern global::System.IntPtr NewAngleAxis(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AngleAxis__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewAngleAxis(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AngleAxis_angle_set")]
-            public static extern void AngleSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AngleAxis_angle_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AngleSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AngleAxis_angle_get")]
-            public static extern global::System.IntPtr AngleGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AngleAxis_angle_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr AngleGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AngleAxis_axis_set")]
-            public static extern void AxisSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AngleAxis_axis_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AxisSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AngleAxis_axis_get")]
-            public static extern global::System.IntPtr AxisGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AngleAxis_axis_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr AxisGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_AngleAxis")]
-            public static extern void DeleteAngleAxis(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_AngleAxis", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteAngleAxis(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.AngleThresholdPair.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.AngleThresholdPair.cs
@@ -15,35 +15,44 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class AngleThresholdPair
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AngleThresholdPair__SWIG_0")]
-            public static extern global::System.IntPtr NewAngleThresholdPair();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AngleThresholdPair__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewAngleThresholdPair();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AngleThresholdPair__SWIG_1")]
-            public static extern global::System.IntPtr NewAngleThresholdPair(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AngleThresholdPair__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewAngleThresholdPair(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AngleThresholdPair__SWIG_2")]
-            public static extern global::System.IntPtr NewAngleThresholdPair(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AngleThresholdPair__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewAngleThresholdPair(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AngleThresholdPair_first_set")]
-            public static extern void FirstSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AngleThresholdPair_first_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FirstSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AngleThresholdPair_first_get")]
-            public static extern global::System.IntPtr FirstGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AngleThresholdPair_first_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr FirstGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AngleThresholdPair_second_set")]
-            public static extern void SecondSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AngleThresholdPair_second_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SecondSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AngleThresholdPair_second_get")]
-            public static extern global::System.IntPtr SecondGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AngleThresholdPair_second_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr SecondGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_AngleThresholdPair")]
-            public static extern void DeleteAngleThresholdPair(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_AngleThresholdPair", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteAngleThresholdPair(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.AnimatedImageView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.AnimatedImageView.cs
@@ -14,23 +14,33 @@
  * limitations under the License.
  *
  */
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class AnimatedImageView
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_AnimatedImageVisual_Actions_PLAY_get")]
-            public static extern int AnimatedImageVisualActionPlayGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_AnimatedImageVisual_Actions_PLAY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AnimatedImageVisualActionPlayGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_AnimatedImageVisual_Actions_PAUSE_get")]
-            public static extern int AnimatedImageVisualActionPauseGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_AnimatedImageVisual_Actions_PAUSE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AnimatedImageVisualActionPauseGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_AnimatedImageVisual_Actions_STOP_get")]
-            public static extern int AnimatedImageVisualActionStopGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_AnimatedImageVisual_Actions_STOP_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AnimatedImageVisualActionStopGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_AnimatedImageVisual_Actions_JUMP_TO_get")]
-            public static extern int AnimatedImageVisualActionJumpToGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_AnimatedImageVisual_Actions_JUMP_TO_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AnimatedImageVisualActionJumpToGet();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Animation.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Animation.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,236 +26,241 @@ namespace Tizen.NUI
         internal static partial class Animation
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_New")]
-            public static extern global::System.IntPtr New(float jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(float jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Animation")]
-            public static extern void DeleteAnimation(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Animation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteAnimation(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Animation__SWIG_1")]
-            public static extern global::System.IntPtr NewAnimation(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Animation__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewAnimation(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetDuration")]
-            public static extern void SetDuration(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetDuration", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetDuration(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetDuration")]
-            public static extern float GetDuration(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetDuration", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetDuration(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetLooping")]
-            public static extern void SetLooping(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetLooping", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetLooping(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetLoopCount")]
-            public static extern void SetLoopCount(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetLoopCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetLoopCount(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetLoopCount")]
-            public static extern int GetLoopCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetLoopCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetLoopCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetCurrentLoop")]
-            public static extern int GetCurrentLoop(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetCurrentLoop", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetCurrentLoop(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_IsLooping")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_IsLooping", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsLooping(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsLooping(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetEndAction")]
-            public static extern void SetEndAction(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetEndAction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetEndAction(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetEndAction")]
-            public static extern int GetEndAction(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetEndAction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetEndAction(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetDisconnectAction")]
-            public static extern void SetDisconnectAction(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetDisconnectAction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetDisconnectAction(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetDisconnectAction")]
-            public static extern int GetDisconnectAction(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetDisconnectAction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetDisconnectAction(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetDefaultAlphaFunction")]
-            public static extern void SetDefaultAlphaFunction(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetDefaultAlphaFunction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetDefaultAlphaFunction(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetDefaultAlphaFunction")]
-            public static extern global::System.IntPtr GetDefaultAlphaFunction(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetDefaultAlphaFunction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetDefaultAlphaFunction(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetCurrentProgress")]
-            public static extern void SetCurrentProgress(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetCurrentProgress", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetCurrentProgress(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetCurrentProgress")]
-            public static extern float GetCurrentProgress(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetCurrentProgress", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetCurrentProgress(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetSpeedFactor")]
-            public static extern void SetSpeedFactor(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetSpeedFactor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetSpeedFactor(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetSpeedFactor")]
-            public static extern float GetSpeedFactor(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetSpeedFactor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetSpeedFactor(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetPlayRange")]
-            public static extern void SetPlayRange(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetPlayRange", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPlayRange(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetPlayRange")]
-            public static extern global::System.IntPtr GetPlayRange(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetPlayRange", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetPlayRange(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Play")]
-            public static extern void Play(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Play", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Play(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_PlayFrom")]
-            public static extern void PlayFrom(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_PlayFrom", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PlayFrom(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Pause")]
-            public static extern void Pause(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Pause", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Pause(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetState")]
-            public static extern int GetState(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetState", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetState(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Stop")]
-            public static extern void Stop(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Stop", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Stop(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Clear")]
-            public static extern void Clear(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Clear", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Clear(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetLoopingMode")]
-            public static extern void SetLoopingMode(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetLoopingMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetLoopingMode(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetLoopingMode")]
-            public static extern int GetLoopingMode(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetLoopingMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetLoopingMode(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetAnimationId")]
-            public static extern uint GetAnimationId(global::System.Runtime.InteropServices.HandleRef nuiAnimation);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetAnimationId", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetAnimationId(IntPtr nuiAnimation);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetProgressNotification")]
-            public static extern void SetProgressNotification(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetProgressNotification", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetProgressNotification(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetProgressNotification")]
-            public static extern float GetProgressNotification(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetProgressNotification", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetProgressNotification(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetBlendPoint")]
-            public static extern void SetBlendPoint(global::System.Runtime.InteropServices.HandleRef csAnimation, float blendPoint);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetBlendPoint", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetBlendPoint(IntPtr csAnimation, float blendPoint);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetBlendPoint")]
-            public static extern float GetBlendPoint(global::System.Runtime.InteropServices.HandleRef csAnimation);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetBlendPoint", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetBlendPoint(IntPtr csAnimation);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_FinishedSignal")]
-            public static extern global::System.IntPtr FinishedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_FinishedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr FinishedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_ProgressReachedSignal")]
-            public static extern global::System.IntPtr ProgressReachedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_ProgressReachedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ProgressReachedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_PlayAfter")]
-            public static extern void PlayAfter(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_PlayAfter", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PlayAfter(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBy__SWIG_0")]
-            public static extern void AnimateBy(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBy__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateBy(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBy__SWIG_1")]
-            public static extern void AnimateByAlphaFunction(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBy__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateByAlphaFunction(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBy__SWIG_2")]
-            public static extern void AnimateByTimePeriod(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBy__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateByTimePeriod(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBy__SWIG_3")]
-            public static extern void AnimateBy(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, global::System.Runtime.InteropServices.HandleRef jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBy__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateBy(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4, IntPtr jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateTo__SWIG_0")]
-            public static extern void AnimateTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateTo__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateTo(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateTo__SWIG_1")]
-            public static extern void AnimateToAlphaFunction(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateTo__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateToAlphaFunction(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateTo__SWIG_2")]
-            public static extern void AnimateToTimePeriod(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateTo__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateToTimePeriod(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateTo__SWIG_3")]
-            public static extern void AnimateTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, global::System.Runtime.InteropServices.HandleRef jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateTo__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateTo(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4, IntPtr jarg5);
 
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBy__SWIG_0")]
-            public static extern void AnimateBy(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.IntPtr jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBy__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateBy(IntPtr jarg1, IntPtr jarg2, global::System.IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBy__SWIG_1")]
-            public static extern void AnimateByAlphaFunction(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.IntPtr jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBy__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateByAlphaFunction(IntPtr jarg1, IntPtr jarg2, global::System.IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBy__SWIG_2")]
-            public static extern void AnimateByTimePeriod(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.IntPtr jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBy__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateByTimePeriod(IntPtr jarg1, IntPtr jarg2, global::System.IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBy__SWIG_3")]
-            public static extern void AnimateBy(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.IntPtr jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, global::System.Runtime.InteropServices.HandleRef jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBy__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateBy(IntPtr jarg1, IntPtr jarg2, global::System.IntPtr jarg3, IntPtr jarg4, IntPtr jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateTo__SWIG_0")]
-            public static extern void AnimateTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.IntPtr jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateTo__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateTo(IntPtr jarg1, IntPtr jarg2, global::System.IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateTo__SWIG_1")]
-            public static extern void AnimateToAlphaFunction(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.IntPtr jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateTo__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateToAlphaFunction(IntPtr jarg1, IntPtr jarg2, global::System.IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateTo__SWIG_2")]
-            public static extern void AnimateToTimePeriod(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.IntPtr jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateTo__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateToTimePeriod(IntPtr jarg1, IntPtr jarg2, global::System.IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateTo__SWIG_3")]
-            public static extern void AnimateTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.IntPtr jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, global::System.Runtime.InteropServices.HandleRef jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateTo__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateTo(IntPtr jarg1, IntPtr jarg2, global::System.IntPtr jarg3, IntPtr jarg4, IntPtr jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBetween__SWIG_0")]
-            public static extern void AnimateBetween(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBetween__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateBetween(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBetween__SWIG_1")]
-            public static extern void AnimateBetween(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, int jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBetween__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateBetween(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, int jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBetween__SWIG_2")]
-            public static extern void AnimateBetweenAlphaFunction(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBetween__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateBetweenAlphaFunction(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBetween__SWIG_3")]
-            public static extern void AnimateBetweenAlphaFunctionInterpolation(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, int jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBetween__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateBetweenAlphaFunctionInterpolation(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4, int jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBetween__SWIG_4")]
-            public static extern void AnimateBetweenTimePeriod(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBetween__SWIG_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateBetweenTimePeriod(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBetween__SWIG_5")]
-            public static extern void AnimateBetweenTimePeriodInterpolation(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, int jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBetween__SWIG_5", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateBetweenTimePeriodInterpolation(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4, int jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBetween__SWIG_6")]
-            public static extern void AnimateBetween(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, global::System.Runtime.InteropServices.HandleRef jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBetween__SWIG_6", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateBetween(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4, IntPtr jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBetween__SWIG_7")]
-            public static extern void AnimateBetween(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, global::System.Runtime.InteropServices.HandleRef jarg5, int jarg6);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_AnimateBetween__SWIG_7", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateBetween(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4, IntPtr jarg5, int jarg6);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Animate__SWIG_0")]
-            public static extern void Animate(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Animate__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Animate(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Animate__SWIG_1")]
-            public static extern void AnimateAlphaFunction(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, global::System.Runtime.InteropServices.HandleRef jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Animate__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateAlphaFunction(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4, IntPtr jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Animate__SWIG_2")]
-            public static extern void AnimateTimePeriod(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, global::System.Runtime.InteropServices.HandleRef jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Animate__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimateTimePeriod(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4, IntPtr jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Animate__SWIG_3")]
-            public static extern void Animate(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, global::System.Runtime.InteropServices.HandleRef jarg5, global::System.Runtime.InteropServices.HandleRef jarg6);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Animate__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Animate(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4, IntPtr jarg5, IntPtr jarg6);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Show")]
-            public static extern void Show(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Show", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Show(IntPtr jarg1, IntPtr jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Hide")]
-            public static extern void Hide(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Hide", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Hide(IntPtr jarg1, IntPtr jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AnimationSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AnimationSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AnimationSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool AnimationSignalEmpty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AnimationSignal_GetConnectionCount")]
-            public static extern uint AnimationSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AnimationSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint AnimationSignalGetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AnimationSignal_Connect")]
-            public static extern void AnimationSignalConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AnimationSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimationSignalConnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AnimationSignal_Disconnect")]
-            public static extern void AnimationSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AnimationSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimationSignalDisconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AnimationSignal_Emit")]
-            public static extern void AnimationSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AnimationSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AnimationSignalEmit(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AnimationSignal")]
-            public static extern global::System.IntPtr NewAnimationSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AnimationSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewAnimationSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_AnimationSignal")]
-            public static extern void DeleteAnimationSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_AnimationSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteAnimationSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Any.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Any.cs
@@ -14,33 +14,43 @@
  * limitations under the License.
  *
  */
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Any
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Any__SWIG_0")]
-            public static extern global::System.IntPtr NewAny();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Any__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewAny();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Any")]
-            public static extern void DeleteAny(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Any", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteAny(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Any_AssertAlways")]
-            public static extern void AssertAlways(string jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Any_AssertAlways", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AssertAlways(string jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Any__SWIG_2")]
-            public static extern global::System.IntPtr NewAny(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Any__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewAny(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Any_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Any_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Any_GetType")]
-            public static extern global::System.IntPtr GetType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Any_GetType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetType(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Any_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Any_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Application.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Application.cs
@@ -15,107 +15,113 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Application
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MakeCallback")]
-            public static extern global::System.IntPtr MakeCallback(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MakeCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr MakeCallback(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_PreInitialize")]
-            public static extern void PreInitialize();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_PreInitialize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PreInitialize();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_IsSupportPreInitializedCreation")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsSupportPreInitializedCreation();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_IsSupportPreInitializedCreation", StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static partial bool IsSupportPreInitializedCreation();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_GetPreInitializeWindow")]
-            public static extern global::System.IntPtr GetPreInitializeWindow();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_GetPreInitializeWindow", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetPreInitializeWindow();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_New__SWIG_0")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_New__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_New__SWIG_1")]
-            public static extern global::System.IntPtr New(int jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_New__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_New__SWIG_2")]
-            public static extern global::System.IntPtr New(int jarg1, string jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_New__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int jarg1, string jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_New__SWIG_3")]
-            public static extern global::System.IntPtr New(int jarg1, string jarg3, int jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_New__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int jarg1, string jarg3, int jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Application__SWIG_0")]
-            public static extern global::System.IntPtr NewApplication();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Application__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewApplication();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Application__SWIG_1")]
-            public static extern global::System.IntPtr NewApplication(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Application__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewApplication(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(global::System.IntPtr jarg1, global::System.IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Application")]
-            public static extern void DeleteApplication(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Application", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteApplication(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_Lower")]
-            public static extern void Lower(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_Lower", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Lower(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_Quit")]
-            public static extern void Quit(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_Quit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Quit(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_AddIdle")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddIdle(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_AddIdle", StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static partial bool AddIdle(global::System.IntPtr jarg1, global::System.IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_GetWindow")]
-            public static extern global::System.IntPtr GetWindow(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_GetWindow", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetWindow(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_GetWindowsListSize")]
-            public static extern uint GetWindowsListSize();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_GetWindowsListSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetWindowsListSize();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_GetWindowsFromList")]
-            public static extern global::System.IntPtr GetWindowsFromList(uint jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_GetWindowsFromList", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetWindowsFromList(uint jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_GetResourcePath")]
-            public static extern string GetResourcePath();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_GetResourcePath", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetResourcePath();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_GetLanguage")]
-            public static extern string GetLanguage(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_GetLanguage", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetLanguage(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_GetRegion")]
-            public static extern string GetRegion(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_GetRegion", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetRegion(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_New__SWIG_4")]
-            public static extern global::System.IntPtr New(int jarg1, string jarg3, int jarg4, global::System.Runtime.InteropServices.HandleRef jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_New__SWIG_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int jarg1, string jarg3, int jarg4, global::System.IntPtr jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_New__SWIG_5")]
-            public static extern global::System.IntPtr New(int argc, string argv, string styleSheet, int windowMode, global::System.Runtime.InteropServices.HandleRef initRectangle, int windowType);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_New__SWIG_5", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int argc, string argv, string styleSheet, int windowMode, global::System.IntPtr initRectangle, int windowType);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_New__SWIG_6")]
-            public static extern global::System.IntPtr New(int argc, string argv, string jarg3, int jarg4, global::System.Runtime.InteropServices.HandleRef jarg5, bool jarg7);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_New__SWIG_6", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int argc, string argv, string jarg3, int jarg4, global::System.IntPtr jarg5, [MarshalAs(UnmanagedType.U1)] bool jarg7);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_New_WithWindowData")]
-            public static extern global::System.IntPtr New(int argc, string argv, string styleSheet, bool uiThread, global::System.Runtime.InteropServices.HandleRef windowData);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_New_WithWindowData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int argc, string argv, string styleSheet, [MarshalAs(UnmanagedType.U1)] bool uiThread, global::System.IntPtr windowData);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_FlushUpdateMessages")]
-            public static extern void FlushUpdateMessages(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_FlushUpdateMessages", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FlushUpdateMessages(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetScreenSize")]
-            public static extern global::System.IntPtr GetScreenSize();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetScreenSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetScreenSize();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetGeometryHittestEnabled")]
-            public static extern void SetGeometryHittestEnabled(bool enable);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetGeometryHittestEnabled", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetGeometryHittestEnabled([MarshalAs(UnmanagedType.U1)] bool enable);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IsGeometryHittestEnabled")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsGeometryHittestEnabled();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IsGeometryHittestEnabled", StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static partial bool IsGeometryHittestEnabled();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetAvailableScreens")]
-            public static extern global::System.IntPtr GetAvailableScreens();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetAvailableScreens", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetAvailableScreens();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_SetApplicationLocale")]
-            public static extern void SetApplicationLocale(global::System.Runtime.InteropServices.HandleRef application, string locale);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_SetApplicationLocale", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetApplicationLocale(global::System.IntPtr application, string locale);
         }
     }
 }
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ApplicationControlSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ApplicationControlSignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class ApplicationControlSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationControlSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationControlSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationControlSignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationControlSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationControlSignal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationControlSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationControlSignal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationControlSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationControlSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, System.IntPtr jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationControlSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, IntPtr jarg2, System.IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ApplicationControlSignal")]
-            public static extern global::System.IntPtr NewApplicationControlSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ApplicationControlSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewApplicationControlSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ApplicationControlSignal")]
-            public static extern void DeleteApplicationControlSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ApplicationControlSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteApplicationControlSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ApplicationSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ApplicationSignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class ApplicationSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationSignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationSignal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationSignal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ApplicationSignal")]
-            public static extern global::System.IntPtr NewApplicationSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ApplicationSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewApplicationSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ApplicationSignal")]
-            public static extern void DeleteApplicationSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ApplicationSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteApplicationSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.AsyncImageLoader.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.AsyncImageLoader.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,39 +26,44 @@ namespace Tizen.NUI
         internal static partial class AsyncImageLoader
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_AsyncImageLoader")]
-            public static extern void DeleteAsyncImageLoader(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_AsyncImageLoader", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteAsyncImageLoader(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_Load__SWIG_0")]
-            public static extern uint Load(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_Load__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint Load(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_Load__SWIG_1")]
-            public static extern uint Load(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_Load__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint Load(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_Load__SWIG_2")]
-            public static extern uint Load(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, int jarg4, int jarg5, bool jarg6);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_Load__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint Load(IntPtr jarg1, string jarg2, IntPtr jarg3, int jarg4, int jarg5, [MarshalAs(UnmanagedType.U1)] bool jarg6);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_Cancel")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_Cancel", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Cancel(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            public static partial bool Cancel(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_CancelAll")]
-            public static extern void CancelAll(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_CancelAll", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void CancelAll(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_ImageLoadedSignal_Connect")]
-            public static extern void ImageLoadedSignalConnect(global::System.Runtime.InteropServices.HandleRef asyncImageLoader, global::System.Runtime.InteropServices.HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_ImageLoadedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ImageLoadedSignalConnect(IntPtr asyncImageLoader, IntPtr handler);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_ImageLoadedSignal_Disconnect")]
-            public static extern void ImageLoadedSignalDisconnect(global::System.Runtime.InteropServices.HandleRef asyncImageLoader, global::System.Runtime.InteropServices.HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_ImageLoadedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ImageLoadedSignalDisconnect(IntPtr asyncImageLoader, IntPtr handler);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_PixelBufferLoadedSignal_Connect")]
-            public static extern void PixelBufferLoadedSignalConnect(global::System.Runtime.InteropServices.HandleRef asyncImageLoader, global::System.Runtime.InteropServices.HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_PixelBufferLoadedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PixelBufferLoadedSignalConnect(IntPtr asyncImageLoader, IntPtr handler);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_PixelBufferLoadedSignal_Disconnect")]
-            public static extern void PixelBufferLoadedSignalDisconnect(global::System.Runtime.InteropServices.HandleRef asyncImageLoader, global::System.Runtime.InteropServices.HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AsyncImageLoader_PixelBufferLoadedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PixelBufferLoadedSignalDisconnect(IntPtr asyncImageLoader, IntPtr handler);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.BackgroundBlurEffect.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.BackgroundBlurEffect.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2025 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,54 +14,59 @@
  * limitations under the License.
  *
  */
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
-    using global::System;
-    using global::System.Runtime.InteropServices;
-
     internal static partial class Interop
     {
         internal static class BackgroundBlurEffect
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_New__SWIG_1")]
-            public static extern IntPtr New(uint blurRadius);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_New__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr New(uint blurRadius);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_SetBlurOnce")]
-            public static extern void SetBlurOnce(HandleRef effect, bool blurRadius);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_SetBlurOnce", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetBlurOnce(IntPtr effect, [MarshalAs(UnmanagedType.U1)] bool blurRadius);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_GetBlurOnce")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_GetBlurOnce", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool GetBlurOnce(HandleRef effect);
+            public static partial bool GetBlurOnce(IntPtr effect);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_SetBlurRadius")]
-            public static extern void SetBlurRadius(HandleRef effect, uint blurRadius);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_SetBlurRadius", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetBlurRadius(IntPtr effect, uint blurRadius);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_GetBlurRadius")]
-            public static extern uint GetBlurRadius(HandleRef effect);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_GetBlurRadius", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetBlurRadius(IntPtr effect);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_SetBlurDownscaleFactor")]
-            public static extern void SetBlurDownscaleFactor(HandleRef effect, float blurDownscaleFactor);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_SetBlurDownscaleFactor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetBlurDownscaleFactor(IntPtr effect, float blurDownscaleFactor);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_GetBlurDownscaleFactor")]
-            public static extern float GetBlurDownscaleFactor(HandleRef effect);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_GetBlurDownscaleFactor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetBlurDownscaleFactor(IntPtr effect);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_AddBlurStrengthAnimation")]
-            public static extern void AddBlurStrengthAnimation(HandleRef effect, HandleRef animation, HandleRef alphaFunction, HandleRef timePeriod, float fromValue, float toValue);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_AddBlurStrengthAnimation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddBlurStrengthAnimation(IntPtr effect, IntPtr animation, IntPtr alphaFunction, IntPtr timePeriod, float fromValue, float toValue);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_AddBlurOpacityAnimation")]
-            public static extern void AddBlurOpacityAnimation(HandleRef effect, HandleRef animation, HandleRef alphaFunction, HandleRef timePeriod, float fromValue, float toValue);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_AddBlurOpacityAnimation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddBlurOpacityAnimation(IntPtr effect, IntPtr animation, IntPtr alphaFunction, IntPtr timePeriod, float fromValue, float toValue);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_SetSourceActor")]
-            public static extern void SetSourceView(HandleRef effect, HandleRef sourceView);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_SetSourceActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetSourceView(IntPtr effect, IntPtr sourceView);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_SetStopperActor")]
-            public static extern void SetStopperView(HandleRef effect, HandleRef stopperView);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_SetStopperActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetStopperView(IntPtr effect, IntPtr stopperView);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_FinishedSignal_Connect")]
-            public static extern void FinishedSignalConnect(HandleRef effect, HandleRef callback);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_FinishedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FinishedSignalConnect(IntPtr effect, IntPtr callback);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_FinishedSignal_Disconnect")]
-            public static extern void FinishedSignalDisconnect(HandleRef effect, HandleRef callback);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_FinishedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FinishedSignalDisconnect(IntPtr effect, IntPtr callback);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.BaseHandle.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.BaseHandle.cs
@@ -15,56 +15,65 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class BaseHandle
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_BaseHandle__SWIG_1")]
-            public static extern global::System.IntPtr NewBaseHandle();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_BaseHandle__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewBaseHandle();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_BaseHandle")]
-            public static extern void DeleteBaseHandle(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_BaseHandle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteBaseHandle(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_BaseHandle")]
-            public static extern void DeleteBaseHandle(global::System.IntPtr jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_BaseHandle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteBaseHandle(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_BaseHandle__SWIG_2")]
-            public static extern global::System.IntPtr NewBaseHandle(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_BaseHandle__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewBaseHandle(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_DoAction")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_DoAction", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool DoAction(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            public static partial bool DoAction(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_GetTypeName")]
-            public static extern string GetTypeName(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_GetTypeName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetTypeName(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_GetTypeInfo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_GetTypeInfo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetTypeInfo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool GetTypeInfo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_GetBaseObject__SWIG_0")]
-            public static extern global::System.IntPtr GetBaseObject(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_GetBaseObject__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetBaseObject(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_EqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_EqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool EqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool EqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_NotEqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_NotEqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool NotEqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool NotEqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_GetObjectPtr")]
-            public static extern global::System.IntPtr GetObjectPtr(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_GetObjectPtr", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetObjectPtr(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_HasBody")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_HasBody", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool HasBody(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool HasBody(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_IsEqual")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_IsEqual", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsEqual(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool IsEqual(IntPtr jarg1, IntPtr jarg2);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.BaseObject.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.BaseObject.cs
@@ -15,22 +15,31 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class BaseObject
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseObject_DoAction")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseObject_DoAction", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool DoAction(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            public static partial bool DoAction(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseObject_GetTypeName")]
-            public static extern string GetTypeName(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseObject_GetTypeName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetTypeName(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseObject_GetTypeInfo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseObject_GetTypeInfo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetTypeInfo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool GetTypeInfo(IntPtr jarg1, IntPtr jarg2);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.BorderVisual.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.BorderVisual.cs
@@ -15,20 +15,29 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class NDalicBorderVisual
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BORDER_VISUAL_COLOR_get")]
-            public static extern int ColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BORDER_VISUAL_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BORDER_VISUAL_SIZE_get")]
-            public static extern int SizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BORDER_VISUAL_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BORDER_VISUAL_ANTI_ALIASING_get")]
-            public static extern int AntiAliasingGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BORDER_VISUAL_ANTI_ALIASING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AntiAliasingGet();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Builder.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Builder.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,82 +26,87 @@ namespace Tizen.NUI
         internal static partial class Builder
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Builder")]
-            public static extern void DeleteBuilder(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Builder", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteBuilder(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_LoadFromString__SWIG_0")]
-            public static extern void LoadFromString(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_LoadFromString__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LoadFromString(IntPtr jarg1, string jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_LoadFromString__SWIG_1")]
-            public static extern void LoadFromString(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_LoadFromString__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LoadFromString(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_AddConstants")]
-            public static extern void AddConstants(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_AddConstants", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddConstants(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_AddConstant")]
-            public static extern void AddConstant(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_AddConstant", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddConstant(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_GetConstants")]
-            public static extern global::System.IntPtr GetConstants(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_GetConstants", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetConstants(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_GetConstant")]
-            public static extern global::System.IntPtr GetConstant(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_GetConstant", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetConstant(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_CreateAnimation__SWIG_0")]
-            public static extern global::System.IntPtr CreateAnimation(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_CreateAnimation__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CreateAnimation(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_CreateAnimation__SWIG_1")]
-            public static extern global::System.IntPtr CreateAnimationWithPropertyMap(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_CreateAnimation__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CreateAnimationWithPropertyMap(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_CreateAnimation__SWIG_2")]
-            public static extern global::System.IntPtr CreateAnimationWithView(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_CreateAnimation__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CreateAnimationWithView(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_CreateAnimation__SWIG_3")]
-            public static extern global::System.IntPtr CreateAnimation(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_CreateAnimation__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CreateAnimation(IntPtr jarg1, string jarg2, IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_Create__SWIG_0")]
-            public static extern global::System.IntPtr Create(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_Create__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Create(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_Create__SWIG_1")]
-            public static extern global::System.IntPtr Create(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_Create__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Create(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_CreateFromJson")]
-            public static extern global::System.IntPtr CreateFromJson(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_CreateFromJson", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CreateFromJson(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_ApplyStyle")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_ApplyStyle", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool ApplyStyle(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            public static partial bool ApplyStyle(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_ApplyFromJson")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_ApplyFromJson", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool ApplyFromJson(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, string jarg3);
+            public static partial bool ApplyFromJson(IntPtr jarg1, IntPtr jarg2, string jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_AddActors__SWIG_0")]
-            public static extern void AddActors(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_AddActors__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddActors(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_AddActors__SWIG_1")]
-            public static extern void AddActors(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_AddActors__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddActors(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_CreateRenderTask")]
-            public static extern void CreateRenderTask(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_CreateRenderTask", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void CreateRenderTask(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_GetPath")]
-            public static extern global::System.IntPtr GetPath(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_GetPath", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetPath(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_GetPathConstrainer")]
-            public static extern global::System.IntPtr GetPathConstrainer(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_GetPathConstrainer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetPathConstrainer(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_GetLinearConstrainer")]
-            public static extern global::System.IntPtr GetLinearConstrainer(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_GetLinearConstrainer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetLinearConstrainer(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_QuitSignal_Connect")]
-            public static extern global::System.IntPtr QuitConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_QuitSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr QuitConnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_QuitSignal_Disconnect")]
-            public static extern global::System.IntPtr QuitDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Builder_QuitSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr QuitDisconnect(IntPtr jarg1, IntPtr jarg2);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.CameraActor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.CameraActor.cs
@@ -15,123 +15,132 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class CameraActor
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_TYPE_get")]
-            public static extern int TypeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_TYPE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TypeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_PROJECTION_MODE_get")]
-            public static extern int ProjectionModeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_PROJECTION_MODE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ProjectionModeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_FIELD_OF_VIEW_get")]
-            public static extern int FieldOfViewGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_FIELD_OF_VIEW_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int FieldOfViewGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_ASPECT_RATIO_get")]
-            public static extern int AspectRatioGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_ASPECT_RATIO_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AspectRatioGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_NEAR_PLANE_DISTANCE_get")]
-            public static extern int NearPlaneDistanceGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_NEAR_PLANE_DISTANCE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int NearPlaneDistanceGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_FAR_PLANE_DISTANCE_get")]
-            public static extern int FarPlaneDistanceGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_FAR_PLANE_DISTANCE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int FarPlaneDistanceGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_LEFT_PLANE_DISTANCE_get")]
-            public static extern int LeftPlaneDistanceGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_LEFT_PLANE_DISTANCE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LeftPlaneDistanceGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_RIGHT_PLANE_DISTANCE_get")]
-            public static extern int RightPlaneDistanceGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_RIGHT_PLANE_DISTANCE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RightPlaneDistanceGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_TOP_PLANE_DISTANCE_get")]
-            public static extern int TopPlaneDistanceGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_TOP_PLANE_DISTANCE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TopPlaneDistanceGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_BOTTOM_PLANE_DISTANCE_get")]
-            public static extern int BottomPlaneDistanceGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_BOTTOM_PLANE_DISTANCE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BottomPlaneDistanceGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_TARGET_POSITION_get")]
-            public static extern int TargetPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_TARGET_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TargetPositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_PROJECTION_MATRIX_get")]
-            public static extern int ProjectionMatrixGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_PROJECTION_MATRIX_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ProjectionMatrixGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_VIEW_MATRIX_get")]
-            public static extern int ViewMatrixGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_VIEW_MATRIX_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ViewMatrixGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_INVERT_Y_AXIS_get")]
-            public static extern int InvertYAxisGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Property_INVERT_Y_AXIS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InvertYAxisGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_New__SWIG_0")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_New__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_New__SWIG_1")]
-            public static extern global::System.IntPtr New(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_New__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_CameraActor")]
-            public static extern void DeleteCameraActor(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_CameraActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteCameraActor(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_CameraActor__SWIG_1")]
-            public static extern global::System.IntPtr NewCameraActor(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_CameraActor__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewCameraActor(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetType")]
-            public static extern void SetType(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetType(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_GetType")]
-            public static extern int GetType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_GetType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetType(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetProjectionMode")]
-            public static extern void SetProjectionMode(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetProjectionMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetProjectionMode(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_GetProjectionMode")]
-            public static extern int GetProjectionMode(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_GetProjectionMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetProjectionMode(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetFieldOfView")]
-            public static extern void SetFieldOfView(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetFieldOfView", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFieldOfView(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_GetFieldOfView")]
-            public static extern float GetFieldOfView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_GetFieldOfView", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetFieldOfView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetAspectRatio")]
-            public static extern void SetAspectRatio(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetAspectRatio", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetAspectRatio(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_GetAspectRatio")]
-            public static extern float GetAspectRatio(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_GetAspectRatio", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetAspectRatio(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetNearClippingPlane")]
-            public static extern void SetNearClippingPlane(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetNearClippingPlane", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetNearClippingPlane(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_GetNearClippingPlane")]
-            public static extern float GetNearClippingPlane(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_GetNearClippingPlane", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetNearClippingPlane(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetFarClippingPlane")]
-            public static extern void SetFarClippingPlane(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetFarClippingPlane", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFarClippingPlane(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_GetFarClippingPlane")]
-            public static extern float GetFarClippingPlane(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_GetFarClippingPlane", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetFarClippingPlane(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetTargetPosition")]
-            public static extern void SetTargetPosition(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetTargetPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTargetPosition(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_GetTargetPosition")]
-            public static extern global::System.IntPtr GetTargetPosition(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_GetTargetPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetTargetPosition(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetInvertYAxis")]
-            public static extern void SetInvertYAxis(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetInvertYAxis", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetInvertYAxis(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_GetInvertYAxis")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_GetInvertYAxis", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetInvertYAxis(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool GetInvertYAxis(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetPerspectiveProjection")]
-            public static extern void SetPerspectiveProjection(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetPerspectiveProjection", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPerspectiveProjection(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetOrthographicProjection__SWIG_0")]
-            public static extern void SetOrthographicProjection(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetOrthographicProjection__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetOrthographicProjection(IntPtr jarg1, IntPtr jarg2);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.CameraView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.CameraView.cs
@@ -15,9 +15,11 @@
  *
  */
 
-using System;
-using System.Collections.Generic;
-using System.Text;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+using global::System.Collections.Generic;
+using global::System.Text;
 
 namespace Tizen.NUI
 {
@@ -25,18 +27,23 @@ namespace Tizen.NUI
     {
         internal static partial class CameraView
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraView_New__SWIG_0")]
-            public static extern global::System.IntPtr New(global::System.IntPtr jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraView_New__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(global::System.IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_CameraView")]
-            public static extern void DeleteCameraView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_CameraView", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteCameraView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_CameraView__SWIG_1")]
-            public static extern global::System.IntPtr NewCameraView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_CameraView__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewCameraView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraView_Update")]
-            public static extern void Update(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraView_Update", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Update(IntPtr jarg1);
 
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.CanvasView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.CanvasView.cs
@@ -15,43 +15,52 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class CanvasView
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_New__SWIG_0")]
-            public static extern global::System.IntPtr New(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_New__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_New__SWIG_1")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_New__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_CanvasView")]
-            public static extern void DeleteCanvasView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_CanvasView", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteCanvasView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_AddDrawable")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_AddDrawable", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddDrawable(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool AddDrawable(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_RemoveDrawable")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_RemoveDrawable", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool RemoveDrawable(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool RemoveDrawable(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_RemoveAllDrawables")]
-            public static extern void RemoveAllDrawables(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_RemoveAllDrawables", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemoveAllDrawables(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_RequestRasterization")]
-            public static extern void RequestRasterization(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_RequestRasterization", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RequestRasterization(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_Property_VIEWBOX_get")]
-            public static extern int PropertyViewBoxGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_Property_VIEWBOX_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PropertyViewBoxGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_Property_SYNCHRONOUS_LOADING_get")]
-            public static extern int PropertySynchronousLoadingGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_Property_SYNCHRONOUS_LOADING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PropertySynchronousLoadingGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_Property_RASTERIZATION_REQUEST_MANUALLY_get")]
-            public static extern int PropertyRasterizationRequestManuallyGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_Property_RASTERIZATION_REQUEST_MANUALLY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PropertyRasterizationRequestManuallyGet();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Capture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Capture.cs
@@ -15,72 +15,76 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
-    using global::System;
-    using global::System.Runtime.InteropServices;
-
     internal static partial class Interop
     {
         internal static partial class Capture
         {
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_New")]
-            public static extern IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr New();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Capture")]
-            public static extern void Delete(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Capture", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Delete(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Start_1")]
-            public static extern void Start1(HandleRef capture, HandleRef source, HandleRef size, string path, HandleRef clearColor);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Start_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Start1(IntPtr capture, IntPtr source, IntPtr size, string path, IntPtr clearColor);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Start_2")]
-            public static extern void Start2(HandleRef capture, HandleRef source, HandleRef size, string path);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Start_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Start2(IntPtr capture, IntPtr source, IntPtr size, string path);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Start_3")]
-            public static extern void Start3(HandleRef capture, HandleRef source, HandleRef size, string path, HandleRef clearColor, uint quality);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Start_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Start3(IntPtr capture, IntPtr source, IntPtr size, string path, IntPtr clearColor, uint quality);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Start_4")]
-            public static extern void Start4(HandleRef capture, HandleRef source, HandleRef position, HandleRef size, string path, HandleRef clearColor);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Start_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Start4(IntPtr capture, IntPtr source, IntPtr position, IntPtr size, string path, IntPtr clearColor);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_SetImageQuality")]
-            public static extern void SetImageQuality(HandleRef capture, uint quality);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_SetImageQuality", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetImageQuality(IntPtr capture, uint quality);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_SetExclusive")]
-            public static extern void SetExclusive(HandleRef capture, bool exclusive);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_SetExclusive", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetExclusive(IntPtr capture, [MarshalAs(UnmanagedType.U1)] bool exclusive);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_IsExclusive")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_IsExclusive", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsExclusive(HandleRef capture);
+            public static partial bool IsExclusive(IntPtr capture);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Signal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Signal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SignalEmpty(HandleRef jarg1);
+            public static partial bool SignalEmpty(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Signal_GetConnectionCount")]
-            public static extern uint SignalGetConnectionCount(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Signal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint SignalGetConnectionCount(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Signal_Connect")]
-            public static extern void SignalConnect(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Signal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SignalConnect(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Signal_Disconnect")]
-            public static extern void SignalDisconnect(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Signal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SignalDisconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Signal_Emit")]
-            public static extern void SignalEmit(HandleRef jarg1, HandleRef jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Signal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SignalEmit(IntPtr jarg1, IntPtr jarg2, int jarg3);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Signal_Get")]
-            public static extern IntPtr Get(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Signal_Get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr Get(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_GetImageUrl")]
-            public static extern IntPtr GetImageUrl(HandleRef capture);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_GetImageUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GetImageUrl(IntPtr capture);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_GetNativeImageSource")]
-            public static extern IntPtr GetNativeImageSourcePtr(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_GetNativeImageSource", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GetNativeImageSourcePtr(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_GetCapturedBuffer")]
-            public static extern IntPtr GetCapturedBuffer(HandleRef capture);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_GetCapturedBuffer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GetCapturedBuffer(IntPtr capture);
 
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ClampState2D.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ClampState2D.cs
@@ -24,3 +24,5 @@ namespace Tizen.NUI
         }
     }
 }
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Clipboard.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Clipboard.cs
@@ -15,49 +15,58 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Clipboard
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Clipboard_Get")]
-            public static extern global::System.IntPtr Get();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Clipboard_Get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Get();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Clipboard_SetData")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Clipboard_SetData", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SetData(global::System.Runtime.InteropServices.HandleRef clipboard, string mimeType, string data);
+            public static partial bool SetData(IntPtr clipboard, string mimeType, string data);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Clipboard_GetData")]
-            public static extern uint GetData(global::System.Runtime.InteropServices.HandleRef clipboard, string mimeType);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Clipboard_GetData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetData(IntPtr clipboard, string mimeType);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Clipboard_DataReceivedSignal")]
-            public static extern global::System.IntPtr ClipboardDataReceivedSignal(global::System.Runtime.InteropServices.HandleRef clipboard);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Clipboard_DataReceivedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ClipboardDataReceivedSignal(IntPtr clipboard);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Clipboard_DataSelectedSignal")]
-            public static extern global::System.IntPtr ClipboardDataSelectedSignal(global::System.Runtime.InteropServices.HandleRef clipboard);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Clipboard_DataSelectedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ClipboardDataSelectedSignal(IntPtr clipboard);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ClipboardSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ClipboardSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool ClipboardSignalEmpty(global::System.Runtime.InteropServices.HandleRef signal);
+            public static partial bool ClipboardSignalEmpty(IntPtr signal);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ClipboardSignal_GetConnectionCount")]
-            public static extern uint ClipboardSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef signal);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ClipboardSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint ClipboardSignalGetConnectionCount(IntPtr signal);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ClipboardSignal_Connect")]
-            public static extern void ClipboardSignalConnect(global::System.Runtime.InteropServices.HandleRef signal, global::System.Runtime.InteropServices.HandleRef clipboard);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ClipboardSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ClipboardSignalConnect(IntPtr signal, IntPtr clipboard);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ClipboardSignal_Disconnect")]
-            public static extern void ClipboardSignalDisconnect(global::System.Runtime.InteropServices.HandleRef signal, global::System.Runtime.InteropServices.HandleRef clipboard);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ClipboardSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ClipboardSignalDisconnect(IntPtr signal, IntPtr clipboard);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ClipboardSignal_Emit")]
-            public static extern void ClipboardSignalEmit(global::System.Runtime.InteropServices.HandleRef signal, global::System.Runtime.InteropServices.HandleRef clipboard);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ClipboardSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ClipboardSignalEmit(IntPtr signal, IntPtr clipboard);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ClipboardSignal")]
-            public static extern global::System.IntPtr NewClipboardSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ClipboardSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewClipboardSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ClipboardSignal")]
-            public static extern void DeleteClipboardSignal(global::System.Runtime.InteropServices.HandleRef signal);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ClipboardSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteClipboardSignal(IntPtr signal);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ColorVisual.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ColorVisual.cs
@@ -15,14 +15,23 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class NDalicColorVisual
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_COLOR_VISUAL_MIX_COLOR_get")]
-            public static extern int ColorVisualMixColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_COLOR_VISUAL_MIX_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ColorVisualMixColorGet();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ComponentApplication.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ComponentApplication.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Text;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+using global::System.Collections.Generic;
+using global::System.Text;
 
 namespace Tizen.NUI
 {
@@ -25,26 +27,31 @@ namespace Tizen.NUI
         internal static partial class ComponentApplication
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ComponentApplication")]
-            public static extern global::System.IntPtr New(int argc, string argv, string styleSheet);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ComponentApplication", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int argc, string argv, string styleSheet);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ComponentApplication_SWIG1")]
-            public static extern global::System.IntPtr NewComponentApplication(global::System.Runtime.InteropServices.HandleRef swigCPtr);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ComponentApplication_SWIG1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewComponentApplication(IntPtr swigCPtr);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_assign_ComponentApplication")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef swigCPtr, global::System.Runtime.InteropServices.HandleRef swigCPtr2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_assign_ComponentApplication", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr swigCPtr, IntPtr swigCPtr2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ComponentApplication")]
-            public static extern global::System.IntPtr DeleteComponentApplication(global::System.Runtime.InteropServices.HandleRef swigCPtr);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ComponentApplication", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DeleteComponentApplication(IntPtr swigCPtr);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ComponentApplication_CreateNativeSignal")]
-            public static extern global::System.IntPtr CreateNativeSignal(global::System.Runtime.InteropServices.HandleRef swigCPtr);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ComponentApplication_CreateNativeSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CreateNativeSignal(IntPtr swigCPtr);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ComponentApplication_CreateNativeSignal_Connect")]
-            public static extern global::System.IntPtr CreateNativeSignalConnect(global::System.Runtime.InteropServices.HandleRef swigCPtr, global::System.Runtime.InteropServices.HandleRef func);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ComponentApplication_CreateNativeSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CreateNativeSignalConnect(IntPtr swigCPtr, IntPtr func);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ComponentApplication_CreateNativeSignal_Disconnect")]
-            public static extern global::System.IntPtr CreateNativeSignalDisconnect(global::System.Runtime.InteropServices.HandleRef swigCPtr, global::System.Runtime.InteropServices.HandleRef func);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ComponentApplication_CreateNativeSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CreateNativeSignalDisconnect(IntPtr swigCPtr, IntPtr func);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ConnectionTracker.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ConnectionTracker.cs
@@ -15,32 +15,41 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class ConnectionTracker
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ConnectionTrackerInterface")]
-            public static extern void DeleteConnectionTrackerInterface(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ConnectionTrackerInterface", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteConnectionTrackerInterface(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ConnectionTrackerInterface_SignalConnected")]
-            public static extern void ConnectionTrackerInterfaceSignalConnected(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ConnectionTrackerInterface_SignalConnected", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ConnectionTrackerInterfaceSignalConnected(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ConnectionTracker")]
-            public static extern void DeleteConnectionTracker(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ConnectionTracker", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteConnectionTracker(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ConnectionTracker_DisconnectAll")]
-            public static extern void DisconnectAll(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ConnectionTracker_DisconnectAll", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DisconnectAll(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ConnectionTracker_SignalConnected")]
-            public static extern void SignalConnected(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ConnectionTracker_SignalConnected", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SignalConnected(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ConnectionTracker_SignalDisconnected")]
-            public static extern void SignalDisconnected(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ConnectionTracker_SignalDisconnected", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SignalDisconnected(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ConnectionTracker_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ConnectionTracker_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Constraint.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Constraint.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,87 +26,92 @@ namespace Tizen.NUI
         internal static partial class Constraint
         {
             // Property type specific API
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_New_Boolean")]
-            public static extern global::System.IntPtr ConstraintBooleanNew(global::System.Runtime.InteropServices.HandleRef target, int propertyIndex, global::System.Runtime.InteropServices.HandleRef constraintFunction);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_New_Boolean", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ConstraintBooleanNew(IntPtr target, int propertyIndex, IntPtr constraintFunction);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_New_Float")]
-            public static extern global::System.IntPtr ConstraintFloatNew(global::System.Runtime.InteropServices.HandleRef target, int propertyIndex, global::System.Runtime.InteropServices.HandleRef constraintFunction);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_New_Float", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ConstraintFloatNew(IntPtr target, int propertyIndex, IntPtr constraintFunction);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_New_Integer")]
-            public static extern global::System.IntPtr ConstraintIntegerNew(global::System.Runtime.InteropServices.HandleRef target, int propertyIndex, global::System.Runtime.InteropServices.HandleRef constraintFunction);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_New_Integer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ConstraintIntegerNew(IntPtr target, int propertyIndex, IntPtr constraintFunction);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_New_Vector2")]
-            public static extern global::System.IntPtr ConstraintVector2New(global::System.Runtime.InteropServices.HandleRef target, int propertyIndex, global::System.Runtime.InteropServices.HandleRef constraintFunction);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_New_Vector2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ConstraintVector2New(IntPtr target, int propertyIndex, IntPtr constraintFunction);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_New_Vector3")]
-            public static extern global::System.IntPtr ConstraintVector3New(global::System.Runtime.InteropServices.HandleRef target, int propertyIndex, global::System.Runtime.InteropServices.HandleRef constraintFunction);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_New_Vector3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ConstraintVector3New(IntPtr target, int propertyIndex, IntPtr constraintFunction);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_New_Vector4")]
-            public static extern global::System.IntPtr ConstraintVector4New(global::System.Runtime.InteropServices.HandleRef target, int propertyIndex, global::System.Runtime.InteropServices.HandleRef constraintFunction);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_New_Vector4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ConstraintVector4New(IntPtr target, int propertyIndex, IntPtr constraintFunction);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_New_Matrix3")]
-            public static extern global::System.IntPtr ConstraintMatrix3New(global::System.Runtime.InteropServices.HandleRef target, int propertyIndex, global::System.Runtime.InteropServices.HandleRef constraintFunction);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_New_Matrix3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ConstraintMatrix3New(IntPtr target, int propertyIndex, IntPtr constraintFunction);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_New_Matrix")]
-            public static extern global::System.IntPtr ConstraintMatrixNew(global::System.Runtime.InteropServices.HandleRef target, int propertyIndex, global::System.Runtime.InteropServices.HandleRef constraintFunction);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_New_Matrix", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ConstraintMatrixNew(IntPtr target, int propertyIndex, IntPtr constraintFunction);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_New_Quaternion")]
-            public static extern global::System.IntPtr ConstraintRotationNew(global::System.Runtime.InteropServices.HandleRef target, int propertyIndex, global::System.Runtime.InteropServices.HandleRef constraintFunction);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_New_Quaternion", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ConstraintRotationNew(IntPtr target, int propertyIndex, IntPtr constraintFunction);
 
             // Common API
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint")]
-            public static extern global::System.IntPtr DeleteConstraint(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DeleteConstraint(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_AddSource")]
-            public static extern void AddSource(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef sourceHandle, int sourceIndex);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_AddSource", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddSource(IntPtr jarg1, IntPtr sourceHandle, int sourceIndex);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_AddLocalSource")]
-            public static extern void AddLocalSource(global::System.Runtime.InteropServices.HandleRef jarg1, int sourceIndex);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_AddLocalSource", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddLocalSource(IntPtr jarg1, int sourceIndex);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_AddParentSource")]
-            public static extern void AddParentSource(global::System.Runtime.InteropServices.HandleRef jarg1, int sourceIndex);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_AddParentSource", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddParentSource(IntPtr jarg1, int sourceIndex);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Apply")]
-            public static extern void Apply(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Apply", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Apply(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_ApplyPost")]
-            public static extern void ApplyPost(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_ApplyPost", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ApplyPost(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Remove")]
-            public static extern void Remove(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-            // Note : Dali use RemoveAction as apply action behavior.
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_SetRemoveAction")]
-            public static extern void SetApplyAction(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Remove", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Remove(IntPtr jarg1);
 
             // Note : Dali use RemoveAction as apply action behavior.
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_GetRemoveAction")]
-            public static extern int GetApplyAction(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_SetRemoveAction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetApplyAction(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_SetApplyRate")]
-            public static extern void SetApplyRate(global::System.Runtime.InteropServices.HandleRef jarg1, uint applyRate);
+            // Note : Dali use RemoveAction as apply action behavior.
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_GetRemoveAction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetApplyAction(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_GetApplyRate")]
-            public static extern uint GetApplyRate(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_SetApplyRate", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetApplyRate(IntPtr jarg1, uint applyRate);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_SetTag")]
-            public static extern void SetTag(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_GetApplyRate", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetApplyRate(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_GetTag")]
-            public static extern uint GetTag(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_SetTag", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTag(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_GetTargetObject")]
-            public static extern global::System.IntPtr GetTargetObject(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_GetTag", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetTag(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_GetTargetProperty")]
-            public static extern int GetTargetProperty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_GetTargetObject", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetTargetObject(IntPtr jarg1);
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_GetTargetProperty", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetTargetProperty(IntPtr jarg1);
 
             // Special Constraint
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EqualConstraintWithParentFloat_New")]
-            public static extern global::System.IntPtr NewEqualConstraintWithParentFloat(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EqualConstraintWithParentFloat_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewEqualConstraintWithParentFloat(IntPtr jarg1, int jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RelativeConstraintWithParentFloat_New")]
-            public static extern global::System.IntPtr NewRelativeConstraintWithParentFloat(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3, float jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RelativeConstraintWithParentFloat_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRelativeConstraintWithParentFloat(IntPtr jarg1, int jarg2, int jarg3, float jarg4);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ConstraintFunction.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ConstraintFunction.cs
@@ -15,127 +15,136 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class ConstraintFunction
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Boolean_New")]
-            public static extern global::System.IntPtr BooleanFunctionNew();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Boolean_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr BooleanFunctionNew();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Boolean_SetHandler")]
-            public static extern void SetBooleanFunction(global::System.Runtime.InteropServices.HandleRef function, global::System.Runtime.InteropServices.HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Boolean_SetHandler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetBooleanFunction(IntPtr function, IntPtr handler);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Boolean_GetId")]
-            public static extern uint GetBooleanFunctionId(global::System.Runtime.InteropServices.HandleRef function);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Boolean_GetId", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetBooleanFunctionId(IntPtr function);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint_Function_Boolean")]
-            public static extern void DeleteBooleanFunction(global::System.Runtime.InteropServices.HandleRef function);
-
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Float_New")]
-            public static extern global::System.IntPtr FloatFunctionNew();
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Float_SetHandler")]
-            public static extern void SetFloatFunction(global::System.Runtime.InteropServices.HandleRef function, global::System.Runtime.InteropServices.HandleRef handler);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Float_GetId")]
-            public static extern uint GetFloatFunctionId(global::System.Runtime.InteropServices.HandleRef function);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint_Function_Float")]
-            public static extern void DeleteFloatFunction(global::System.Runtime.InteropServices.HandleRef function);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint_Function_Boolean", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteBooleanFunction(IntPtr function);
 
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Integer_New")]
-            public static extern global::System.IntPtr IntegerFunctionNew();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Float_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr FloatFunctionNew();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Integer_SetHandler")]
-            public static extern void SetIntegerFunction(global::System.Runtime.InteropServices.HandleRef function, global::System.Runtime.InteropServices.HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Float_SetHandler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFloatFunction(IntPtr function, IntPtr handler);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Integer_GetId")]
-            public static extern uint GetIntegerFunctionId(global::System.Runtime.InteropServices.HandleRef function);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Float_GetId", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetFloatFunctionId(IntPtr function);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint_Function_Integer")]
-            public static extern void DeleteIntegerFunction(global::System.Runtime.InteropServices.HandleRef function);
-
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Vector2_New")]
-            public static extern global::System.IntPtr Vector2FunctionNew();
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Vector2_SetHandler")]
-            public static extern void SetVector2Function(global::System.Runtime.InteropServices.HandleRef function, global::System.Runtime.InteropServices.HandleRef handler);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Vector2_GetId")]
-            public static extern uint GetVector2FunctionId(global::System.Runtime.InteropServices.HandleRef function);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint_Function_Vector2")]
-            public static extern void DeleteVector2Function(global::System.Runtime.InteropServices.HandleRef function);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint_Function_Float", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteFloatFunction(IntPtr function);
 
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Vector3_New")]
-            public static extern global::System.IntPtr Vector3FunctionNew();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Integer_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr IntegerFunctionNew();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Vector3_SetHandler")]
-            public static extern void SetVector3Function(global::System.Runtime.InteropServices.HandleRef function, global::System.Runtime.InteropServices.HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Integer_SetHandler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetIntegerFunction(IntPtr function, IntPtr handler);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Vector3_GetId")]
-            public static extern uint GetVector3FunctionId(global::System.Runtime.InteropServices.HandleRef function);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Integer_GetId", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetIntegerFunctionId(IntPtr function);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint_Function_Vector3")]
-            public static extern void DeleteVector3Function(global::System.Runtime.InteropServices.HandleRef function);
-
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Vector4_New")]
-            public static extern global::System.IntPtr Vector4FunctionNew();
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Vector4_SetHandler")]
-            public static extern void SetVector4Function(global::System.Runtime.InteropServices.HandleRef function, global::System.Runtime.InteropServices.HandleRef handler);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Vector4_GetId")]
-            public static extern uint GetVector4FunctionId(global::System.Runtime.InteropServices.HandleRef function);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint_Function_Vector4")]
-            public static extern void DeleteVector4Function(global::System.Runtime.InteropServices.HandleRef function);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint_Function_Integer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteIntegerFunction(IntPtr function);
 
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Matrix3_New")]
-            public static extern global::System.IntPtr Matrix3FunctionNew();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Vector2_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Vector2FunctionNew();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Matrix3_SetHandler")]
-            public static extern void SetMatrix3Function(global::System.Runtime.InteropServices.HandleRef function, global::System.Runtime.InteropServices.HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Vector2_SetHandler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetVector2Function(IntPtr function, IntPtr handler);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Matrix3_GetId")]
-            public static extern uint GetMatrix3FunctionId(global::System.Runtime.InteropServices.HandleRef function);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Vector2_GetId", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetVector2FunctionId(IntPtr function);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint_Function_Matrix3")]
-            public static extern void DeleteMatrix3Function(global::System.Runtime.InteropServices.HandleRef function);
-
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Matrix_New")]
-            public static extern global::System.IntPtr MatrixFunctionNew();
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Matrix_SetHandler")]
-            public static extern void SetMatrixFunction(global::System.Runtime.InteropServices.HandleRef function, global::System.Runtime.InteropServices.HandleRef handler);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Matrix_GetId")]
-            public static extern uint GetMatrixFunctionId(global::System.Runtime.InteropServices.HandleRef function);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint_Function_Matrix")]
-            public static extern void DeleteMatrixFunction(global::System.Runtime.InteropServices.HandleRef function);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint_Function_Vector2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteVector2Function(IntPtr function);
 
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Quaternion_New")]
-            public static extern global::System.IntPtr RotationFunctionNew();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Vector3_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Vector3FunctionNew();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Quaternion_SetHandler")]
-            public static extern void SetRotationFunction(global::System.Runtime.InteropServices.HandleRef function, global::System.Runtime.InteropServices.HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Vector3_SetHandler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetVector3Function(IntPtr function, IntPtr handler);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Quaternion_GetId")]
-            public static extern uint GetRotationFunctionId(global::System.Runtime.InteropServices.HandleRef function);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Vector3_GetId", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetVector3FunctionId(IntPtr function);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint_Function_Quaternion")]
-            public static extern void DeleteRotationFunction(global::System.Runtime.InteropServices.HandleRef function);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint_Function_Vector3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteVector3Function(IntPtr function);
+
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Vector4_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Vector4FunctionNew();
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Vector4_SetHandler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetVector4Function(IntPtr function, IntPtr handler);
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Vector4_GetId", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetVector4FunctionId(IntPtr function);
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint_Function_Vector4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteVector4Function(IntPtr function);
+
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Matrix3_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Matrix3FunctionNew();
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Matrix3_SetHandler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMatrix3Function(IntPtr function, IntPtr handler);
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Matrix3_GetId", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetMatrix3FunctionId(IntPtr function);
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint_Function_Matrix3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteMatrix3Function(IntPtr function);
+
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Matrix_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr MatrixFunctionNew();
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Matrix_SetHandler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMatrixFunction(IntPtr function, IntPtr handler);
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Matrix_GetId", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetMatrixFunctionId(IntPtr function);
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint_Function_Matrix", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteMatrixFunction(IntPtr function);
+
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Quaternion_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr RotationFunctionNew();
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Quaternion_SetHandler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetRotationFunction(IntPtr function, IntPtr handler);
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Constraint_Function_Quaternion_GetId", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetRotationFunctionId(IntPtr function);
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Constraint_Function_Quaternion", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteRotationFunction(IntPtr function);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ContentReceivedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ContentReceivedSignalType.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class ContentReceivedSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ContentReceivedSignalType_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ContentReceivedSignalType_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ContentReceivedSignalType_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ContentReceivedSignalType_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ContentReceivedSignalType_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ContentReceivedSignalType_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ContentReceivedSignalType_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ContentReceivedSignalType_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ContentReceivedSignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3, string jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ContentReceivedSignalType_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, string jarg2, string jarg3, string jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ContentReceivedSignalType")]
-            public static extern global::System.IntPtr NewContentReceivedSignalType();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ContentReceivedSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewContentReceivedSignalType();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ContentReceivedSignalType")]
-            public static extern void DeleteContentReceivedSignalType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ContentReceivedSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteContentReceivedSignalType(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2020-2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,11 +15,12 @@
  *
  */
 
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Runtime.InteropServices;
-using System.Text;
+using global::System;
+using global::System.Collections.Generic;
+using global::System.ComponentModel;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+using global::System.Text;
 
 namespace Tizen.NUI
 {
@@ -28,131 +29,136 @@ namespace Tizen.NUI
         internal static partial class ControlDevel
         {
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AppendAccessibilityRelation")]
-            public static extern void DaliToolkitDevelControlAppendAccessibilityRelation(HandleRef arg1, HandleRef arg2, int arg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AppendAccessibilityRelation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DaliToolkitDevelControlAppendAccessibilityRelation(IntPtr arg1, IntPtr arg2, int arg3);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_RemoveAccessibilityRelation")]
-            public static extern void DaliToolkitDevelControlRemoveAccessibilityRelation(HandleRef arg1, HandleRef arg2, int arg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_RemoveAccessibilityRelation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DaliToolkitDevelControlRemoveAccessibilityRelation(IntPtr arg1, IntPtr arg2, int arg3);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             public delegate void GetAccessibilityRelationsCallback(int relationType, IntPtr relationTarget, IntPtr userData);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_GetAccessibilityRelations")]
-            public static extern void DaliToolkitDevelControlGetAccessibilityRelations(HandleRef arg1_control, GetAccessibilityRelationsCallback arg2_callback, IntPtr arg3_userData);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_GetAccessibilityRelations", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DaliToolkitDevelControlGetAccessibilityRelations(IntPtr arg1_control, GetAccessibilityRelationsCallback arg2_callback, IntPtr arg3_userData);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_ClearAccessibilityRelations")]
-            public static extern void DaliToolkitDevelControlClearAccessibilityRelations(HandleRef arg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_ClearAccessibilityRelations", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DaliToolkitDevelControlClearAccessibilityRelations(IntPtr arg1);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AppendAccessibilityAttribute")]
-            public static extern void DaliToolkitDevelControlAppendAccessibilityAttribute(HandleRef arg1, string arg2_key, string arg3_value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AppendAccessibilityAttribute", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DaliToolkitDevelControlAppendAccessibilityAttribute(IntPtr arg1, string arg2_key, string arg3_value);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_RemoveAccessibilityAttribute")]
-            public static extern void DaliToolkitDevelControlRemoveAccessibilityAttribute(HandleRef arg1, string arg2_key);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_RemoveAccessibilityAttribute", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DaliToolkitDevelControlRemoveAccessibilityAttribute(IntPtr arg1, string arg2_key);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_SetAccessibilityReadingInfoType2")]
-            public static extern void DaliToolkitDevelControlSetAccessibilityReadingInfoTypes(HandleRef arg1, int arg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_SetAccessibilityReadingInfoType2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DaliToolkitDevelControlSetAccessibilityReadingInfoTypes(IntPtr arg1, int arg2);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_GetAccessibilityReadingInfoType2")]
-            public static extern int DaliToolkitDevelControlGetAccessibilityReadingInfoTypes(HandleRef arg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_GetAccessibilityReadingInfoType2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DaliToolkitDevelControlGetAccessibilityReadingInfoTypes(IntPtr arg1);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_ClearAccessibilityHighlight")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_ClearAccessibilityHighlight", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool DaliToolkitDevelControlClearAccessibilityHighlight(HandleRef arg1);
+            public static partial bool DaliToolkitDevelControlClearAccessibilityHighlight(IntPtr arg1);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_GrabAccessibilityHighlight")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_GrabAccessibilityHighlight", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool DaliToolkitDevelControlGrabAccessibilityHighlight(HandleRef arg1);
+            public static partial bool DaliToolkitDevelControlGrabAccessibilityHighlight(IntPtr arg1);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_GetAccessibilityStates")]
-            public static extern ulong DaliToolkitDevelControlGetAccessibilityStates(HandleRef arg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_GetAccessibilityStates", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial ulong DaliToolkitDevelControlGetAccessibilityStates(IntPtr arg1);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_NotifyAccessibilityStateChange")]
-            public static extern IntPtr DaliToolkitDevelControlNotifyAccessibilityStateChange(HandleRef arg1, ulong arg2, int arg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_NotifyAccessibilityStateChange", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr DaliToolkitDevelControlNotifyAccessibilityStateChange(IntPtr arg1, ulong arg2, int arg3);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitAccessibilityEvent")]
-            public static extern IntPtr DaliAccessibilityEmitAccessibilityEvent(HandleRef arg1, int arg2_event);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitAccessibilityEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr DaliAccessibilityEmitAccessibilityEvent(IntPtr arg1, int arg2_event);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitAccessibilityStateChangedEvent")]
-            public static extern IntPtr DaliAccessibilityEmitAccessibilityStateChangedEvent(HandleRef arg1, int arg2_state, int arg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitAccessibilityStateChangedEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr DaliAccessibilityEmitAccessibilityStateChangedEvent(IntPtr arg1, int arg2_state, int arg3);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitTextInsertedEvent")]
-            public static extern IntPtr DaliAccessibilityEmitTextInsertedEvent(HandleRef arg1, int arg2_pos, int arg3_len, string arg3_content);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitTextInsertedEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr DaliAccessibilityEmitTextInsertedEvent(IntPtr arg1, int arg2_pos, int arg3_len, string arg3_content);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitTextDeletedEvent")]
-            public static extern IntPtr DaliAccessibilityEmitTextDeletedEvent(HandleRef arg1, int arg2_pos, int arg3_len, string arg3_content);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitTextDeletedEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr DaliAccessibilityEmitTextDeletedEvent(IntPtr arg1, int arg2_pos, int arg3_len, string arg3_content);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitTextCursorMovedEvent")]
-            public static extern IntPtr DaliAccessibilityEmitTextCursorMovedEvent(HandleRef arg1, int arg2_pos);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitTextCursorMovedEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr DaliAccessibilityEmitTextCursorMovedEvent(IntPtr arg1, int arg2_pos);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitScrollStartedEvent")]
-            public static extern IntPtr DaliAccessibilityEmitScrollStartedEvent(HandleRef arg1_actor);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitScrollStartedEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr DaliAccessibilityEmitScrollStartedEvent(IntPtr arg1_actor);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitScrollFinishedEvent")]
-            public static extern IntPtr DaliAccessibilityEmitScrollFinishedEvent(HandleRef arg1_actor);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitScrollFinishedEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr DaliAccessibilityEmitScrollFinishedEvent(IntPtr arg1_actor);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_IsSuppressedEvent")]
-            public static extern bool DaliAccessibilityIsSuppressedEvent(HandleRef arg1, int accessibilityEvent);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_IsSuppressedEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial bool DaliAccessibilityIsSuppressedEvent(IntPtr arg1, int accessibilityEvent);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_SetSuppressedEvent")]
-            public static extern void DaliAccessibilitySetSuppressedEvent(HandleRef arg1, int accessibilityEvent, bool isSuppressed);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_SetSuppressedEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DaliAccessibilitySetSuppressedEvent(IntPtr arg1, int accessibilityEvent, [MarshalAs(UnmanagedType.U1)] bool isSuppressed);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_new_Range")]
-            public static extern IntPtr DaliAccessibilityNewRange(int arg1_start, int arg2_end, string arg3_content);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_new_Range", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr DaliAccessibilityNewRange(int arg1_start, int arg2_end, string arg3_content);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_Bridge_RegisterDefaultLabel")]
-            public static extern void DaliAccessibilityBridgeRegisterDefaultLabel(HandleRef arg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_Bridge_RegisterDefaultLabel", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DaliAccessibilityBridgeRegisterDefaultLabel(IntPtr arg1);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_Bridge_UnregisterDefaultLabel")]
-            public static extern void DaliAccessibilityBridgeUnregisterDefaultLabel(HandleRef arg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_Bridge_UnregisterDefaultLabel", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DaliAccessibilityBridgeUnregisterDefaultLabel(IntPtr arg1);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_Accessible_GetCurrentlyHighlightedActor")]
-            public static extern IntPtr DaliAccessibilityAccessibleGetCurrentlyHighlightedActor();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_Accessible_GetCurrentlyHighlightedActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr DaliAccessibilityAccessibleGetCurrentlyHighlightedActor();
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_Accessible_GetHighlightActor")]
-            public static extern IntPtr DaliAccessibilityAccessibleGetHighlightActor();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_Accessible_GetHighlightActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr DaliAccessibilityAccessibleGetHighlightActor();
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_Accessible_SetHighlightActor")]
-            public static extern void DaliAccessibilityAccessibleSetHighlightActor(HandleRef arg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_Accessible_SetHighlightActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DaliAccessibilityAccessibleSetHighlightActor(IntPtr arg1);
 
 #if false
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityActionSignal")]
-            public static extern IntPtr DaliToolkitDevelControlAccessibilityActionSignal(BaseComponents.View.ControlHandle arg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AccessibilityActionSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr DaliToolkitDevelControlAccessibilityActionSignal(BaseComponents.View.ControlHandle arg1);
 #endif
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_SetCustomHighlightOverlay")]
-            public static extern void SetCustomHighlightOverlay(global::System.Runtime.InteropServices.HandleRef control, global::System.Runtime.InteropServices.HandleRef position, global::System.Runtime.InteropServices.HandleRef size);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_SetCustomHighlightOverlay", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetCustomHighlightOverlay(IntPtr control, IntPtr position, IntPtr size);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_ResetCustomHighlightOverlay")]
-            public static extern void ResetCustomHighlightOverlay(global::System.Runtime.InteropServices.HandleRef control);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_ResetCustomHighlightOverlay", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ResetCustomHighlightOverlay(IntPtr control);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.CustomAlgorithmInterface.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.CustomAlgorithmInterface.cs
@@ -15,23 +15,32 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class CustomAlgorithmInterface
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_CustomAlgorithmInterface")]
-            public static extern void DeleteCustomAlgorithmInterface(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_CustomAlgorithmInterface", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteCustomAlgorithmInterface(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CustomAlgorithmInterface_GetNextFocusableActor")]
-            public static extern global::System.IntPtr GetNextFocusableActor(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, int jarg4, string deviceName);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CustomAlgorithmInterface_GetNextFocusableActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetNextFocusableActor(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, int jarg4, string deviceName);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_CustomAlgorithmInterface")]
-            public static extern global::System.IntPtr NewCustomAlgorithmInterface();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_CustomAlgorithmInterface", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewCustomAlgorithmInterface();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CustomAlgorithmInterface_director_connect")]
-            public static extern void DirectorConnect(global::System.Runtime.InteropServices.HandleRef jarg1, Tizen.NUI.CustomAlgorithmInterface.SwigDelegateCustomAlgorithmInterface_0 delegate0);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CustomAlgorithmInterface_director_connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DirectorConnect(IntPtr jarg1, Tizen.NUI.CustomAlgorithmInterface.SwigDelegateCustomAlgorithmInterface_0 delegate0);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.DaliException.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.DaliException.cs
@@ -15,29 +15,38 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class DaliException
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_DaliException")]
-            public static extern global::System.IntPtr NewDaliException(string jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_DaliException", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewDaliException(string jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DaliException_location_set")]
-            public static extern void LocationSet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DaliException_location_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LocationSet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DaliException_location_get")]
-            public static extern string LocationGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DaliException_location_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string LocationGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DaliException_condition_set")]
-            public static extern void ConditionSet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DaliException_condition_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ConditionSet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DaliException_condition_get")]
-            public static extern string ConditionGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DaliException_condition_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string ConditionGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_DaliException")]
-            public static extern void DeleteDaliException(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_DaliException", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteDaliException(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Degree.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Degree.cs
@@ -15,29 +15,38 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Degree
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Degree__SWIG_0")]
-            public static extern global::System.IntPtr NewDegree();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Degree__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewDegree();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Degree__SWIG_1")]
-            public static extern global::System.IntPtr NewDegree(float jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Degree__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewDegree(float jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Degree__SWIG_2")]
-            public static extern global::System.IntPtr NewDegree(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Degree__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewDegree(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Degree_degree_set")]
-            public static extern void DegreeSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Degree_degree_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DegreeSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Degree_degree_get")]
-            public static extern float DegreeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Degree_degree_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float DegreeGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Degree")]
-            public static extern void DeleteDegree(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Degree", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteDegree(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.DeviceOrientationChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.DeviceOrientationChangedSignal.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class DeviceOrientationChangedSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignalType_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignalType_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignalType_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignalType_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignalType_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignalType_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignalType_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignalType_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignalType_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_new_DeviceOrientationChangedSignalType")]
-            public static extern global::System.IntPtr NewDeviceOrientationChangedSignalType();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_new_DeviceOrientationChangedSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewDeviceOrientationChangedSignalType();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_delete_DeviceOrientationChangedSignalType")]
-            public static extern void DeleteDeviceOrientationChangedSignalType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_delete_DeviceOrientationChangedSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteDeviceOrientationChangedSignalType(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.DoGestureSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.DoGestureSignal.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,9 +14,12 @@
  * limitations under the License.
  *
  */
-using System;
-using System.Collections.Generic;
-using System.Text;
+ 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+using global::System.Collections.Generic;
+using global::System.Text;
 
 namespace Tizen.NUI
 {
@@ -24,15 +27,20 @@ namespace Tizen.NUI
     {
         internal static partial class DoGestureSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Signal_GesturePairToVoid_GetSizeOfGestureInfo")]
-            public static extern uint GetSizeOfGestureInfo();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Signal_GesturePairToVoid_GetSizeOfGestureInfo", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetSizeOfGestureInfo();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Signal_GesturePairToVoid_GetResult")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Signal_GesturePairToVoid_GetResult", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetResult(global::System.IntPtr jarg1);
+            public static partial bool GetResult(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Signal_GesturePairToVoid_SetResult")]
-            public static extern void SetResult(global::System.IntPtr jarg1, bool result);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Signal_GesturePairToVoid_SetResult", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetResult(global::System.IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool result);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.DragAndDrop.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.DragAndDrop.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -29,41 +33,46 @@ namespace Tizen.NUI
                 Drop
             }
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragAndDrop_New__SWIG_0")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragAndDrop_New__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragAndDrop_StartDragAndDrop")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragAndDrop_StartDragAndDrop", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool StartDragAndDrop(global::System.Runtime.InteropServices.HandleRef dragAndDrop, global::System.Runtime.InteropServices.HandleRef sourceView, global::System.Runtime.InteropServices.HandleRef shadow, string [] mimeTypes, int mimeTypsSize, string [] dataSet, int dataSetSize, global::System.Runtime.InteropServices.HandleRef callback);
+            public static partial bool StartDragAndDrop(IntPtr dragAndDrop, IntPtr sourceView, IntPtr shadow, string [] mimeTypes, int mimeTypsSize, string [] dataSet, int dataSetSize, IntPtr callback);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragAndDrop_AddListener")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragAndDrop_AddListener", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddListener(global::System.Runtime.InteropServices.HandleRef dragAndDrop, global::System.Runtime.InteropServices.HandleRef targetView, string mimeType, global::System.Runtime.InteropServices.HandleRef callback);
+            public static partial bool AddListener(IntPtr dragAndDrop, IntPtr targetView, string mimeType, IntPtr callback);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragAndDrop_RemoveListener")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragAndDrop_RemoveListener", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool RemoveListener(global::System.Runtime.InteropServices.HandleRef dragAndDrop, global::System.Runtime.InteropServices.HandleRef targetView, global::System.Runtime.InteropServices.HandleRef callback);
+            public static partial bool RemoveListener(IntPtr dragAndDrop, IntPtr targetView, IntPtr callback);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragAndDrop_Window_AddListener")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragAndDrop_Window_AddListener", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool WindowAddListener(global::System.Runtime.InteropServices.HandleRef dragAndDrop, global::System.Runtime.InteropServices.HandleRef targetWindow, string mimeType, global::System.Runtime.InteropServices.HandleRef callback);
+            public static partial bool WindowAddListener(IntPtr dragAndDrop, IntPtr targetWindow, string mimeType, IntPtr callback);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragAndDrop_Window_RemoveListener")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragAndDrop_Window_RemoveListener", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool WindowRemoveListener(global::System.Runtime.InteropServices.HandleRef dragAndDrop, global::System.Runtime.InteropServices.HandleRef targetWindow, global::System.Runtime.InteropServices.HandleRef callback);
+            public static partial bool WindowRemoveListener(IntPtr dragAndDrop, IntPtr targetWindow, IntPtr callback);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragEvent_GetAction")]
-            public static extern int GetAction(global::System.IntPtr dragAndDrop);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragEvent_GetAction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetAction(global::System.IntPtr dragAndDrop);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragEvent_GetPosition")]
-            public static extern global::System.IntPtr GetPosition(global::System.IntPtr dragAndDrop);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragEvent_GetPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetPosition(global::System.IntPtr dragAndDrop);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragEvent_GetMimeTypes")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragEvent_GetMimeTypes", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetMimeTypes(global::System.IntPtr dragAndDrop, out global::System.IntPtr mimeTypes, out int count);
+            public static partial bool GetMimeTypes(global::System.IntPtr dragAndDrop, out global::System.IntPtr mimeTypes, out int count);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragEvent_GetData")]
-            public static extern string GetData(global::System.IntPtr dragAndDrop);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragEvent_GetData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetData(global::System.IntPtr dragAndDrop);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Drawable.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Drawable.cs
@@ -15,44 +15,53 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Drawable
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_Translate")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_Translate", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Translate(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3);
+            public static partial bool Translate(IntPtr jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_SetOpacity")]
-            public static extern void SetOpacity(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_SetOpacity", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetOpacity(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_GetOpacity")]
-            public static extern float GetOpacity(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_GetOpacity", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetOpacity(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_Scale")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_Scale", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Scale(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            public static partial bool Scale(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_Rotate")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_Rotate", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Rotate(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            public static partial bool Rotate(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_Transform")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_Transform", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Transform(global::System.Runtime.InteropServices.HandleRef jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] float[] jarg2);
+            public static partial bool Transform(IntPtr jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] float[] jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_GetBoundingBox")]
-            public static extern global::System.IntPtr GetBoundingBox(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_GetBoundingBox", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetBoundingBox(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_SetClipPath")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_SetClipPath", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SetClipPath(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool SetClipPath(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_SetMask")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_SetMask", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SetMask(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3);
+            public static partial bool SetMask(IntPtr jarg1, IntPtr jarg2, int jarg3);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.DrawableGroup.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.DrawableGroup.cs
@@ -15,26 +15,35 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class DrawableGroup
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DrawableGroup_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DrawableGroup_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DrawableGroup_AddDrawable")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DrawableGroup_AddDrawable", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddDrawable(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool AddDrawable(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DrawableGroup_RemoveDrawable")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DrawableGroup_RemoveDrawable", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool RemoveDrawable(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool RemoveDrawable(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DrawableGroup_RemoveAllDrawables")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DrawableGroup_RemoveAllDrawables", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool RemoveAllDrawables(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool RemoveAllDrawables(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.EncodedImageBuffer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.EncodedImageBuffer.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,33 +15,36 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
-    using global::System;
-    using global::System.Runtime.InteropServices;
-
     internal static partial class Interop
     {
         internal static partial class EncodedImageBuffer
         {
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EncodedImageBuffer_New__SWIG_1")]
-            public static extern IntPtr New(global::System.Runtime.InteropServices.HandleRef jarg1, int imageType);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EncodedImageBuffer_New__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr New(IntPtr jarg1, int imageType);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_EncodedImageBuffer")]
-            public static extern void DeleteEncodedImageBuffer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_EncodedImageBuffer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteEncodedImageBuffer(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EncodedImageBuffer_SetImageType")]
-            public static extern void SetImageType(global::System.Runtime.InteropServices.HandleRef jarg1, int imageType);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EncodedImageBuffer_SetImageType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetImageType(IntPtr jarg1, int imageType);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EncodedImageBuffer_GetImageType")]
-            public static extern int GetImageType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EncodedImageBuffer_GetImageType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetImageType(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EncodedImageBuffer_GetRawBuffer")]
-            public static extern IntPtr GetRawBuffer(IntPtr handle);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EncodedImageBuffer_GetRawBuffer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GetRawBuffer(IntPtr handle);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EncodedImageBuffer_GenerateUrl")]
-            public static extern IntPtr GenerateUrl(IntPtr handle);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EncodedImageBuffer_GenerateUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GenerateUrl(IntPtr handle);
         }
     }
 }
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.EventThreadCallback.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.EventThreadCallback.cs
@@ -15,20 +15,29 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class EventThreadCallback
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_EventThreadCallback")]
-            public static extern global::System.IntPtr NewEventThreadCallback(Tizen.NUI.EventThreadCallback.CallbackDelegate delegate1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_EventThreadCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewEventThreadCallback(Tizen.NUI.EventThreadCallback.CallbackDelegate delegate1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_EventThreadCallback")]
-            public static extern void DeleteEventThreadCallback(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_EventThreadCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteEventThreadCallback(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EventThreadCallback_Trigger")]
-            public static extern void Trigger(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EventThreadCallback_Trigger", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Trigger(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Extents.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Extents.cs
@@ -15,61 +15,70 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Extents
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Extents__SWIG_0")]
-            public static extern global::System.IntPtr NewExtents();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Extents__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewExtents();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Extents__SWIG_1")]
-            public static extern global::System.IntPtr NewExtents(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Extents__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewExtents(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Extents__SWIG_2")]
-            public static extern global::System.IntPtr NewExtents(ushort jarg1, ushort jarg2, ushort jarg3, ushort jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Extents__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewExtents(ushort jarg1, ushort jarg2, ushort jarg3, ushort jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_Assign__SWIG_0")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_Assign__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_EqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_EqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool EqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool EqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_NotEqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_NotEqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool NotEqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool NotEqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_set_all")]
-            public static extern void SetAll(global::System.Runtime.InteropServices.HandleRef jarg1, ushort jarg2, ushort jarg3, ushort jarg4, ushort jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_set_all", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetAll(IntPtr jarg1, ushort jarg2, ushort jarg3, ushort jarg4, ushort jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_start_set")]
-            public static extern void StartSet(global::System.Runtime.InteropServices.HandleRef jarg1, ushort jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_start_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void StartSet(IntPtr jarg1, ushort jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_start_get")]
-            public static extern ushort StartGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_start_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial ushort StartGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_end_set")]
-            public static extern void EndSet(global::System.Runtime.InteropServices.HandleRef jarg1, ushort jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_end_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EndSet(IntPtr jarg1, ushort jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_end_get")]
-            public static extern ushort EndGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_end_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial ushort EndGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_top_set")]
-            public static extern void TopSet(global::System.Runtime.InteropServices.HandleRef jarg1, ushort jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_top_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TopSet(IntPtr jarg1, ushort jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_top_get")]
-            public static extern ushort TopGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_top_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial ushort TopGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_bottom_set")]
-            public static extern void BottomSet(global::System.Runtime.InteropServices.HandleRef jarg1, ushort jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_bottom_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void BottomSet(IntPtr jarg1, ushort jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_bottom_get")]
-            public static extern ushort BottomGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_bottom_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial ushort BottomGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Extents")]
-            public static extern void DeleteExtents(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Extents", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteExtents(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.FadeTransitionItem.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FadeTransitionItem.cs
@@ -15,27 +15,31 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
-    using global::System;
-    using global::System.Runtime.InteropServices;
-
     internal static partial class Interop
     {
         internal static partial class FadeTransitionItem
         {
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FadeTransition_New")]
-            public static extern IntPtr New(HandleRef view, float opacity, HandleRef timePeriod);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FadeTransition_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr New(IntPtr view, float opacity, IntPtr timePeriod);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FadeTransition")]
-            public static extern void Delete(HandleRef fade);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FadeTransition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Delete(IntPtr fade);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FadeTransition_Set")]
-            public static extern IntPtr NewFadeTransitionItem(HandleRef fade);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FadeTransition_Set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr NewFadeTransitionItem(IntPtr fade);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FadeTransition_Assign")]
-            public static extern IntPtr Assign(HandleRef destination, HandleRef source);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FadeTransition_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr Assign(IntPtr destination, IntPtr source);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.FlexContainer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FlexContainer.cs
@@ -15,44 +15,53 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class FlexContainer
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_Property_CONTENT_DIRECTION_get")]
-            public static extern int ContentDirectionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_Property_CONTENT_DIRECTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ContentDirectionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_Property_FLEX_DIRECTION_get")]
-            public static extern int FlexDirectionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_Property_FLEX_DIRECTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int FlexDirectionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_Property_FLEX_WRAP_get")]
-            public static extern int FlexWrapGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_Property_FLEX_WRAP_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int FlexWrapGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_Property_JUSTIFY_CONTENT_get")]
-            public static extern int JustifyContentGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_Property_JUSTIFY_CONTENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int JustifyContentGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_Property_ALIGN_ITEMS_get")]
-            public static extern int AlignItemsGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_Property_ALIGN_ITEMS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AlignItemsGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_Property_ALIGN_CONTENT_get")]
-            public static extern int AlignContentGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_Property_ALIGN_CONTENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AlignContentGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_ChildProperty_FLEX_get")]
-            public static extern int ChildPropertyFlexGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_ChildProperty_FLEX_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ChildPropertyFlexGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_ChildProperty_ALIGN_SELF_get")]
-            public static extern int ChildPropertyAlignSelfGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_ChildProperty_ALIGN_SELF_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ChildPropertyAlignSelfGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_ChildProperty_FLEX_MARGIN_get")]
-            public static extern int ChildPropertyFlexMarginGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_ChildProperty_FLEX_MARGIN_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ChildPropertyFlexMarginGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FlexContainer")]
-            public static extern void DeleteFlexContainer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FlexContainer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteFlexContainer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexContainer_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.FocusChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FocusChangedSignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class FocusChangedSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusChangedSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusChangedSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusChangedSignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusChangedSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusChangedSignal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusChangedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusChangedSignal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusChangedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusChangedSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusChangedSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FocusChangedSignal")]
-            public static extern global::System.IntPtr NewFocusChangedSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FocusChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewFocusChangedSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FocusChangedSignal")]
-            public static extern void DeleteFocusChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FocusChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteFocusChangedSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.FocusGroupChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FocusGroupChangedSignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class FocusGroupChangedSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusGroupChangedSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusGroupChangedSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusGroupChangedSignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusGroupChangedSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusGroupChangedSignal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusGroupChangedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusGroupChangedSignal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusGroupChangedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusGroupChangedSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, bool jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusGroupChangedSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, IntPtr jarg2, [MarshalAs(UnmanagedType.U1)] bool jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FocusGroupChangedSignal")]
-            public static extern global::System.IntPtr NewFocusGroupChangedSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FocusGroupChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewFocusGroupChangedSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FocusGroupChangedSignal")]
-            public static extern void DeleteFocusGroupChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FocusGroupChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteFocusGroupChangedSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.FocusManager.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FocusManager.cs
@@ -14,7 +14,10 @@
  * limitations under the License.
  *
  */
-using System.Runtime.InteropServices;
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -22,102 +25,107 @@ namespace Tizen.NUI
     {
         internal static partial class FocusManager
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_new_KeyboardFocusManager")]
-            public static extern global::System.IntPtr NewFocusManager();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_new_KeyboardFocusManager", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewFocusManager();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_Get")]
-            public static extern global::System.IntPtr Get();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_Get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Get();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_SetCurrentFocusActor")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_SetCurrentFocusActor", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SetCurrentFocusActor(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool SetCurrentFocusActor(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_GetCurrentFocusActor")]
-            public static extern global::System.IntPtr GetCurrentFocusActor(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_GetCurrentFocusActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetCurrentFocusActor(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_MoveFocus")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_MoveFocus", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool MoveFocus(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            public static partial bool MoveFocus(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_ClearFocus")]
-            public static extern void ClearFocus(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_ClearFocus", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ClearFocus(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_SetFocusGroupLoop")]
-            public static extern void SetFocusGroupLoop(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_SetFocusGroupLoop", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFocusGroupLoop(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_GetFocusGroupLoop")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_GetFocusGroupLoop", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetFocusGroupLoop(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool GetFocusGroupLoop(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_SetAsFocusGroup")]
-            public static extern void SetAsFocusGroup(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, bool jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_SetAsFocusGroup", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetAsFocusGroup(IntPtr jarg1, IntPtr jarg2, [MarshalAs(UnmanagedType.U1)] bool jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_IsFocusGroup")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_IsFocusGroup", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsFocusGroup(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool IsFocusGroup(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_GetFocusGroup")]
-            public static extern global::System.IntPtr GetFocusGroup(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_GetFocusGroup", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetFocusGroup(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_SetFocusIndicatorActor")]
-            public static extern void SetFocusIndicatorActor(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_SetFocusIndicatorActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFocusIndicatorActor(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_GetFocusIndicatorActor")]
-            public static extern global::System.IntPtr GetFocusIndicatorActor(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_GetFocusIndicatorActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetFocusIndicatorActor(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_MoveFocusBackward")]
-            public static extern void MoveFocusBackward(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_MoveFocusBackward", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void MoveFocusBackward(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_PreFocusChangeSignal")]
-            public static extern global::System.IntPtr PreFocusChangeSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_PreFocusChangeSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr PreFocusChangeSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_FocusChangedSignal")]
-            public static extern global::System.IntPtr FocusChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_FocusChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr FocusChangedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_FocusGroupChangedSignal")]
-            public static extern global::System.IntPtr FocusGroupChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_FocusGroupChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr FocusGroupChangedSignal(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_FocusedActorEnterKeySignal_Connect")]
-            public static extern void FocusedActorEnterKeySignalConnect(HandleRef focusManager, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_FocusedActorEnterKeySignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FocusedActorEnterKeySignalConnect(IntPtr focusManager, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_FocusedActorEnterKeySignal_Disconnect")]
-            public static extern void FocusedActorEnterKeySignalDisconnect(HandleRef focusManager, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_FocusedActorEnterKeySignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FocusedActorEnterKeySignalDisconnect(IntPtr focusManager, IntPtr handler);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardFocusManager_EnableDefaultAlgorithm")]
-            public static extern void EnableDefaultAlgorithm(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardFocusManager_EnableDefaultAlgorithm", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableDefaultAlgorithm(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardFocusManager_IsDefaultAlgorithmEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardFocusManager_IsDefaultAlgorithmEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsDefaultAlgorithmEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsDefaultAlgorithmEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_GetNearestFocusableActor")]
-            public static extern global::System.IntPtr GetNearestFocusableActor(global::System.Runtime.InteropServices.HandleRef rootView, global::System.Runtime.InteropServices.HandleRef currentView, int direction);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_GetNearestFocusableActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetNearestFocusableActor(IntPtr rootView, IntPtr currentView, int direction);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardFocusManager_SetFocusFinderRootActor")]
-            public static extern void SetFocusFinderRootView(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardFocusManager_SetFocusFinderRootActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFocusFinderRootView(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardFocusManager_ResetFocusFinderRootActor")]
-            public static extern void ResetFocusFinderRootView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardFocusManager_ResetFocusFinderRootActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ResetFocusFinderRootView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_EnableFocusIndicator")]
-            public static extern void EnableFocusIndicator(global::System.Runtime.InteropServices.HandleRef focusManager, bool enable);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_EnableFocusIndicator", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableFocusIndicator(IntPtr focusManager, [MarshalAs(UnmanagedType.U1)] bool enable);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_IsFocusIndicatorEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_IsFocusIndicatorEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsFocusIndicatorEnabled(global::System.Runtime.InteropServices.HandleRef focusManager);
+            public static partial bool IsFocusIndicatorEnabled(IntPtr focusManager);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_GetLastFocusChangeDevice")]
-            public static extern int GetLastFocusChangeDevice(global::System.Runtime.InteropServices.HandleRef focusManager);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_GetLastFocusChangeDevice", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetLastFocusChangeDevice(IntPtr focusManager);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_GetLastFocusChangeDeviceName")]
-            public static extern string GetLastFocusChangeDeviceName(global::System.Runtime.InteropServices.HandleRef focusManager);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_GetLastFocusChangeDeviceName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetLastFocusChangeDeviceName(IntPtr focusManager);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_SetClearFocusOnWindowFocusLost")]
-            public static extern void SetClearFocusOnWindowFocusLost(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_SetClearFocusOnWindowFocusLost", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetClearFocusOnWindowFocusLost(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_GetClearFocusOnWindowFocusLost")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_GetClearFocusOnWindowFocusLost", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetClearFocusOnWindowFocusLost(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool GetClearFocusOnWindowFocusLost(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.FontClient.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FontClient.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,229 +26,234 @@ namespace Tizen.NUI
         internal static partial class FontClient
         {
             //for FontClient
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_PreCache")]
-            public static extern void PreCache(string[] fallbackFamilyArray, int fallbackFamilySize, string[] extraFamilyArray, int extraFamilySize, string localeFamily, bool useThread, bool syncCreation);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_PreCache", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PreCache(string[] fallbackFamilyArray, int fallbackFamilySize, string[] extraFamilyArray, int extraFamilySize, string localeFamily, [MarshalAs(UnmanagedType.U1)] bool useThread, [MarshalAs(UnmanagedType.U1)] bool syncCreation);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_FontPreLoad")]
-            public static extern void FontPreLoad(string[] fontPathArray, int fontPathSize, string[] memoryFontPathArray, int memoryFontPathSize, bool useThread, bool syncCreation);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_FontPreLoad", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FontPreLoad(string[] fontPathArray, int fontPathSize, string[] memoryFontPathArray, int memoryFontPathSize, [MarshalAs(UnmanagedType.U1)] bool useThread, [MarshalAs(UnmanagedType.U1)] bool syncCreation);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_EnableDesignCompatibility")]
-            public static extern void EnableDesignCompatibility();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_EnableDesignCompatibility", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableDesignCompatibility();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FontClient_GlyphBufferData")]
-            public static extern global::System.IntPtr NewFontClientGlyphBufferData();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FontClient_GlyphBufferData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewFontClientGlyphBufferData();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FontClient_GlyphBufferData")]
-            public static extern void DeleteFontClientGlyphBufferData(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FontClient_GlyphBufferData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteFontClientGlyphBufferData(IntPtr jarg1);
 
             /*
-                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint="CSharp_Dali_FontClient_GlyphBufferData_buffer_set")]
-                public static extern void GlyphBufferDataBufferSet(global::System.Runtime.InteropServices.HandleRef jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)]byte[] jarg2);
+                [LibraryImport(NDalicPINVOKE.Lib, EntryPoint="CSharp_Dali_FontClient_GlyphBufferData_buffer_set", StringMarshalling = StringMarshalling.Utf8)]
+                public static partial void GlyphBufferDataBufferSet(IntPtr jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)]byte[] jarg2);
 
-                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint="CSharp_Dali_FontClient_GlyphBufferData_buffer_get")]
-                public static extern byte[] GlyphBufferDataBufferGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+                [LibraryImport(NDalicPINVOKE.Lib, EntryPoint="CSharp_Dali_FontClient_GlyphBufferData_buffer_get", StringMarshalling = StringMarshalling.Utf8)]
+                public static partial byte[] GlyphBufferDataBufferGet(IntPtr jarg1);
             */
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GlyphBufferData_width_set")]
-            public static extern void GlyphBufferDataWidthSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GlyphBufferData_width_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlyphBufferDataWidthSet(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GlyphBufferData_width_get")]
-            public static extern uint GlyphBufferDataWidthGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GlyphBufferData_width_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GlyphBufferDataWidthGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GlyphBufferData_height_set")]
-            public static extern void GlyphBufferDataHeightSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GlyphBufferData_height_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlyphBufferDataHeightSet(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GlyphBufferData_height_get")]
-            public static extern uint GlyphBufferDataHeightGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GlyphBufferData_height_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GlyphBufferDataHeightGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GlyphBufferData_format_set")]
-            public static extern void GlyphBufferDataFormatSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GlyphBufferData_format_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlyphBufferDataFormatSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GlyphBufferData_format_get")]
-            public static extern int GlyphBufferDataFormatGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GlyphBufferData_format_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GlyphBufferDataFormatGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_Get")]
-            public static extern global::System.IntPtr Get();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_Get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Get();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FontClient__SWIG_0")]
-            public static extern global::System.IntPtr NewFontClient();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FontClient__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewFontClient();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_SetDpi")]
-            public static extern void SetDpi(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, uint jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_SetDpi", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetDpi(IntPtr jarg1, uint jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetDefaultFontSize")]
-            public static extern int GetDefaultFontSize(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetDefaultFontSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetDefaultFontSize(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_ResetSystemDefaults")]
-            public static extern void ResetSystemDefaults(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_ResetSystemDefaults", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ResetSystemDefaults(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetDefaultPlatformFontDescription")]
-            public static extern void GetDefaultPlatformFontDescription(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetDefaultPlatformFontDescription", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GetDefaultPlatformFontDescription(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetSystemFonts")]
-            public static extern global::System.IntPtr GetSystemFonts(global::System.Runtime.InteropServices.HandleRef fontClient);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetSystemFonts", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetSystemFonts(IntPtr fontClient);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetDescription")]
-            public static extern void GetDescription(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetDescription", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GetDescription(IntPtr jarg1, uint jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetPointSize")]
-            public static extern uint GetPointSize(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetPointSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetPointSize(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_IsCharacterSupportedByFont")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_IsCharacterSupportedByFont", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsCharacterSupportedByFont(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, uint jarg3);
+            public static partial bool IsCharacterSupportedByFont(IntPtr jarg1, uint jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_FindDefaultFont__SWIG_0")]
-            public static extern uint FindDefaultFont(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, uint jarg3, bool jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_FindDefaultFont__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint FindDefaultFont(IntPtr jarg1, uint jarg2, uint jarg3, [MarshalAs(UnmanagedType.U1)] bool jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_FindDefaultFont__SWIG_1")]
-            public static extern uint FindDefaultFont(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, uint jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_FindDefaultFont__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint FindDefaultFont(IntPtr jarg1, uint jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_FindDefaultFont__SWIG_2")]
-            public static extern uint FindDefaultFont(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_FindDefaultFont__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint FindDefaultFont(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_FindFallbackFont__SWIG_0")]
-            public static extern uint FindFallbackFont(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, uint jarg4, bool jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_FindFallbackFont__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint FindFallbackFont(IntPtr jarg1, uint jarg2, IntPtr jarg3, uint jarg4, [MarshalAs(UnmanagedType.U1)] bool jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_FindFallbackFont__SWIG_1")]
-            public static extern uint FindFallbackFont(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, uint jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_FindFallbackFont__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint FindFallbackFont(IntPtr jarg1, uint jarg2, IntPtr jarg3, uint jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_FindFallbackFont__SWIG_2")]
-            public static extern uint FindFallbackFont(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_FindFallbackFont__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint FindFallbackFont(IntPtr jarg1, uint jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetFontId__SWIG_0")]
-            public static extern uint GetFontId(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, uint jarg3, uint jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetFontId__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetFontId(IntPtr jarg1, string jarg2, uint jarg3, uint jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetFontId__SWIG_1")]
-            public static extern uint GetFontId(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, uint jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetFontId__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetFontId(IntPtr jarg1, string jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetFontId__SWIG_2")]
-            public static extern uint GetFontId(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetFontId__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetFontId(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetFontId__SWIG_3")]
-            public static extern uint GetFontId(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, uint jarg3, uint jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetFontId__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetFontId(IntPtr jarg1, IntPtr jarg2, uint jarg3, uint jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetFontId__SWIG_4")]
-            public static extern uint GetFontId(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, uint jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetFontId__SWIG_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetFontId(IntPtr jarg1, IntPtr jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetFontId__SWIG_5")]
-            public static extern uint GetFontId(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetFontId__SWIG_5", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetFontId(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_IsScalable__SWIG_0")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_IsScalable__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsScalable(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            public static partial bool IsScalable(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_IsScalable__SWIG_1")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_IsScalable__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsScalable(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool IsScalable(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetFontMetrics")]
-            public static extern void GetFontMetrics(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetFontMetrics", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GetFontMetrics(IntPtr jarg1, uint jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetGlyphIndex")]
-            public static extern uint GetGlyphIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, uint jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetGlyphIndex", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetGlyphIndex(IntPtr jarg1, uint jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetGlyphMetrics__SWIG_0")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetGlyphMetrics__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetGlyphMetrics(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, uint jarg3, int jarg4, bool jarg5);
+            public static partial bool GetGlyphMetrics(IntPtr jarg1, IntPtr jarg2, uint jarg3, int jarg4, [MarshalAs(UnmanagedType.U1)] bool jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetGlyphMetrics__SWIG_1")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetGlyphMetrics__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetGlyphMetrics(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, uint jarg3, int jarg4);
+            public static partial bool GetGlyphMetrics(IntPtr jarg1, IntPtr jarg2, uint jarg3, int jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_CreateBitmap__SWIG_0")]
-            public static extern void CreateBitmap(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, uint jarg3, bool jarg4, bool jarg5, global::System.Runtime.InteropServices.HandleRef jarg6, int jarg7);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_CreateBitmap__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void CreateBitmap(IntPtr jarg1, uint jarg2, uint jarg3, [MarshalAs(UnmanagedType.U1)] bool jarg4, [MarshalAs(UnmanagedType.U1)] bool jarg5, IntPtr jarg6, int jarg7);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_CreateBitmap__SWIG_1")]
-            public static extern global::System.IntPtr CreateBitmap(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, uint jarg3, int jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_CreateBitmap__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CreateBitmap(IntPtr jarg1, uint jarg2, uint jarg3, int jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetEllipsisGlyph")]
-            public static extern global::System.IntPtr GetEllipsisGlyph(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetEllipsisGlyph", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetEllipsisGlyph(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_IsColorGlyph")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_IsColorGlyph", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsColorGlyph(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, uint jarg3);
+            public static partial bool IsColorGlyph(IntPtr jarg1, uint jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_AddCustomFontDirectory")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_AddCustomFontDirectory", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddCustomFontDirectory(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            public static partial bool AddCustomFontDirectory(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FontDescription")]
-            public static extern global::System.IntPtr NewFontDescription();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FontDescription", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewFontDescription();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FontDescription")]
-            public static extern void DeleteFontDescription(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FontDescription", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteFontDescription(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_path_set")]
-            public static extern void FontDescriptionPathSet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_path_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FontDescriptionPathSet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_path_get")]
-            public static extern string FontDescriptionPathGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_path_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string FontDescriptionPathGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_family_set")]
-            public static extern void FontDescriptionFamilySet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_family_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FontDescriptionFamilySet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_family_get")]
-            public static extern string FontDescriptionFamilyGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_family_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string FontDescriptionFamilyGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_width_set")]
-            public static extern void FontDescriptionWidthSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_width_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FontDescriptionWidthSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_width_get")]
-            public static extern int FontDescriptionWidthGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_width_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int FontDescriptionWidthGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_weight_set")]
-            public static extern void FontDescriptionWeightSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_weight_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FontDescriptionWeightSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_weight_get")]
-            public static extern int FontDescriptionWeightGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_weight_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int FontDescriptionWeightGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_slant_set")]
-            public static extern void FontDescriptionSlantSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_slant_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FontDescriptionSlantSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_slant_get")]
-            public static extern int FontDescriptionSlantGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontDescription_slant_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int FontDescriptionSlantGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FontMetrics__SWIG_0")]
-            public static extern global::System.IntPtr NewFontMetrics();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FontMetrics__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewFontMetrics();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FontMetrics__SWIG_1")]
-            public static extern global::System.IntPtr NewFontMetrics(float jarg1, float jarg2, float jarg3, float jarg4, float jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FontMetrics__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewFontMetrics(float jarg1, float jarg2, float jarg3, float jarg4, float jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_ascender_set")]
-            public static extern void FontMetricsAscenderSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_ascender_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FontMetricsAscenderSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_ascender_get")]
-            public static extern float FontMetricsAscenderGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_ascender_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float FontMetricsAscenderGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_descender_set")]
-            public static extern void FontMetricsDescenderSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_descender_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FontMetricsDescenderSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_descender_get")]
-            public static extern float FontMetricsDescenderGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_descender_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float FontMetricsDescenderGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_height_set")]
-            public static extern void FontMetricsHeightSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_height_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FontMetricsHeightSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_height_get")]
-            public static extern float FontMetricsHeightGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_height_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float FontMetricsHeightGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_underlinePosition_set")]
-            public static extern void FontMetricsUnderlinePositionSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_underlinePosition_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FontMetricsUnderlinePositionSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_underlinePosition_get")]
-            public static extern float FontMetricsUnderlinePositionGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_underlinePosition_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float FontMetricsUnderlinePositionGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_underlineThickness_set")]
-            public static extern void FontMetricsUnderlineThicknessSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_underlineThickness_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FontMetricsUnderlineThicknessSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_underlineThickness_get")]
-            public static extern float FontMetricsUnderlineThicknessGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontMetrics_underlineThickness_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float FontMetricsUnderlineThicknessGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FontMetrics")]
-            public static extern void DeleteFontMetrics(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FontMetrics", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteFontMetrics(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.FrameBroker.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FrameBroker.cs
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-using System;
-using System.Runtime.InteropServices;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 using Tizen.NUI;
 
@@ -72,20 +73,20 @@ namespace Tizen.NUI
                 public FrameContextErrorCallback OnError;
             }
 
-            [DllImport(Libraries.FrameBroker, EntryPoint = "frame_context_start_animation")]
+            [LibraryImport(Libraries.FrameBroker, EntryPoint = "frame_context_start_animation", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern ErrorCode StartAnimation(IntPtr handle);
 
-            [DllImport(Libraries.FrameBroker, EntryPoint = "frame_context_finish_animation")]
+            [LibraryImport(Libraries.FrameBroker, EntryPoint = "frame_context_finish_animation", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern ErrorCode FinishAnimation(IntPtr handle);
 
 
-            [DllImport(Libraries.FrameBroker, EntryPoint = "frame_broker_create")]
+            [LibraryImport(Libraries.FrameBroker, EntryPoint = "frame_broker_create", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern ErrorCode Create(IntPtr wl2Win, ref FrameContextLifecycleCallbacks callbacks, IntPtr userData, out SafeFrameBrokerHandle handle);
 
-            [DllImport(Libraries.FrameBroker, EntryPoint = "frame_broker_destroy")]
+            [LibraryImport(Libraries.FrameBroker, EntryPoint = "frame_broker_destroy", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern ErrorCode DangerousDestroy(IntPtr handle);
 
-            [DllImport(Libraries.FrameBroker, EntryPoint = "frame_broker_send_launch_request")]
+            [LibraryImport(Libraries.FrameBroker, EntryPoint = "frame_broker_send_launch_request", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern ErrorCode SendLaunchRequest(SafeFrameBrokerHandle handle, SafeAppControlHandle safeAppControlHandle, AppControlResultCallback resultCallback, AppControlReplyCallback replyCallback, IntPtr userData);
 
 
@@ -103,32 +104,35 @@ namespace Tizen.NUI
                 Backward = 1,
             }
 
-            [DllImport(Libraries.FrameBroker, EntryPoint = "frame_get_tbm_surface")]
+            [LibraryImport(Libraries.FrameBroker, EntryPoint = "frame_get_tbm_surface", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern ErrorCode GetTbmSurface(IntPtr handle, out IntPtr tbmSurface);
 
-            [DllImport(Libraries.FrameBroker, EntryPoint = "frame_get_image_file")]
+            [LibraryImport(Libraries.FrameBroker, EntryPoint = "frame_get_image_file", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern ErrorCode GetImageFile(IntPtr handle, out Int32 fd, out UInt32 size);
 
-            [DllImport(Libraries.FrameBroker, EntryPoint = "frame_get_file_path")]
+            [LibraryImport(Libraries.FrameBroker, EntryPoint = "frame_get_file_path", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern ErrorCode GetFilePath(IntPtr handle, out string filePath);
 
-            [DllImport(Libraries.FrameBroker, EntryPoint = "frame_get_file_group")]
+            [LibraryImport(Libraries.FrameBroker, EntryPoint = "frame_get_file_group", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern ErrorCode GetFileGroup(IntPtr handle, out string fileGroup);
 
-            [DllImport(Libraries.FrameBroker, EntryPoint = "frame_get_type")]
+            [LibraryImport(Libraries.FrameBroker, EntryPoint = "frame_get_type", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern ErrorCode GetType(IntPtr handle, out FrameType type);
 
-            [DllImport(Libraries.FrameBroker, EntryPoint = "frame_get_direction")]
+            [LibraryImport(Libraries.FrameBroker, EntryPoint = "frame_get_direction", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern ErrorCode GetDirection(IntPtr handle, out FrameDirection direction);
 
-            [DllImport(Libraries.FrameBroker, EntryPoint = "frame_get_position_x")]
+            [LibraryImport(Libraries.FrameBroker, EntryPoint = "frame_get_position_x", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern ErrorCode GetPositionX(IntPtr handle, out Int32 x);
 
-            [DllImport(Libraries.FrameBroker, EntryPoint = "frame_get_position_y")]
+            [LibraryImport(Libraries.FrameBroker, EntryPoint = "frame_get_position_y", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern ErrorCode GetPositionY(IntPtr handle, out Int32 y);
 
-            [DllImport(Libraries.FrameBroker, EntryPoint = "frame_get_extra_data")]
+            [LibraryImport(Libraries.FrameBroker, EntryPoint = "frame_get_extra_data", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern ErrorCode GetExtraData(IntPtr handle, out SafeBundleHandle safeBundleHandle);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.FrameBuffer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FrameBuffer.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,38 +26,43 @@ namespace Tizen.NUI
         internal static partial class FrameBuffer
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_New")]
-            public static extern global::System.IntPtr New(uint jarg1, uint jarg2, uint jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(uint jarg1, uint jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FrameBuffer")]
-            public static extern void DeleteFrameBuffer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FrameBuffer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteFrameBuffer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_AttachColorTexture__SWIG_0")]
-            public static extern void AttachColorTexture(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_AttachColorTexture__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AttachColorTexture(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_AttachColorTexture__SWIG_1")]
-            public static extern void AttachColorTexture(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, uint jarg3, uint jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_AttachColorTexture__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AttachColorTexture(IntPtr jarg1, IntPtr jarg2, uint jarg3, uint jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_AttachDepthTexture")]
-            public static extern void AttachDepthTexture(global::System.Runtime.InteropServices.HandleRef frameBuffer, global::System.Runtime.InteropServices.HandleRef depthTexture, uint mipmapLevel);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_AttachDepthTexture", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AttachDepthTexture(IntPtr frameBuffer, IntPtr depthTexture, uint mipmapLevel);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_GetColorTexture")]
-            public static extern global::System.IntPtr GetColorTexture(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_GetColorTexture", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetColorTexture(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_GetColorTexture_Index")]
-            public static extern global::System.IntPtr GetColorTextureByIndex(global::System.Runtime.InteropServices.HandleRef frameBuffer, uint index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_GetColorTexture_Index", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetColorTextureByIndex(IntPtr frameBuffer, uint index);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_GetDepthTexture")]
-            public static extern global::System.IntPtr GetDepthTexture(global::System.Runtime.InteropServices.HandleRef frameBuffer);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_GetDepthTexture", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetDepthTexture(IntPtr frameBuffer);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_GenerateUrl")]
-            public static extern global::System.IntPtr GenerateUrl(global::System.IntPtr frameBuffer, int pixelFormat, int width, int height);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_GenerateUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GenerateUrl(global::System.IntPtr frameBuffer, int pixelFormat, int width, int height);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_GenerateUrl_Index")]
-            public static extern global::System.IntPtr GenerateUrlByIndex(global::System.IntPtr frameBuffer, uint index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_GenerateUrl_Index", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GenerateUrlByIndex(global::System.IntPtr frameBuffer, uint index);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_GenerateDepthUrl")]
-            public static extern global::System.IntPtr GenerateDepthUrl(global::System.IntPtr frameBuffer);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_GenerateDepthUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GenerateDepthUrl(global::System.IntPtr frameBuffer);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.FrameProvider.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FrameProvider.cs
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-using System;
-using System.Runtime.InteropServices;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 using Tizen.NUI;
 using Tizen.Applications;
@@ -46,17 +47,20 @@ namespace Tizen.NUI
                 public HideCallback OnHide;
             }
 
-            [DllImport(Libraries.FrameProvider, EntryPoint = "frame_provider_create")]
+            [LibraryImport(Libraries.FrameProvider, EntryPoint = "frame_provider_create", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern ErrorCode Create(IntPtr wl2Win, ref FrameProviderEventCallbacks callbacks, IntPtr userData, out SafeFrameProviderHandle handle);
 
-            [DllImport(Libraries.FrameProvider, EntryPoint = "frame_provider_destroy")]
+            [LibraryImport(Libraries.FrameProvider, EntryPoint = "frame_provider_destroy", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern ErrorCode DangerousDestroy(IntPtr handle);
 
-            [DllImport(Libraries.FrameProvider, EntryPoint = "frame_provider_notify_show_status")]
+            [LibraryImport(Libraries.FrameProvider, EntryPoint = "frame_provider_notify_show_status", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern ErrorCode NotifyShowStatus(SafeFrameProviderHandle handle, SafeBundleHandle safeBundleHandle);
 
-            [DllImport(Libraries.FrameProvider, EntryPoint = "frame_provider_notify_hide_status")]
+            [LibraryImport(Libraries.FrameProvider, EntryPoint = "frame_provider_notify_hide_status", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern ErrorCode NotifyHideStatus(SafeFrameProviderHandle handle, SafeBundleHandle safeBundleHandle);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.FrameUpdateCallbackInterface.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FrameUpdateCallbackInterface.cs
@@ -15,148 +15,157 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class FrameUpdateCallbackInterface
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FrameCallbackInterface")]
-            public static extern global::System.IntPtr newFrameUpdateCallbackInterface();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FrameCallbackInterface", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr newFrameUpdateCallbackInterface();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FrameCallbackInterface")]
-            public static extern void DeleteFrameUpdateCallbackInterface(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FrameCallbackInterface", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteFrameUpdateCallbackInterface(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_director_connect_with_return")]
-            public static extern void FrameUpdateCallbackInterfaceDirectorConnectV1(global::System.Runtime.InteropServices.HandleRef jarg1, Tizen.NUI.FrameUpdateCallbackInterface.DelegateFrameUpdateCallbackInterfaceV1 delegate1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_director_connect_with_return", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FrameUpdateCallbackInterfaceDirectorConnectV1(IntPtr jarg1, Tizen.NUI.FrameUpdateCallbackInterface.DelegateFrameUpdateCallbackInterfaceV1 delegate1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetPosition")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetPosition", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceGetPosition(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector);
+            public static partial bool FrameCallbackInterfaceGetPosition(global::System.IntPtr proxy, uint id, IntPtr vector);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_SetPosition")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_SetPosition", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceSetPosition(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector);
+            public static partial bool FrameCallbackInterfaceSetPosition(global::System.IntPtr proxy, uint id, IntPtr vector);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakePosition")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakePosition", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceBakePosition(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector);
+            public static partial bool FrameCallbackInterfaceBakePosition(global::System.IntPtr proxy, uint id, IntPtr vector);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetOrientation")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetOrientation", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceGetOrientation(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef orientation);
+            public static partial bool FrameCallbackInterfaceGetOrientation(global::System.IntPtr proxy, uint id, IntPtr orientation);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_SetOrientation")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_SetOrientation", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceSetOrientation(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef orientation);
+            public static partial bool FrameCallbackInterfaceSetOrientation(global::System.IntPtr proxy, uint id, IntPtr orientation);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeOrientation")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeOrientation", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceBakeOrientation(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef orientation);
+            public static partial bool FrameCallbackInterfaceBakeOrientation(global::System.IntPtr proxy, uint id, IntPtr orientation);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetPositionAndSize")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetPositionAndSize", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceGetPositionAndSize(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector, global::System.Runtime.InteropServices.HandleRef vector2);
+            public static partial bool FrameCallbackInterfaceGetPositionAndSize(global::System.IntPtr proxy, uint id, IntPtr vector, IntPtr vector2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetWorldPositionScaleAndSize")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetWorldPositionScaleAndSize", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceGetWorldPositionScaleAndSize(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector, global::System.Runtime.InteropServices.HandleRef vector2, global::System.Runtime.InteropServices.HandleRef vector3);
+            public static partial bool FrameCallbackInterfaceGetWorldPositionScaleAndSize(global::System.IntPtr proxy, uint id, IntPtr vector, IntPtr vector2, IntPtr vector3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetWorldTransformAndSize")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetWorldTransformAndSize", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceGetWorldTransformAndSize(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector, global::System.Runtime.InteropServices.HandleRef vector2, global::System.Runtime.InteropServices.HandleRef rotation, global::System.Runtime.InteropServices.HandleRef vector3);
+            public static partial bool FrameCallbackInterfaceGetWorldTransformAndSize(global::System.IntPtr proxy, uint id, IntPtr vector, IntPtr vector2, IntPtr rotation, IntPtr vector3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetSize")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetSize", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceGetSize(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector);
+            public static partial bool FrameCallbackInterfaceGetSize(global::System.IntPtr proxy, uint id, IntPtr vector);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_SetSize")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_SetSize", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceSetSize(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector);
+            public static partial bool FrameCallbackInterfaceSetSize(global::System.IntPtr proxy, uint id, IntPtr vector);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeSize")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeSize", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceBakeSize(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector);
+            public static partial bool FrameCallbackInterfaceBakeSize(global::System.IntPtr proxy, uint id, IntPtr vector);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetScale")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetScale", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceGetScale(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector);
+            public static partial bool FrameCallbackInterfaceGetScale(global::System.IntPtr proxy, uint id, IntPtr vector);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_SetScale")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_SetScale", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceSetScale(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector);
+            public static partial bool FrameCallbackInterfaceSetScale(global::System.IntPtr proxy, uint id, IntPtr vector);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeScale")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeScale", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceBakeScale(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector);
+            public static partial bool FrameCallbackInterfaceBakeScale(global::System.IntPtr proxy, uint id, IntPtr vector);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetColor")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetColor", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceGetColor(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector);
+            public static partial bool FrameCallbackInterfaceGetColor(global::System.IntPtr proxy, uint id, IntPtr vector);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_SetColor")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_SetColor", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceSetColor(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector);
+            public static partial bool FrameCallbackInterfaceSetColor(global::System.IntPtr proxy, uint id, IntPtr vector);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeColor")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeColor", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceBakeColor(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector);
+            public static partial bool FrameCallbackInterfaceBakeColor(global::System.IntPtr proxy, uint id, IntPtr vector);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_SetIgnored")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_SetIgnored", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceSetIgnored(global::System.IntPtr proxy, uint id, [global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)] bool ignored);
+            public static partial bool FrameCallbackInterfaceSetIgnored(global::System.IntPtr proxy, uint id, [global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)] bool ignored);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetIgnored")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetIgnored", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceGetIgnored(global::System.IntPtr proxy, uint id, [global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)] out bool ignored);
+            public static partial bool FrameCallbackInterfaceGetIgnored(global::System.IntPtr proxy, uint id, [global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)] out bool ignored);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetCustomProperty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetCustomProperty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceGetCustomProperty(global::System.IntPtr proxy, uint id, string propertyName, global::System.Runtime.InteropServices.HandleRef propertyValue);
+            public static partial bool FrameCallbackInterfaceGetCustomProperty(global::System.IntPtr proxy, uint id, string propertyName, IntPtr propertyValue);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeCustomProperty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeCustomProperty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceBakeCustomProperty(global::System.IntPtr proxy, uint id, string propertyName, global::System.Runtime.InteropServices.HandleRef propertyValue);
+            public static partial bool FrameCallbackInterfaceBakeCustomProperty(global::System.IntPtr proxy, uint id, string propertyName, IntPtr propertyValue);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_AddFrameCallback")]
-            public static extern void FrameCallbackInterfaceAddFrameUpdateCallback(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_AddFrameCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FrameCallbackInterfaceAddFrameUpdateCallback(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_RemoveFrameCallback")]
-            public static extern void FrameCallbackInterfaceRemoveFrameUpdateCallback(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_RemoveFrameCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FrameCallbackInterfaceRemoveFrameUpdateCallback(IntPtr jarg1, IntPtr jarg2);
 
             // UIVector2 and UIColor
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetPositionVector2Componentwise")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetPositionVector2Componentwise", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceGetPositionVector2Componentwise(global::System.IntPtr proxy, uint id, ref float x, ref float y);
+            public static partial bool FrameCallbackInterfaceGetPositionVector2Componentwise(global::System.IntPtr proxy, uint id, ref float x, ref float y);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakePositionVector2Componentwise")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakePositionVector2Componentwise", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceBakePositionVector2Componentwise(global::System.IntPtr proxy, uint id, float x, float y);
+            public static partial bool FrameCallbackInterfaceBakePositionVector2Componentwise(global::System.IntPtr proxy, uint id, float x, float y);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetSizeVector2Componentwise")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetSizeVector2Componentwise", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceGetSizeVector2Componentwise(global::System.IntPtr proxy, uint id, ref float x, ref float y);
+            public static partial bool FrameCallbackInterfaceGetSizeVector2Componentwise(global::System.IntPtr proxy, uint id, ref float x, ref float y);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeSizeVector2Componentwise")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeSizeVector2Componentwise", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceBakeSizeVector2Componentwise(global::System.IntPtr proxy, uint id, float x, float y);
+            public static partial bool FrameCallbackInterfaceBakeSizeVector2Componentwise(global::System.IntPtr proxy, uint id, float x, float y);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetScaleVector2Componentwise")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetScaleVector2Componentwise", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceGetScaleVector2Componentwise(global::System.IntPtr proxy, uint id, ref float x, ref float y);
+            public static partial bool FrameCallbackInterfaceGetScaleVector2Componentwise(global::System.IntPtr proxy, uint id, ref float x, ref float y);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeScaleVector2Componentwise")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeScaleVector2Componentwise", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceBakeScaleVector2Componentwise(global::System.IntPtr proxy, uint id, float x, float y);
+            public static partial bool FrameCallbackInterfaceBakeScaleVector2Componentwise(global::System.IntPtr proxy, uint id, float x, float y);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetColorVector4Componentwise")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetColorVector4Componentwise", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceGetColorVector4Componentwise(global::System.IntPtr proxy, uint id, ref float r, ref float g, ref float b, ref float a);
+            public static partial bool FrameCallbackInterfaceGetColorVector4Componentwise(global::System.IntPtr proxy, uint id, ref float r, ref float g, ref float b, ref float a);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeColorVector4Componentwise")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeColorVector4Componentwise", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FrameCallbackInterfaceBakeColorVector4Componentwise(global::System.IntPtr proxy, uint id, float r, float g, float b, float a);
+            public static partial bool FrameCallbackInterfaceBakeColorVector4Componentwise(global::System.IntPtr proxy, uint id, float r, float g, float b, float a);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GLView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GLView.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,9 @@
  *
  */
 
-using System.Runtime.InteropServices;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -23,54 +25,57 @@ namespace Tizen.NUI
     {
         internal static partial class GLView
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_New_SWIG")]
-            public static extern global::System.IntPtr New(int nuiColorFormat);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_New_SWIG", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int nuiColorFormat);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_New2_SWIG")]
-            public static extern global::System.IntPtr New(int backendMode, int nuiColorFormat);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_New2_SWIG", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int backendMode, int nuiColorFormat);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_RegisterGlCallbacks")]
-            public static extern void GlViewRegisterGlCallbacks(HandleRef nuiGlView, HandleRef nuiInitCB, HandleRef nuiRenderFrameCB, HandleRef nuiTerminateCB);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_RegisterGlCallbacks", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlViewRegisterGlCallbacks(IntPtr nuiGlView, IntPtr nuiInitCB, IntPtr nuiRenderFrameCB, IntPtr nuiTerminateCB);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_SetResizeCallback")]
-            public static extern void GlViewSetResizeCallback(HandleRef nuiGlView, HandleRef nuiResizeCB);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_SetResizeCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlViewSetResizeCallback(IntPtr nuiGlView, IntPtr nuiResizeCB);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_SetGraphicsConfig")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_SetGraphicsConfig", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GlViewSetGraphicsConfig(HandleRef nuiGlView, bool nuiDepth, bool nuiStencil, int nuiMsaa, int nuiVersion);
+            public static partial bool GlViewSetGraphicsConfig(IntPtr nuiGlView, [MarshalAs(UnmanagedType.U1)] bool nuiDepth, [MarshalAs(UnmanagedType.U1)] bool nuiStencil, int nuiMsaa, int nuiVersion);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_SetRenderingMode")]
-            public static extern void GlViewSetRenderingMode(HandleRef nuiGlView, int nuiRenderingMode);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_SetRenderingMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlViewSetRenderingMode(IntPtr nuiGlView, int nuiRenderingMode);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_GetRenderingMode")]
-            public static extern global::System.IntPtr GlViewGetRenderingMode(HandleRef nuiGlView);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_GetRenderingMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GlViewGetRenderingMode(IntPtr nuiGlView);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_RenderOnce")]
-            public static extern void GlViewRenderOnce(HandleRef nuiGlView);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_RenderOnce", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlViewRenderOnce(IntPtr nuiGlView);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_Terminate")]
-            public static extern void GlViewTerminate(HandleRef nuiGlView);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_Terminate", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlViewTerminate(IntPtr nuiGlView);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_BindTextureResources")]
-            public static extern void GlViewBindTextureResources(HandleRef nuiGlView, global::System.IntPtr textures, int size);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_BindTextureResources", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlViewBindTextureResources(IntPtr nuiGlView, global::System.IntPtr textures, int size);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderCallbackInput_Size_get")]
-            public static extern global::System.IntPtr GlViewGetRednerCallbackInputSize(global::System.IntPtr renderInput);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderCallbackInput_Size_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GlViewGetRednerCallbackInputSize(global::System.IntPtr renderInput);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderCallbackInput_Mvp_get")]
-            public static extern global::System.IntPtr GlViewGetRednerCallbackInputMvp(global::System.IntPtr renderInput);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderCallbackInput_Mvp_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GlViewGetRednerCallbackInputMvp(global::System.IntPtr renderInput);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderCallbackInput_Projection_get")]
-            public static extern global::System.IntPtr GlViewGetRednerCallbackInputProjection(global::System.IntPtr renderInput);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderCallbackInput_Projection_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GlViewGetRednerCallbackInputProjection(global::System.IntPtr renderInput);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderCallbackInput_ClippingBox_get")]
-            public static extern global::System.IntPtr GlViewGetRednerCallbackInputClipplingBox(global::System.IntPtr renderInput);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderCallbackInput_ClippingBox_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GlViewGetRednerCallbackInputClipplingBox(global::System.IntPtr renderInput);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderCallbackInput_TextureBindings_get")]
-            public static extern global::System.IntPtr GlViewGetRednerCallbackInputTextureBindings(global::System.IntPtr renderInput, ref int size);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderCallbackInput_TextureBindings_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GlViewGetRednerCallbackInputTextureBindings(global::System.IntPtr renderInput, ref int size);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderCallbackInput_WorldColor_get")]
-            public static extern global::System.IntPtr GlViewGetRednerCallbackInputWorldColor(global::System.IntPtr renderInput);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderCallbackInput_WorldColor_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GlViewGetRednerCallbackInputWorldColor(global::System.IntPtr renderInput);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GLWindow.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GLWindow.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,9 @@
  *
  */
 
-using System.Runtime.InteropServices;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -23,106 +25,109 @@ namespace Tizen.NUI
     {
         internal static partial class GLWindow
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_New__SWIG_0")]
-            public static extern global::System.IntPtr GlWindowNew();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_New__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GlWindowNew();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_New__SWIG_1")]
-            public static extern global::System.IntPtr GlWindowNew(HandleRef jarg1, string jarg2, string jarg3, bool jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_New__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GlWindowNew(IntPtr jarg1, string jarg2, string jarg3, [MarshalAs(UnmanagedType.U1)] bool jarg4);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_SetGraphicsConfig")]
-            public static extern global::System.IntPtr GlWindowSetGraphicsConfig(HandleRef jarg1, bool jarg2, bool jarg3, int jarg4, int jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_SetGraphicsConfig", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GlWindowSetGraphicsConfig(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2, [MarshalAs(UnmanagedType.U1)] bool jarg3, int jarg4, int jarg5);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Raise")]
-            public static extern void GlWindowRaise(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Raise", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlWindowRaise(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Lower")]
-            public static extern void GlWindowLower(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Lower", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlWindowLower(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Activate")]
-            public static extern void GlWindowActivate(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Activate", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlWindowActivate(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Show")]
-            public static extern void GlWindowShow(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Show", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlWindowShow(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Hide")]
-            public static extern void GlWindowHide(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Hide", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlWindowHide(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_SetPositionSize")]
-            public static extern void GlWindowSetPositionSize(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_SetPositionSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlWindowSetPositionSize(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_GetPositionSize")]
-            public static extern global::System.IntPtr GlWindowGetPositionSize(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_GetPositionSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GlWindowGetPositionSize(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_GetSupportedAuxiliaryHintCount")]
-            public static extern uint GlWindowGetSupportedAuxiliaryHintCount(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_GetSupportedAuxiliaryHintCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GlWindowGetSupportedAuxiliaryHintCount(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_GetSupportedAuxiliaryHint")]
-            public static extern string GlWindowGetSupportedAuxiliaryHint(HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_GetSupportedAuxiliaryHint", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GlWindowGetSupportedAuxiliaryHint(IntPtr jarg1, uint jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_AddAuxiliaryHint")]
-            public static extern uint GlWindowAddAuxiliaryHint(HandleRef jarg1, string jarg2, string jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_AddAuxiliaryHint", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GlWindowAddAuxiliaryHint(IntPtr jarg1, string jarg2, string jarg3);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_RemoveAuxiliaryHint")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_RemoveAuxiliaryHint", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GlWindowRemoveAuxiliaryHint(HandleRef jarg1, uint jarg2);
+            public static partial bool GlWindowRemoveAuxiliaryHint(IntPtr jarg1, uint jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_SetAuxiliaryHintValue")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_SetAuxiliaryHintValue", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GlWindowSetAuxiliaryHintValue(HandleRef jarg1, uint jarg2, string jarg3);
+            public static partial bool GlWindowSetAuxiliaryHintValue(IntPtr jarg1, uint jarg2, string jarg3);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_GetAuxiliaryHintValue")]
-            public static extern string GlWindowGetAuxiliaryHintValue(HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_GetAuxiliaryHintValue", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GlWindowGetAuxiliaryHintValue(IntPtr jarg1, uint jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_GetAuxiliaryHintId")]
-            public static extern uint GlWindowGetAuxiliaryHintId(HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_GetAuxiliaryHintId", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GlWindowGetAuxiliaryHintId(IntPtr jarg1, string jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_SetInputRegion")]
-            public static extern void GlWindowSetInputRegion(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_SetInputRegion", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlWindowSetInputRegion(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_SetOpaqueState")]
-            public static extern void GlWindowSetOpaqueState(HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_SetOpaqueState", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlWindowSetOpaqueState(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_IsOpaqueState")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_IsOpaqueState", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GlWindowIsOpaqueState(HandleRef jarg1);
+            public static partial bool GlWindowIsOpaqueState(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_GetCurrentOrientation")]
-            public static extern int GlWindowGetCurrentOrientation(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_GetCurrentOrientation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GlWindowGetCurrentOrientation(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_SetAvailableOrientations")]
-            public static extern void GlWindowSetAvailableOrientations(HandleRef jarg1, HandleRef jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_SetAvailableOrientations", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlWindowSetAvailableOrientations(IntPtr jarg1, IntPtr jarg2, int jarg3);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_SetPreferredOrientation")]
-            public static extern void GlWindowSetPreferredOrientation(HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_SetPreferredOrientation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlWindowSetPreferredOrientation(IntPtr jarg1, int jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_RegisterGlCallbacks")]
-            public static extern void GlWindowRegisterGlCallbacks(HandleRef jarg1, HandleRef jarg2, HandleRef jarg3, HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_RegisterGlCallbacks", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlWindowRegisterGlCallbacks(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_RenderOnce")]
-            public static extern void GlWindowRenderOnce(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_RenderOnce", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlWindowRenderOnce(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_GetRenderingMode")]
-            public static extern int GlWindowGetRenderingMode(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_GetRenderingMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GlWindowGetRenderingMode(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_SetRenderingMode")]
-            public static extern void GlWindowSetRenderingMode(HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_SetRenderingMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlWindowSetRenderingMode(IntPtr jarg1, int jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_TouchedSignal_Connect")]
-            public static extern void GlWindowTouchSignalConnect(HandleRef glWindow, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_TouchedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlWindowTouchSignalConnect(IntPtr glWindow, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_TouchedSignal_Disconnect")]
-            public static extern void GlWindowTouchSignalDisconnect(HandleRef glWindow, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_TouchedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlWindowTouchSignalDisconnect(IntPtr glWindow, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_FocusChangedSignal")]
-            public static extern global::System.IntPtr GlWindowFocusChangedSignal(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_FocusChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GlWindowFocusChangedSignal(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_KeyEventSignal")]
-            public static extern global::System.IntPtr GlWindowKeyEventSignal(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_KeyEventSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GlWindowKeyEventSignal(IntPtr jarg1);
 
             // For windows resized signal
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_ResizedSignal")]
-            public static extern global::System.IntPtr GlWindowResizedSignal(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_ResizedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GlWindowResizedSignal(IntPtr jarg1);
 
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GLWindowFocusChangeSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GLWindowFocusChangeSignal.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,8 +15,9 @@
  *
  */
 
-using System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices;
 
+using global::System.Runtime.InteropServices.Marshalling;
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -26,3 +27,5 @@ namespace Tizen.NUI
         }
     }
 }
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GLWindowResizedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GLWindowResizedSignal.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,9 @@
  *
  */
 
-using System.Runtime.InteropServices;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -23,27 +25,30 @@ namespace Tizen.NUI
     {
         internal static partial class GLWindowResizedSignal
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_ResizedSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_ResizedSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GlWindowResizedSignalEmpty(HandleRef jarg1);
+            public static partial bool GlWindowResizedSignalEmpty(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_ResizedSignal_GetConnectionCount")]
-            public static extern uint GlWindowResizedSignalGetConnectionCount(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_ResizedSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GlWindowResizedSignalGetConnectionCount(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_ResizedSignal_Connect")]
-            public static extern void GlWindowResizedSignalConnect(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_ResizedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlWindowResizedSignalConnect(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_ResizedSignal_Disconnect")]
-            public static extern void GlWindowResizedSignalDisconnect(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_ResizedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlWindowResizedSignalDisconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_ResizedSignal_Emit")]
-            public static extern void GlWindowResizedSignalEmit(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_ResizedSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlWindowResizedSignalEmit(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_GlWindow_ResizedSignal")]
-            public static extern global::System.IntPtr NewGlWindowResizedSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_GlWindow_ResizedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewGlWindowResizedSignal();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_delete_ResizedSignal")]
-            public static extern void GlWindowDeleteResizedSignal(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_delete_ResizedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlWindowDeleteResizedSignal(IntPtr jarg1);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GLWindowVisibilityChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GLWindowVisibilityChangedSignal.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,9 @@
  *
  */
 
-using System.Runtime.InteropServices;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -23,27 +25,30 @@ namespace Tizen.NUI
     {
         internal static partial class GLWindowVisibilityChangedSignal
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal")]
-            public static extern global::System.IntPtr GetSignal(HandleRef glWindow);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetSignal(IntPtr glWindow);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(HandleRef signalType);
+            public static partial bool Empty(IntPtr signalType);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(HandleRef signalType);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr signalType);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal_Connect")]
-            public static extern void Connect(HandleRef signalType, HandleRef callback);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr signalType, IntPtr callback);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal_Disconnect")]
-            public static extern void Disconnect(HandleRef signalType, HandleRef callback);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr signalType, IntPtr callback);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal_Emit")]
-            public static extern void Emit(HandleRef signalType, HandleRef window, bool visibility);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr signalType, IntPtr window, [MarshalAs(UnmanagedType.U1)] bool visibility);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal_delete")]
-            public static extern void DeleteSignal(HandleRef signalType);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal_delete", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteSignal(IntPtr signalType);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GaussianBlurEffect.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GaussianBlurEffect.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2025 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,48 +14,53 @@
  * limitations under the License.
  *
  */
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
-    using global::System;
-    using global::System.Runtime.InteropServices;
-
     internal static partial class Interop
     {
         internal static class GaussianBlurEffect
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_New__SWIG_1")]
-            public static extern IntPtr New(uint blurRadius);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_New__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr New(uint blurRadius);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_SetBlurOnce")]
-            public static extern void SetBlurOnce(HandleRef effect, bool blurRadius);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_SetBlurOnce", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetBlurOnce(IntPtr effect, [MarshalAs(UnmanagedType.U1)] bool blurRadius);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_GetBlurOnce")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_GetBlurOnce", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool GetBlurOnce(HandleRef effect);
+            public static partial bool GetBlurOnce(IntPtr effect);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_SetBlurRadius")]
-            public static extern void SetBlurRadius(HandleRef effect, uint blurRadius);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_SetBlurRadius", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetBlurRadius(IntPtr effect, uint blurRadius);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_GetBlurRadius")]
-            public static extern uint GetBlurRadius(HandleRef effect);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_GetBlurRadius", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetBlurRadius(IntPtr effect);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_SetBlurDownscaleFactor")]
-            public static extern void SetBlurDownscaleFactor(HandleRef effect, float blurDownscaleFactor);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_SetBlurDownscaleFactor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetBlurDownscaleFactor(IntPtr effect, float blurDownscaleFactor);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_GetBlurDownscaleFactor")]
-            public static extern float GetBlurDownscaleFactor(HandleRef effect);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_GetBlurDownscaleFactor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetBlurDownscaleFactor(IntPtr effect);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_AddBlurStrengthAnimation")]
-            public static extern void AddBlurStrengthAnimation(HandleRef effect, HandleRef animation, HandleRef alphaFunction, HandleRef timePeriod, float fromValue, float toValue);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_AddBlurStrengthAnimation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddBlurStrengthAnimation(IntPtr effect, IntPtr animation, IntPtr alphaFunction, IntPtr timePeriod, float fromValue, float toValue);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_AddBlurOpacityAnimation")]
-            public static extern void AddBlurOpacityAnimation(HandleRef effect, HandleRef animation, HandleRef alphaFunction, HandleRef timePeriod, float fromValue, float toValue);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_AddBlurOpacityAnimation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddBlurOpacityAnimation(IntPtr effect, IntPtr animation, IntPtr alphaFunction, IntPtr timePeriod, float fromValue, float toValue);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_FinishedSignal_Connect")]
-            public static extern void FinishedSignalConnect(HandleRef effect, HandleRef callback);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_FinishedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FinishedSignalConnect(IntPtr effect, IntPtr callback);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_FinishedSignal_Disconnect")]
-            public static extern void FinishedSignalDisconnect(HandleRef effect, HandleRef callback);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_FinishedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FinishedSignalDisconnect(IntPtr effect, IntPtr callback);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GaussianBlurView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GaussianBlurView.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,41 +26,46 @@ namespace Tizen.NUI
         internal static partial class GaussianBlurView
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_GaussianBlurView__SWIG_1")]
-            public static extern global::System.IntPtr NewGaussianBlurView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_GaussianBlurView__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewGaussianBlurView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_GaussianBlurView")]
-            public static extern void DeleteGaussianBlurView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_GaussianBlurView", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteGaussianBlurView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_New__SWIG_0")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_New__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_New__SWIG_1")]
-            public static extern global::System.IntPtr New(uint jarg1, float jarg2, int jarg3, float jarg4, float jarg5, bool jarg6);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_New__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(uint jarg1, float jarg2, int jarg3, float jarg4, float jarg5, [MarshalAs(UnmanagedType.U1)] bool jarg6);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_Activate")]
-            public static extern void Activate(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_Activate", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Activate(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_ActivateOnce")]
-            public static extern void ActivateOnce(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_ActivateOnce", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ActivateOnce(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_Deactivate")]
-            public static extern void Deactivate(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_Deactivate", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Deactivate(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_SetUserImageAndOutputRenderTarget")]
-            public static extern void SetUserImageAndOutputRenderTarget(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_SetUserImageAndOutputRenderTarget", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetUserImageAndOutputRenderTarget(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_GetBlurStrengthPropertyIndex")]
-            public static extern int GetBlurStrengthPropertyIndex(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_GetBlurStrengthPropertyIndex", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetBlurStrengthPropertyIndex(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_SetBackgroundColor")]
-            public static extern void SetBackgroundColor(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_SetBackgroundColor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetBackgroundColor(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_GetBackgroundColor")]
-            public static extern global::System.IntPtr GetBackgroundColor(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_GetBackgroundColor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetBackgroundColor(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_FinishedSignal")]
-            public static extern global::System.IntPtr FinishedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurView_FinishedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr FinishedSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GaussianBlurViewSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GaussianBlurViewSignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class GaussianBlurViewSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurViewSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurViewSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurViewSignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurViewSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurViewSignal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurViewSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurViewSignal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurViewSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurViewSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurViewSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_GaussianBlurViewSignal")]
-            public static extern global::System.IntPtr NewGaussianBlurViewSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_GaussianBlurViewSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewGaussianBlurViewSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_GaussianBlurViewSignal")]
-            public static extern void DeleteGaussianBlurViewSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_GaussianBlurViewSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteGaussianBlurViewSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Geometry.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Geometry.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,29 +26,34 @@ namespace Tizen.NUI
         internal static partial class Geometry
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Geometry_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Geometry_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Geometry")]
-            public static extern void DeleteGeometry(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Geometry", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteGeometry(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Geometry_AddVertexBuffer")]
-            public static extern uint AddVertexBuffer(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Geometry_AddVertexBuffer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint AddVertexBuffer(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Geometry_GetNumberOfVertexBuffers")]
-            public static extern uint GetNumberOfVertexBuffers(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Geometry_GetNumberOfVertexBuffers", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetNumberOfVertexBuffers(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Geometry_RemoveVertexBuffer")]
-            public static extern void RemoveVertexBuffer(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Geometry_RemoveVertexBuffer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemoveVertexBuffer(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Geometry_SetIndexBuffer")]
-            public static extern void SetIndexBuffer(global::System.Runtime.InteropServices.HandleRef jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] ushort[] jarg2, uint jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Geometry_SetIndexBuffer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetIndexBuffer(IntPtr jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] ushort[] jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Geometry_SetType")]
-            public static extern void SetType(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Geometry_SetType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetType(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Geometry_GetType")]
-            public static extern int GetType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Geometry_GetType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetType(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Gesture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Gesture.cs
@@ -15,32 +15,41 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Gesture
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Gesture")]
-            public static extern global::System.IntPtr NewGesture(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Gesture", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewGesture(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Gesture")]
-            public static extern void DeleteGesture(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Gesture", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteGesture(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_type_get")]
-            public static extern int TypeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_type_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TypeGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_state_get")]
-            public static extern int StateGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_state_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int StateGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_time_get")]
-            public static extern uint TimeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_time_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint TimeGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_sourceType_get")]
-            public static extern int SourceTypeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_sourceType_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SourceTypeGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_sourceData_get")]
-            public static extern int SourceDataGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_sourceData_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SourceDataGet(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GestureDetector.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GestureDetector.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,40 +26,45 @@ namespace Tizen.NUI
         internal static partial class GestureDetector
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_GestureDetector__SWIG_0")]
-            public static extern global::System.IntPtr NewGestureDetector();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_GestureDetector__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewGestureDetector();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_GestureDetector")]
-            public static extern void DeleteGestureDetector(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_GestureDetector", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteGestureDetector(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_GestureDetector__SWIG_1")]
-            public static extern global::System.IntPtr NewGestureDetector(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_GestureDetector__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewGestureDetector(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureDetector_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureDetector_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureDetector_Attach")]
-            public static extern void Attach(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureDetector_Attach", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Attach(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureDetector_Detach")]
-            public static extern void Detach(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureDetector_Detach", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Detach(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureDetector_DetachAll")]
-            public static extern void DetachAll(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureDetector_DetachAll", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DetachAll(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureDetector_GetAttachedActorCount")]
-            public static extern uint GetAttachedActorCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureDetector_GetAttachedActorCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetAttachedActorCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureDetector_GetAttachedActor")]
-            public static extern global::System.IntPtr GetAttachedActor(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureDetector_GetAttachedActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetAttachedActor(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureDetector_HandleEvent")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureDetector_HandleEvent", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool HandleEvent(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            public static partial bool HandleEvent(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureDetector_CancelAllOtherGestureDetectors")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureDetector_CancelAllOtherGestureDetectors", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool CancelAllOtherGestureDetectors(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool CancelAllOtherGestureDetectors(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GestureOptions.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GestureOptions.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,89 +15,98 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class GestureOptions
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGesturePredictionMode")]
-            public static extern void SetPanGesturePredictionMode(int mode);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGesturePredictionMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPanGesturePredictionMode(int mode);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGesturePredictionAmount")]
-            public static extern void SetPanGesturePredictionAmount(uint amount);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGesturePredictionAmount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPanGesturePredictionAmount(uint amount);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureMaximumPredictionAmount")]
-            public static extern void SetPanGestureMaximumPredictionAmount(uint amount);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureMaximumPredictionAmount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPanGestureMaximumPredictionAmount(uint amount);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureMinimumPredictionAmount")]
-            public static extern void SetPanGestureMinimumPredictionAmount(uint amount);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureMinimumPredictionAmount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPanGestureMinimumPredictionAmount(uint amount);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGesturePredictionAmountAdjustment")]
-            public static extern void SetPanGesturePredictionAmountAdjustment(uint amount);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGesturePredictionAmountAdjustment", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPanGesturePredictionAmountAdjustment(uint amount);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureSmoothingMode")]
-            public static extern void SetPanGestureSmoothingMode(int mode);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureSmoothingMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPanGestureSmoothingMode(int mode);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureSmoothingAmount")]
-            public static extern void SetPanGestureSmoothingAmount(float jaamountrg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureSmoothingAmount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPanGestureSmoothingAmount(float jaamountrg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureUseActualTimes")]
-            public static extern void SetPanGestureUseActualTimes(bool enable);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureUseActualTimes", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPanGestureUseActualTimes([MarshalAs(UnmanagedType.U1)] bool enable);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureInterpolationTimeRange")]
-            public static extern void SetPanGestureInterpolationTimeRange(int range);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureInterpolationTimeRange", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPanGestureInterpolationTimeRange(int range);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureScalarOnlyPredictionEnabled")]
-            public static extern void SetPanGestureScalarOnlyPredictionEnabled(bool enable);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureScalarOnlyPredictionEnabled", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPanGestureScalarOnlyPredictionEnabled([MarshalAs(UnmanagedType.U1)] bool enable);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureTwoPointPredictionEnabled")]
-            public static extern void SetPanGestureTwoPointPredictionEnabled(bool enable);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureTwoPointPredictionEnabled", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPanGestureTwoPointPredictionEnabled([MarshalAs(UnmanagedType.U1)] bool enable);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureTwoPointInterpolatePastTime")]
-            public static extern void SetPanGestureTwoPointInterpolatePastTime(int time);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureTwoPointInterpolatePastTime", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPanGestureTwoPointInterpolatePastTime(int time);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureTwoPointVelocityBias")]
-            public static extern void SetPanGestureTwoPointVelocityBias(float velocity);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureTwoPointVelocityBias", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPanGestureTwoPointVelocityBias(float velocity);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureTwoPointAccelerationBias")]
-            public static extern void SetPanGestureTwoPointAccelerationBias(float acceleration);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureTwoPointAccelerationBias", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPanGestureTwoPointAccelerationBias(float acceleration);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureMultitapSmoothingRange")]
-            public static extern void SetPanGestureMultitapSmoothingRange(int range);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureMultitapSmoothingRange", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPanGestureMultitapSmoothingRange(int range);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureMinimumDistance")]
-            public static extern void SetPanGestureMinimumDistance(int distance);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureMinimumDistance", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPanGestureMinimumDistance(int distance);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureMinimumPanEvents")]
-            public static extern void SetPanGestureMinimumPanEvents(int number);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPanGestureMinimumPanEvents", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPanGestureMinimumPanEvents(int number);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPinchGestureMinimumDistance")]
-            public static extern void SetPinchGestureMinimumDistance(float distance);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPinchGestureMinimumDistance", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPinchGestureMinimumDistance(float distance);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPinchGestureMinimumTouchEvents")]
-            public static extern void SetPinchGestureMinimumTouchEvents(uint number);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPinchGestureMinimumTouchEvents", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPinchGestureMinimumTouchEvents(uint number);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPinchGestureMinimumTouchEventsAfterStart")]
-            public static extern void SetPinchGestureMinimumTouchEventsAfterStart(uint number);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetPinchGestureMinimumTouchEventsAfterStart", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPinchGestureMinimumTouchEventsAfterStart(uint number);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetRotationGestureMinimumTouchEvents")]
-            public static extern void SetRotationGestureMinimumTouchEvents(uint number);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetRotationGestureMinimumTouchEvents", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetRotationGestureMinimumTouchEvents(uint number);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetRotationGestureMinimumTouchEventsAfterStart")]
-            public static extern void SetRotationGestureMinimumTouchEventsAfterStart(uint number);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetRotationGestureMinimumTouchEventsAfterStart", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetRotationGestureMinimumTouchEventsAfterStart(uint number);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetLongPressMinimumHoldingTime")]
-            public static extern void SetLongPressMinimumHoldingTime(uint time);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetLongPressMinimumHoldingTime", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetLongPressMinimumHoldingTime(uint time);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetTapMaximumAllowedTime")]
-            public static extern void SetDoubleTapTimeout(uint ms);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetTapMaximumAllowedTime", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetDoubleTapTimeout(uint ms);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetTapRecognizerTime")]
-            public static extern void SetTapRecognizerTime(uint ms);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetTapRecognizerTime", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTapRecognizerTime(uint ms);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetTapMaximumMotionAllowedDistance")]
-            public static extern void SetTapMaximumMotionAllowedDistance(float distance);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetTapMaximumMotionAllowedDistance", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTapMaximumMotionAllowedDistance(float distance);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GlyphInfo.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GlyphInfo.cs
@@ -15,68 +15,77 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class GlytphInfo
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_GlyphInfo__SWIG_0")]
-            public static extern global::System.IntPtr NewGlyphInfo();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_GlyphInfo__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewGlyphInfo();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_GlyphInfo__SWIG_1")]
-            public static extern global::System.IntPtr NewGlyphInfo(uint jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_GlyphInfo__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewGlyphInfo(uint jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_fontId_set")]
-            public static extern void GlyphInfoFontIdSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_fontId_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlyphInfoFontIdSet(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_fontId_get")]
-            public static extern uint GlyphInfoFontIdGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_fontId_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GlyphInfoFontIdGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_index_set")]
-            public static extern void GlyphInfoIndexSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_index_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlyphInfoIndexSet(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_index_get")]
-            public static extern uint GlyphInfoIndexGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_index_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GlyphInfoIndexGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_width_set")]
-            public static extern void GlyphInfoWidthSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_width_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlyphInfoWidthSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_width_get")]
-            public static extern float GlyphInfoWidthGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_width_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GlyphInfoWidthGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_height_set")]
-            public static extern void GlyphInfoHeightSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_height_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlyphInfoHeightSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_height_get")]
-            public static extern float GlyphInfoHeightGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_height_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GlyphInfoHeightGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_xBearing_set")]
-            public static extern void GlyphInfoXBearingSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_xBearing_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlyphInfoXBearingSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_xBearing_get")]
-            public static extern float GlyphInfoXBearingGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_xBearing_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GlyphInfoXBearingGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_yBearing_set")]
-            public static extern void GlyphInfoYBearingSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_yBearing_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlyphInfoYBearingSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_yBearing_get")]
-            public static extern float GlyphInfoYBearingGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_yBearing_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GlyphInfoYBearingGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_advance_set")]
-            public static extern void GlyphInfoAdvanceSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_advance_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlyphInfoAdvanceSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_advance_get")]
-            public static extern float GlyphInfoAdvanceGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_advance_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GlyphInfoAdvanceGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_scaleFactor_set")]
-            public static extern void GlyphInfoScaleFactorSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_scaleFactor_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlyphInfoScaleFactorSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_scaleFactor_get")]
-            public static extern float GlyphInfoScaleFactorGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlyphInfo_scaleFactor_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GlyphInfoScaleFactorGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_GlyphInfo")]
-            public static extern void DeleteGlyphInfo(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_GlyphInfo", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteGlyphInfo(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Gradient.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Gradient.cs
@@ -15,29 +15,38 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Gradient
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gradient_SetColorStops")]
-            public static extern void SetColorStops(global::System.Runtime.InteropServices.HandleRef gradient, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] float[] stops, uint stopsLength);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gradient_SetColorStops", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetColorStops(IntPtr gradient, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] float[] stops, uint stopsLength);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gradient_GetColorStopsCount")]
-            public static extern uint GetColorStopsCount(global::System.Runtime.InteropServices.HandleRef gradient);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gradient_GetColorStopsCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetColorStopsCount(IntPtr gradient);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gradient_GetColorStopsOffsetIndexOf")]
-            public static extern float GetColorStopsOffsetIndexOf(global::System.Runtime.InteropServices.HandleRef gradient, uint index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gradient_GetColorStopsOffsetIndexOf", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetColorStopsOffsetIndexOf(IntPtr gradient, uint index);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gradient_GetColorStopsColorIndexOf")]
-            public static extern global::System.IntPtr GetColorStopsColorIndexOf(global::System.Runtime.InteropServices.HandleRef gradient, uint index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gradient_GetColorStopsColorIndexOf", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetColorStopsColorIndexOf(IntPtr gradient, uint index);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gradient_SetSpread")]
-            public static extern void SetSpread(global::System.Runtime.InteropServices.HandleRef gradient, int index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gradient_SetSpread", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetSpread(IntPtr gradient, int index);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gradient_GetSpread")]
-            public static extern int GetSpread(global::System.Runtime.InteropServices.HandleRef gradient);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gradient_GetSpread", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetSpread(IntPtr gradient);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GradientVisual.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GradientVisual.cs
@@ -15,39 +15,48 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class NDalicGradientVisual
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_START_POSITION_get")]
-            public static extern int GradientVisualStartPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_START_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GradientVisualStartPositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_END_POSITION_get")]
-            public static extern int GradientVisualEndPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_END_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GradientVisualEndPositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_CENTER_get")]
-            public static extern int GradientVisualCenterGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_CENTER_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GradientVisualCenterGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_RADIUS_get")]
-            public static extern int GradientVisualRadiusGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_RADIUS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GradientVisualRadiusGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_STOP_OFFSET_get")]
-            public static extern int GradientVisualStopOffsetGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_STOP_OFFSET_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GradientVisualStopOffsetGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_STOP_COLOR_get")]
-            public static extern int GradientVisualStopColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_STOP_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GradientVisualStopColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_UNITS_get")]
-            public static extern int GradientVisualUnitsGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_UNITS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GradientVisualUnitsGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_SPREAD_METHOD_get")]
-            public static extern int GradientVisualSpreadMethodGet();
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_START_OFFSET_get")]
-            public static extern int GradientVisualStartOffsetGet();
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_START_ANGLE_get")]
-            public static extern int GradientVisualStartAngleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_SPREAD_METHOD_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GradientVisualSpreadMethodGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_START_OFFSET_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GradientVisualStartOffsetGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_START_ANGLE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GradientVisualStartAngleGet();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GraphicsCapabilities.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GraphicsCapabilities.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,15 +15,24 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class GraphicsCapabilities
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IsBlendEquationSupported")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IsBlendEquationSupported", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsBlendEquationSupported(int blendEquation);
+            public static partial bool IsBlendEquationSupported(int blendEquation);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Handle.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Handle.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,62 +26,67 @@ namespace Tizen.NUI
         internal static partial class Handle
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Handle")]
-            public static extern void DeleteHandle(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Handle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteHandle(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_GetPropertyName")]
-            public static extern string GetPropertyName(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_GetPropertyName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetPropertyName(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_GetPropertyIndex")]
-            public static extern int GetPropertyIndex(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_GetPropertyIndex", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetPropertyIndex(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_IsPropertyWritable")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_IsPropertyWritable", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsPropertyWritable(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            public static partial bool IsPropertyWritable(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_IsPropertyAnimatable")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_IsPropertyAnimatable", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsPropertyAnimatable(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            public static partial bool IsPropertyAnimatable(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_IsPropertyAConstraintInput")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_IsPropertyAConstraintInput", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsPropertyAConstraintInput(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            public static partial bool IsPropertyAConstraintInput(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_GetPropertyType")]
-            public static extern int GetPropertyType(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_GetPropertyType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetPropertyType(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_SetProperty")]
-            public static extern void SetProperty(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_SetProperty", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetProperty(IntPtr jarg1, int jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_SetProperties")]
-            public static extern void SetProperties(global::System.Runtime.InteropServices.HandleRef handle, global::System.Runtime.InteropServices.HandleRef propertyMap);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_SetProperties", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetProperties(IntPtr handle, IntPtr propertyMap);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_RegisterProperty__SWIG_0")]
-            public static extern int RegisterProperty(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_RegisterProperty__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RegisterProperty(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_RegisterProperty__SWIG_1")]
-            public static extern int RegisterProperty(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, int jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_RegisterProperty__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RegisterProperty(IntPtr jarg1, string jarg2, IntPtr jarg3, int jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_GetProperty")]
-            public static extern global::System.IntPtr GetProperty(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_GetProperty", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetProperty(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_GetCurrentProperty")]
-            public static extern global::System.IntPtr GetCurrentProperty(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_GetCurrentProperty", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetCurrentProperty(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_AddPropertyNotification__SWIG_0")]
-            public static extern global::System.IntPtr AddPropertyNotification(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_AddPropertyNotification__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr AddPropertyNotification(IntPtr jarg1, int jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_AddPropertyNotification__SWIG_1")]
-            public static extern global::System.IntPtr AddPropertyNotification(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_AddPropertyNotification__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr AddPropertyNotification(IntPtr jarg1, int jarg2, int jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_RemovePropertyNotification")]
-            public static extern void RemovePropertyNotification(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_RemovePropertyNotification", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemovePropertyNotification(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_RemovePropertyNotifications")]
-            public static extern void RemovePropertyNotifications(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_RemovePropertyNotifications", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemovePropertyNotifications(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.HandleInternal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.HandleInternal.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,14 +26,19 @@ namespace Tizen.NUI
         internal static partial class HandleInternal
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_GetPropertyCount")]
-            public static extern uint HandleGetPropertyCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_GetPropertyCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint HandleGetPropertyCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_RemoveConstraints__SWIG_0")]
-            public static extern void HandleRemoveConstraints(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_RemoveConstraints__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void HandleRemoveConstraints(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_RemoveConstraints__SWIG_1")]
-            public static extern void HandleRemoveConstraints(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_RemoveConstraints__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void HandleRemoveConstraints(IntPtr jarg1, uint jarg2);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Hover.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Hover.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,41 +26,46 @@ namespace Tizen.NUI
         internal static partial class Hover
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_New")]
-            public static extern global::System.IntPtr New(uint jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(uint jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetTime")]
-            public static extern uint GetTime(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetTime", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetTime(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetPointCount")]
-            public static extern uint GetPointCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetPointCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetPointCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetDeviceId")]
-            public static extern int GetDeviceId(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetDeviceId", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetDeviceId(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetState")]
-            public static extern int GetState(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetState", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetState(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetHitActor")]
-            public static extern global::System.IntPtr GetHitActor(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetHitActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetHitActor(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetLocalPosition")]
-            public static extern global::System.IntPtr GetLocalPosition(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetLocalPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetLocalPosition(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetScreenPosition")]
-            public static extern global::System.IntPtr GetScreenPosition(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetScreenPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetScreenPosition(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetDeviceClass")]
-            public static extern int GetDeviceClass(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetDeviceClass", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetDeviceClass(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetDeviceSubclass")]
-            public static extern int GetDeviceSubClass(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetDeviceSubclass", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetDeviceSubClass(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetDeviceName")]
-            public static extern string GetDeviceName(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetDeviceName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetDeviceName(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Hover")]
-            public static extern void DeleteHover(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Hover", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteHover(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ImageLoading.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ImageLoading.cs
@@ -14,74 +14,84 @@
  * limitations under the License.
  *
  */
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class ImageLoading
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromFile__SWIG_0")]
-            public static extern global::System.IntPtr LoadImageFromFile(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3, int jarg4, bool jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromFile__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr LoadImageFromFile(string jarg1, IntPtr jarg2, int jarg3, int jarg4, [MarshalAs(UnmanagedType.U1)] bool jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromFile__SWIG_1")]
-            public static extern global::System.IntPtr LoadImageFromFile(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3, int jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromFile__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr LoadImageFromFile(string jarg1, IntPtr jarg2, int jarg3, int jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromFile__SWIG_2")]
-            public static extern global::System.IntPtr LoadImageFromFile(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromFile__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr LoadImageFromFile(string jarg1, IntPtr jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromFile__SWIG_3")]
-            public static extern global::System.IntPtr LoadImageFromFile(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromFile__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr LoadImageFromFile(string jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromFile__SWIG_4")]
-            public static extern global::System.IntPtr LoadImageFromFile(string jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromFile__SWIG_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr LoadImageFromFile(string jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromBuffer__SWIG_0")]
-            public static extern global::System.IntPtr LoadImageFromBuffer(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3, int jarg4, bool jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromBuffer__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr LoadImageFromBuffer(IntPtr jarg1, IntPtr jarg2, int jarg3, int jarg4, [MarshalAs(UnmanagedType.U1)] bool jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromBuffer__SWIG_1")]
-            public static extern global::System.IntPtr LoadImageFromBuffer(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3, int jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromBuffer__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr LoadImageFromBuffer(IntPtr jarg1, IntPtr jarg2, int jarg3, int jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromBuffer__SWIG_2")]
-            public static extern global::System.IntPtr LoadImageFromBuffer(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromBuffer__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr LoadImageFromBuffer(IntPtr jarg1, IntPtr jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromBuffer__SWIG_3")]
-            public static extern global::System.IntPtr LoadImageFromBuffer(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromBuffer__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr LoadImageFromBuffer(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromBuffer__SWIG_4")]
-            public static extern global::System.IntPtr LoadImageFromBuffer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LoadImageFromBuffer__SWIG_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr LoadImageFromBuffer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetClosestImageSize__SWIG_0")]
-            public static extern global::System.IntPtr GetClosestImageSize(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3, int jarg4, bool jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetClosestImageSize__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetClosestImageSize(string jarg1, IntPtr jarg2, int jarg3, int jarg4, [MarshalAs(UnmanagedType.U1)] bool jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetClosestImageSize__SWIG_1")]
-            public static extern global::System.IntPtr GetClosestImageSize(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3, int jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetClosestImageSize__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetClosestImageSize(string jarg1, IntPtr jarg2, int jarg3, int jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetClosestImageSize__SWIG_2")]
-            public static extern global::System.IntPtr GetClosestImageSize(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetClosestImageSize__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetClosestImageSize(string jarg1, IntPtr jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetClosestImageSize__SWIG_3")]
-            public static extern global::System.IntPtr GetClosestImageSize(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetClosestImageSize__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetClosestImageSize(string jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetClosestImageSize__SWIG_4")]
-            public static extern global::System.IntPtr GetClosestImageSize(string jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetClosestImageSize__SWIG_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetClosestImageSize(string jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetOriginalImageSize")]
-            public static extern global::System.IntPtr GetOriginalImageSize(string jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetOriginalImageSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetOriginalImageSize(string jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DownloadImageSynchronously__SWIG_0")]
-            public static extern global::System.IntPtr DownloadImageSynchronously(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3, int jarg4, bool jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DownloadImageSynchronously__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DownloadImageSynchronously(string jarg1, IntPtr jarg2, int jarg3, int jarg4, [MarshalAs(UnmanagedType.U1)] bool jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DownloadImageSynchronously__SWIG_1")]
-            public static extern global::System.IntPtr DownloadImageSynchronously(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3, int jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DownloadImageSynchronously__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DownloadImageSynchronously(string jarg1, IntPtr jarg2, int jarg3, int jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DownloadImageSynchronously__SWIG_2")]
-            public static extern global::System.IntPtr DownloadImageSynchronously(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DownloadImageSynchronously__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DownloadImageSynchronously(string jarg1, IntPtr jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DownloadImageSynchronously__SWIG_3")]
-            public static extern global::System.IntPtr DownloadImageSynchronously(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DownloadImageSynchronously__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DownloadImageSynchronously(string jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DownloadImageSynchronously__SWIG_4")]
-            public static extern global::System.IntPtr DownloadImageSynchronously(string jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DownloadImageSynchronously__SWIG_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DownloadImageSynchronously(string jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ImageUrl.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ImageUrl.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,27 +15,31 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
-    using global::System;
-    using global::System.Runtime.InteropServices;
-
     internal static partial class Interop
     {
         internal static partial class ImageUrl
         {
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ImageUrl_Copy")]
-            public static extern global::System.IntPtr NewImageUrl(global::System.Runtime.InteropServices.HandleRef csImageUrl);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ImageUrl_Copy", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewImageUrl(IntPtr csImageUrl);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageUrl_New")]
-            public static extern global::System.IntPtr New(HandleRef texture, bool preMultiplied);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageUrl_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(IntPtr texture, [MarshalAs(UnmanagedType.U1)] bool preMultiplied);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ImageUrl")]
-            public static extern void Delete(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ImageUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Delete(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageUrl_Get")]
-            public static extern string GetUrl(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageUrl_Get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetUrl(IntPtr jarg1);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ImageView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ImageView.cs
@@ -14,92 +14,102 @@
  * limitations under the License.
  *
  */
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class ImageView
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_IMAGE_get")]
-            public static extern int ImageGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_IMAGE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_PRE_MULTIPLIED_ALPHA_get")]
-            public static extern int PreMultipliedAlphaGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_PRE_MULTIPLIED_ALPHA_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PreMultipliedAlphaGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_PIXEL_AREA_get")]
-            public static extern int PixelAreaGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_PIXEL_AREA_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PixelAreaGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_PLACEHOLDER_IMAGE_get")]
-            public static extern int PlaceHolderImageGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_PLACEHOLDER_IMAGE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PlaceHolderImageGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_TRANSITION_EFFECT_get")]
-            public static extern int TransitionEffectGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_TRANSITION_EFFECT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TransitionEffectGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_TRANSITION_EFFECT_OPTION_get")]
-            public static extern int TransitionEffectOptionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_TRANSITION_EFFECT_OPTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TransitionEffectOptionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_0")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_2")]
-            public static extern global::System.IntPtr New(string jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(string jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_3")]
-            public static extern global::System.IntPtr New(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(string jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ImageView")]
-            public static extern void DeleteImageView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ImageView", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteImageView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_SetImage__SWIG_1")]
-            public static extern void SetImage(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_SetImage__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetImage(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_SetImage__SWIG_2")]
-            public static extern void SetImage(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_SetImage__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetImage(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ImageVisual_Actions_RELOAD_get")]
-            public static extern int ImageVisualActionReloadGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ImageVisual_Actions_RELOAD_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualActionReloadGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_0")]
-            public static extern global::System.IntPtr ImageView_New__SWIG_0();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ImageView_New__SWIG_0();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_2")]
-            public static extern global::System.IntPtr ImageView_New__SWIG_2(string jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ImageView_New__SWIG_2(string jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_3")]
-            public static extern global::System.IntPtr ImageView_New__SWIG_3(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ImageView_New__SWIG_3(string jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_SWIGUpcast")]
-            public static extern global::System.IntPtr ImageView_SWIGUpcast(global::System.IntPtr jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_SWIGUpcast", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ImageView_SWIGUpcast(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_SetImage__SWIG_1")]
-            public static extern void ImageView_SetImage__SWIG_1(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_SetImage__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ImageView_SetImage__SWIG_1(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_SetImage__SWIG_2")]
-            public static extern void ImageView_SetImage__SWIG_2(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_SetImage__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ImageView_SetImage__SWIG_2(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ImageView")]
-            public static extern void delete_ImageView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ImageView", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void delete_ImageView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_IMAGE_get")]
-            public static extern int ImageView_Property_IMAGE_get();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_IMAGE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageView_Property_IMAGE_get();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_PRE_MULTIPLIED_ALPHA_get")]
-            public static extern int ImageView_Property_PRE_MULTIPLIED_ALPHA_get();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_PRE_MULTIPLIED_ALPHA_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageView_Property_PRE_MULTIPLIED_ALPHA_get();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_PIXEL_AREA_get")]
-            public static extern int ImageView_Property_PIXEL_AREA_get();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_PIXEL_AREA_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageView_Property_PIXEL_AREA_get();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ImageVisual_Actions_RELOAD_get")]
-            public static extern int ImageView_IMAGE_VISUAL_ACTION_RELOAD_get();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ImageVisual_Actions_RELOAD_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageView_IMAGE_VISUAL_ACTION_RELOAD_get();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ImageVisual_Actions_PLAY_get")]
-            public static extern int ImageView_IMAGE_VISUAL_ACTION_PLAY_get();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ImageVisual_Actions_PLAY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageView_IMAGE_VISUAL_ACTION_PLAY_get();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ImageVisual_Actions_PAUSE_get")]
-            public static extern int ImageView_IMAGE_VISUAL_ACTION_PAUSE_get();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ImageVisual_Actions_PAUSE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageView_IMAGE_VISUAL_ACTION_PAUSE_get();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ImageVisual_Actions_STOP_get")]
-            public static extern int ImageView_IMAGE_VISUAL_ACTION_STOP_get();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ImageVisual_Actions_STOP_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageView_IMAGE_VISUAL_ACTION_STOP_get();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ImageVisual.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ImageVisual.cs
@@ -15,77 +15,86 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class NDalicImageVisual
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_URL_get")]
-            public static extern int ImageVisualUrlGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_URL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualUrlGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_ALPHA_MASK_URL_get")]
-            public static extern int ImageVisualAlphaMaskUrlGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_ALPHA_MASK_URL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualAlphaMaskUrlGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_FITTING_MODE_get")]
-            public static extern int ImageVisualFittingModeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_FITTING_MODE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualFittingModeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_SAMPLING_MODE_get")]
-            public static extern int ImageVisualSamplingModeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_SAMPLING_MODE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualSamplingModeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_DESIRED_WIDTH_get")]
-            public static extern int ImageVisualDesiredWidthGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_DESIRED_WIDTH_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualDesiredWidthGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_DESIRED_HEIGHT_get")]
-            public static extern int ImageVisualDesiredHeightGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_DESIRED_HEIGHT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualDesiredHeightGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_SYNCHRONOUS_LOADING_get")]
-            public static extern int ImageVisualSynchronousLoadingGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_SYNCHRONOUS_LOADING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualSynchronousLoadingGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_BORDER_ONLY_get")]
-            public static extern int ImageVisualBorderOnlyGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_BORDER_ONLY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualBorderOnlyGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_PIXEL_AREA_get")]
-            public static extern int ImageVisualPixelAreaGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_PIXEL_AREA_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualPixelAreaGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_WRAP_MODE_U_get")]
-            public static extern int ImageVisualWrapModeUGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_WRAP_MODE_U_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualWrapModeUGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_WRAP_MODE_V_get")]
-            public static extern int ImageVisualWrapModeVGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_WRAP_MODE_V_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualWrapModeVGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_BATCH_SIZE_get")]
-            public static extern int ImageVisualBatchSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_BATCH_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualBatchSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_CACHE_SIZE_get")]
-            public static extern int ImageVisualCacheSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_CACHE_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualCacheSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_FRAME_DELAY_get")]
-            public static extern int ImageVisualFrameDelayGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_FRAME_DELAY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualFrameDelayGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_LOOP_COUNT_get")]
-            public static extern int ImageVisualLoopCountGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_LOOP_COUNT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualLoopCountGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_MASK_CONTENT_SCALE_get")]
-            public static extern int ImageVisualMaskContentScaleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_MASK_CONTENT_SCALE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualMaskContentScaleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_CROP_TO_MASK_get")]
-            public static extern int ImageVisualCropToMaskGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_CROP_TO_MASK_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualCropToMaskGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_RELEASE_POLICY_get")]
-            public static extern int ImageVisualReleasePolicyGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_RELEASE_POLICY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualReleasePolicyGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_LOAD_POLICY_get")]
-            public static extern int ImageVisualLoadPolicyGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_LOAD_POLICY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualLoadPolicyGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_ORIENTATION_CORRECTION_get")]
-            public static extern int ImageVisualOrientationCorrectionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_ORIENTATION_CORRECTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualOrientationCorrectionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_AUXILIARY_IMAGE_URL_get")]
-            public static extern int ImageVisualAuxiliaryImageUrlGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_AUXILIARY_IMAGE_URL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualAuxiliaryImageUrlGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_AUXILIARY_IMAGE_ALPHA_get")]
-            public static extern int ImageVisualAuxiliaryImageAlphaGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IMAGE_VISUAL_AUXILIARY_IMAGE_ALPHA_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualAuxiliaryImageAlphaGet();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.InputMethodContext.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.InputMethodContext.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,209 +26,214 @@ namespace Tizen.NUI
         internal static partial class InputMethodContext
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_InputMethodContext_EventData__SWIG_0")]
-            public static extern global::System.IntPtr NewInputMethodContextEventData();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_InputMethodContext_EventData__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewInputMethodContextEventData();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_InputMethodContext_EventData__SWIG_1")]
-            public static extern global::System.IntPtr NewInputMethodContextEventData(int jarg1, string jarg2, int jarg3, int jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_InputMethodContext_EventData__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewInputMethodContextEventData(int jarg1, string jarg2, int jarg3, int jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_EventData_predictiveString_set")]
-            public static extern void EventDataPredictiveStringSet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_EventData_predictiveString_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EventDataPredictiveStringSet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_EventData_predictiveString_get")]
-            public static extern string EventDataPredictiveStringGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_EventData_predictiveString_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string EventDataPredictiveStringGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_EventData_eventName_set")]
-            public static extern void EventDataEventNameSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_EventData_eventName_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EventDataEventNameSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_EventData_eventName_get")]
-            public static extern int EventDataEventNameGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_EventData_eventName_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EventDataEventNameGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_EventData_cursorOffset_set")]
-            public static extern void EventDataCursorOffsetSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_EventData_cursorOffset_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EventDataCursorOffsetSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_EventData_cursorOffset_get")]
-            public static extern int EventDataCursorOffsetGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_EventData_cursorOffset_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EventDataCursorOffsetGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_EventData_numberOfChars_set")]
-            public static extern void EventDataNumberOfCharsSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_EventData_numberOfChars_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EventDataNumberOfCharsSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_EventData_numberOfChars_get")]
-            public static extern int EventDataNumberOfCharsGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_EventData_numberOfChars_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EventDataNumberOfCharsGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_InputMethodContext_EventData")]
-            public static extern void DeleteInputMethodContextEventData(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_InputMethodContext_EventData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteInputMethodContextEventData(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_InputMethodContext_CallbackData__SWIG_0")]
-            public static extern global::System.IntPtr NewInputMethodContextCallbackData();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_InputMethodContext_CallbackData__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewInputMethodContextCallbackData();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_InputMethodContext_CallbackData__SWIG_1")]
-            public static extern global::System.IntPtr NewInputMethodContextCallbackData(bool jarg1, int jarg2, string jarg3, bool jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_InputMethodContext_CallbackData__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewInputMethodContextCallbackData([MarshalAs(UnmanagedType.U1)] bool jarg1, int jarg2, string jarg3, [MarshalAs(UnmanagedType.U1)] bool jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_CallbackData_currentText_set")]
-            public static extern void CallbackDataCurrentTextSet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_CallbackData_currentText_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void CallbackDataCurrentTextSet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_CallbackData_currentText_get")]
-            public static extern string CallbackDataCurrentTextGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_CallbackData_currentText_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string CallbackDataCurrentTextGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_CallbackData_cursorPosition_set")]
-            public static extern void CallbackDataCursorPositionSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_CallbackData_cursorPosition_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void CallbackDataCursorPositionSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_CallbackData_cursorPosition_get")]
-            public static extern int CallbackDataCursorPositionGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_CallbackData_cursorPosition_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CallbackDataCursorPositionGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_CallbackData_update_set")]
-            public static extern void CallbackDataUpdateSet(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_CallbackData_update_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void CallbackDataUpdateSet(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_CallbackData_update_get")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_CallbackData_update_get", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool CallbackDataUpdateGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool CallbackDataUpdateGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_CallbackData_preeditResetRequired_set")]
-            public static extern void CallbackDataPreeditResetRequiredSet(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_CallbackData_preeditResetRequired_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void CallbackDataPreeditResetRequiredSet(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_CallbackData_preeditResetRequired_get")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_CallbackData_preeditResetRequired_get", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool CallbackDataPreeditResetRequiredGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool CallbackDataPreeditResetRequiredGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_InputMethodContext_CallbackData")]
-            public static extern void DeleteInputMethodContextCallbackData(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_InputMethodContext_CallbackData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteInputMethodContextCallbackData(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_Finalize")]
-            public static extern void Finalize(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_Finalize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Finalize(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_InputMethodContext")]
-            public static extern void DeleteInputMethodContext(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_InputMethodContext", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteInputMethodContext(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_InputMethodContext__SWIG_1")]
-            public static extern global::System.IntPtr NewInputMethodContext(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_InputMethodContext__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewInputMethodContext(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_DownCast")]
-            public static extern global::System.IntPtr DownCast(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_DownCast", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DownCast(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_Activate")]
-            public static extern void Activate(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_Activate", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Activate(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_Deactivate")]
-            public static extern void Deactivate(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_Deactivate", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Deactivate(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_RestoreAfterFocusLost")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_RestoreAfterFocusLost", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool RestoreAfterFocusLost(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool RestoreAfterFocusLost(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetRestoreAfterFocusLost")]
-            public static extern void SetRestoreAfterFocusLost(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetRestoreAfterFocusLost", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetRestoreAfterFocusLost(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_Reset")]
-            public static extern void Reset(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_Reset", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Reset(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_NotifyCursorPosition")]
-            public static extern void NotifyCursorPosition(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_NotifyCursorPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void NotifyCursorPosition(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetCursorPosition")]
-            public static extern void SetCursorPosition(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetCursorPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetCursorPosition(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_GetCursorPosition")]
-            public static extern uint GetCursorPosition(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_GetCursorPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetCursorPosition(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetSurroundingText")]
-            public static extern void SetSurroundingText(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetSurroundingText", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetSurroundingText(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_GetSurroundingText")]
-            public static extern string GetSurroundingText(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_GetSurroundingText", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetSurroundingText(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_NotifyTextInputMultiLine")]
-            public static extern void NotifyTextInputMultiLine(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_NotifyTextInputMultiLine", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void NotifyTextInputMultiLine(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_GetTextDirection")]
-            public static extern int GetTextDirection(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_GetTextDirection", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetTextDirection(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_GetInputMethodArea")]
-            public static extern global::System.IntPtr GetInputMethodArea(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_GetInputMethodArea", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetInputMethodArea(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetInputPanelUserData")]
-            public static extern void SetInputPanelUserData(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetInputPanelUserData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetInputPanelUserData(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_GetInputPanelUserData")]
-            public static extern void GetInputPanelUserData(global::System.Runtime.InteropServices.HandleRef jarg1, out string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_GetInputPanelUserData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GetInputPanelUserData(IntPtr jarg1, out string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_GetInputPanelState")]
-            public static extern int GetInputPanelState(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_GetInputPanelState", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetInputPanelState(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetReturnKeyState")]
-            public static extern void SetReturnKeyState(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetReturnKeyState", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetReturnKeyState(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_AutoEnableInputPanel")]
-            public static extern void AutoEnableInputPanel(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_AutoEnableInputPanel", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AutoEnableInputPanel(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_ShowInputPanel")]
-            public static extern void ShowInputPanel(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_ShowInputPanel", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ShowInputPanel(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_HideInputPanel")]
-            public static extern void HideInputPanel(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_HideInputPanel", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void HideInputPanel(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_GetKeyboardType")]
-            public static extern int GetKeyboardType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_GetKeyboardType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetKeyboardType(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_GetInputPanelLocale")]
-            public static extern string GetInputPanelLocale(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_GetInputPanelLocale", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetInputPanelLocale(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetMIMEType")]
-            public static extern void SetMIMEType(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetMIMEType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMIMEType(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_AllowTextPrediction")]
-            public static extern void AllowTextPrediction(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_AllowTextPrediction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AllowTextPrediction(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_IsTextPredictionAllowed")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_IsTextPredictionAllowed", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsTextPredictionAllowed(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsTextPredictionAllowed(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetFullScreenMode")]
-            public static extern void SetFullScreenMode(global::System.Runtime.InteropServices.HandleRef inputMethodContext, bool fullScreen);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetFullScreenMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFullScreenMode(IntPtr inputMethodContext, [MarshalAs(UnmanagedType.U1)] bool fullScreen);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_IsFullScreenMode")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_IsFullScreenMode", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsFullScreenMode(global::System.Runtime.InteropServices.HandleRef inputMethodContext);
+            public static partial bool IsFullScreenMode(IntPtr inputMethodContext);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetInputPanelLanguage")]
-            public static extern void SetInputPanelLanguage(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetInputPanelLanguage", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetInputPanelLanguage(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_GetInputPanelLanguage")]
-            public static extern int GetInputPanelLanguage(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_GetInputPanelLanguage", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetInputPanelLanguage(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetInputPanelPosition")]
-            public static extern void SetInputPanelPosition(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, uint jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetInputPanelPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetInputPanelPosition(IntPtr jarg1, uint jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetInputPanelPositionAlign")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetInputPanelPositionAlign", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SetInputPanelPositionAlign(global::System.Runtime.InteropServices.HandleRef inputMethodContext, int x, int y, int align);
+            public static partial bool SetInputPanelPositionAlign(IntPtr inputMethodContext, int x, int y, int align);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_ActivatedSignal")]
-            public static extern global::System.IntPtr ActivatedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_ActivatedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ActivatedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_EventReceivedSignal")]
-            public static extern global::System.IntPtr EventReceivedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_EventReceivedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr EventReceivedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_StatusChangedSignal")]
-            public static extern global::System.IntPtr StatusChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_StatusChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr StatusChangedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_ResizedSignal")]
-            public static extern global::System.IntPtr ResizedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_ResizedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ResizedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_LanguageChangedSignal")]
-            public static extern global::System.IntPtr LanguageChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_LanguageChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr LanguageChangedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_KeyboardTypeChangedSignal")]
-            public static extern global::System.IntPtr KeyboardTypeChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_KeyboardTypeChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr KeyboardTypeChangedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_ContentReceivedSignal")]
-            public static extern global::System.IntPtr ContentReceivedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_ContentReceivedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ContentReceivedSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Int32Pair.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Int32Pair.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,32 +14,42 @@
  * limitations under the License.
  *
  */
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
          internal static partial class Int32Pair
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Int32Pair__SWIG_0")]
-            public static extern global::System.IntPtr NewInt32Pair();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Int32Pair__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewInt32Pair();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Int32Pair__SWIG_1")]
-            public static extern global::System.IntPtr NewInt32Pair(int x, int y);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Int32Pair__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewInt32Pair(int x, int y);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Int32Pair_SetX")]
-            public static extern void SetX(global::System.Runtime.InteropServices.HandleRef handle, int x);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Int32Pair_SetX", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetX(IntPtr handle, int x);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Int32Pair_GetX")]
-            public static extern int GetX(global::System.Runtime.InteropServices.HandleRef handle);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Int32Pair_GetX", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetX(IntPtr handle);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Int32Pair_SetY")]
-            public static extern void SetY(global::System.Runtime.InteropServices.HandleRef handle, int y);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Int32Pair_SetY", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetY(IntPtr handle, int y);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Int32Pair_GetY")]
-            public static extern int GetY(global::System.Runtime.InteropServices.HandleRef handle);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Int32Pair_GetY", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetY(IntPtr handle);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Int32Pair")]
-            public static extern void DeleteInt32Pair(global::System.Runtime.InteropServices.HandleRef handle);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Int32Pair", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteInt32Pair(IntPtr handle);
        }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Key.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Key.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,71 +26,76 @@ namespace Tizen.NUI
         internal static partial class Key
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_New")]
-            public static extern global::System.IntPtr New(string jarg1, string jarg2, int jarg3, int jarg4, uint jarg5, int jarg6);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(string jarg1, string jarg2, int jarg3, int jarg4, uint jarg5, int jarg6);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_New__SWIG_1")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_New__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Key")]
-            public static extern void DeleteKey(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Key", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteKey(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_IsShiftModifier")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_IsShiftModifier", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsShiftModifier(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsShiftModifier(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_IsCtrlModifier")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_IsCtrlModifier", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsCtrlModifier(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsCtrlModifier(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_IsAltModifier")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_IsAltModifier", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsAltModifier(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsAltModifier(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyPressedName_set")]
-            public static extern void KeyPressedNameSet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyPressedName_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void KeyPressedNameSet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyPressedName_get")]
-            public static extern string KeyPressedNameGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyPressedName_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string KeyPressedNameGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyPressed_set")]
-            public static extern void KeyPressedSet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyPressed_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void KeyPressedSet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyPressed_get")]
-            public static extern string KeyPressedGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyPressed_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string KeyPressedGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyPressed_set")]
-            public static extern void KeyStringSet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyPressed_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void KeyStringSet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyPressed_get")]
-            public static extern string KeyStringGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyPressed_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string KeyStringGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyCode_set")]
-            public static extern void KeyCodeSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyCode_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void KeyCodeSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyCode_get")]
-            public static extern int KeyCodeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyCode_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int KeyCodeGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyModifier_set")]
-            public static extern void KeyModifierSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyModifier_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void KeyModifierSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyModifier_get")]
-            public static extern int KeyModifierGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_keyModifier_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int KeyModifierGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_time_set")]
-            public static extern void TimeSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_time_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TimeSet(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_time_get")]
-            public static extern uint TimeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_time_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint TimeGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_state_set")]
-            public static extern void StateSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_state_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void StateSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_state_get")]
-            public static extern int StateGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_state_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int StateGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_logicalKey_get")]
-            public static extern string LogicalKeyGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_logicalKey_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string LogicalKeyGet(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.KeyEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.KeyEventSignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class KeyEventSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyEventSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyEventSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyEventSignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyEventSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyEventSignal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyEventSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyEventSignal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyEventSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyEventSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyEventSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_KeyEventSignal")]
-            public static extern global::System.IntPtr NewKeyEventSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_KeyEventSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewKeyEventSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_KeyEventSignal")]
-            public static extern void DeleteKeyEventSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_KeyEventSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteKeyEventSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.KeyFrames.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.KeyFrames.cs
@@ -15,35 +15,44 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class KeyFrames
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyFrames_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyFrames_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_KeyFrames")]
-            public static extern void DeleteKeyFrames(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_KeyFrames", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteKeyFrames(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyFrames_GetType")]
-            public static extern int GetType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyFrames_GetType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetType(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyFrames_GetKeyFrameCount")]
-            public static extern uint GetKeyFrameCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyFrames_GetKeyFrameCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetKeyFrameCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyFrames_GetKeyFrame")]
-            public static extern void GetKeyFrame(global::System.Runtime.InteropServices.HandleRef jarg1, uint index, out float time, global::System.Runtime.InteropServices.HandleRef value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyFrames_GetKeyFrame", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GetKeyFrame(IntPtr jarg1, uint index, out float time, IntPtr value);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyFrames_SetKeyFrameValue")]
-            public static extern void SetKeyFrameValue(global::System.Runtime.InteropServices.HandleRef jarg1, uint index, global::System.Runtime.InteropServices.HandleRef value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyFrames_SetKeyFrameValue", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetKeyFrameValue(IntPtr jarg1, uint index, IntPtr value);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyFrames_Add__SWIG_0")]
-            public static extern void Add(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyFrames_Add__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Add(IntPtr jarg1, float jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyFrames_Add__SWIG_1")]
-            public static extern void Add(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyFrames_Add__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Add(IntPtr jarg1, float jarg2, IntPtr jarg3, IntPtr jarg4);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.KeyInputFocusManager.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.KeyInputFocusManager.cs
@@ -17,6 +17,7 @@
 
 using global::System;
 using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -24,23 +25,26 @@ namespace Tizen.NUI
     {
         internal static partial class KeyInputFocusManager
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_KeyInputFocusManager")]
-            public static extern IntPtr NewKeyInputFocusManager();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_KeyInputFocusManager", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr NewKeyInputFocusManager();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_KeyInputFocusManager")]
-            public static extern void DeleteKeyInputFocusManager(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_KeyInputFocusManager", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteKeyInputFocusManager(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyInputFocusManager_Get")]
-            public static extern IntPtr Get();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyInputFocusManager_Get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr Get();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyInputFocusManager_SetFocus")]
-            public static extern void SetFocus(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyInputFocusManager_SetFocus", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFocus(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyInputFocusManager_GetCurrentFocusControl")]
-            public static extern IntPtr GetCurrentFocusControl(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyInputFocusManager_GetCurrentFocusControl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GetCurrentFocusControl(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyInputFocusManager_RemoveFocus")]
-            public static extern void RemoveFocus(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyInputFocusManager_RemoveFocus", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemoveFocus(IntPtr jarg1, IntPtr jarg2);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.KeyboardEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.KeyboardEventSignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class KeyboardEventSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardEventSignalType_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardEventSignalType_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardEventSignalType_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardEventSignalType_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardEventSignalType_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardEventSignalType_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardEventSignalType_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardEventSignalType_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardEventSignalType_Emit")]
-            public static extern global::System.IntPtr Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardEventSignalType_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Emit(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_KeyboardEventSignalType")]
-            public static extern global::System.IntPtr NewKeyboardEventSignalType();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_KeyboardEventSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewKeyboardEventSignalType();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_KeyboardEventSignalType")]
-            public static extern void DeleteKeyboardEventSignalType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_KeyboardEventSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteKeyboardEventSignalType(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.KeyboardRepeatSettingsChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.KeyboardRepeatSettingsChangedSignal.cs
@@ -15,7 +15,9 @@
  *
  */
 
-using System.Runtime.InteropServices;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -23,28 +25,31 @@ namespace Tizen.NUI
     {
         internal static partial class KeyboardRepeatSettingsChangedSignal
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_ChangedSignal")]
-            public static extern global::System.IntPtr GetSignal(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_ChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetSignal(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_Changed_Signal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_Changed_Signal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_Changed_Signal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_Changed_Signal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_Changed_Signal_Connect")]
-            public static extern void Connect(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_Changed_Signal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_Changed_Signal_Disconnect")]
-            public static extern void Disconnect(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_Changed_Signal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_Changed_Signal_Emit")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_Changed_Signal_Emit", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Emit(HandleRef jarg1);
+            public static partial bool Emit(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_Changed_Signal_delete")]
-            public static extern void DeleteSignal(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_Changed_Signal_delete", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteSignal(IntPtr jarg1);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.KeyboardResizedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.KeyboardResizedSignalType.cs
@@ -14,33 +14,43 @@
  * limitations under the License.
  *
  */
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class KeyboardResizedSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardResizedSignalType_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardResizedSignalType_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardResizedSignalType_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardResizedSignalType_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardResizedSignalType_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardResizedSignalType_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardResizedSignalType_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardResizedSignalType_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardResizedSignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardResizedSignalType_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_KeyboardResizedSignalType")]
-            public static extern global::System.IntPtr NewKeyboardResizedSignalType();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_KeyboardResizedSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewKeyboardResizedSignalType();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_KeyboardResizedSignalType")]
-            public static extern void DeleteKeyboardResizedSignalType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_KeyboardResizedSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteKeyboardResizedSignalType(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.KeyboardTypeSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.KeyboardTypeSignalType.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class KeyboardTypeSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardTypeSignalType_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardTypeSignalType_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardTypeSignalType_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardTypeSignalType_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardTypeSignalType_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardTypeSignalType_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardTypeSignalType_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardTypeSignalType_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardTypeSignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardTypeSignalType_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_KeyboardTypeSignalType")]
-            public static extern global::System.IntPtr NewKeyboardTypeSignalType();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_KeyboardTypeSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewKeyboardTypeSignalType();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_KeyboardTypeSignalType")]
-            public static extern void DeleteKeyboardTypeSignalType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_KeyboardTypeSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteKeyboardTypeSignalType(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.LanguageChangedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.LanguageChangedSignalType.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class LanguageChangedSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LanguageChangedSignalType_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LanguageChangedSignalType_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LanguageChangedSignalType_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LanguageChangedSignalType_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LanguageChangedSignalType_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LanguageChangedSignalType_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LanguageChangedSignalType_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LanguageChangedSignalType_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LanguageChangedSignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LanguageChangedSignalType_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_LanguageChangedSignalType")]
-            public static extern global::System.IntPtr NewLanguageChangedSignalType();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_LanguageChangedSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewLanguageChangedSignalType();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_LanguageChangedSignalType")]
-            public static extern void DeleteLanguageChangedSignalType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_LanguageChangedSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteLanguageChangedSignalType(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Layer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Layer.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,52 +26,57 @@ namespace Tizen.NUI
         internal static partial class Layer
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_Property_BEHAVIOR_get")]
-            public static extern int BehaviorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_Property_BEHAVIOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BehaviorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Layer")]
-            public static extern void DeleteLayer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Layer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteLayer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_RaiseToTop")]
-            public static extern void RaiseToTop(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_RaiseToTop", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RaiseToTop(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_LowerToBottom")]
-            public static extern void LowerToBottom(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_LowerToBottom", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LowerToBottom(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_MoveAbove")]
-            public static extern void MoveAbove(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_MoveAbove", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void MoveAbove(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_MoveBelow")]
-            public static extern void MoveBelow(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_MoveBelow", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void MoveBelow(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_SetBehavior")]
-            public static extern void SetBehavior(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_SetBehavior", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetBehavior(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_GetBehavior")]
-            public static extern int GetBehavior(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_GetBehavior", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetBehavior(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_SetClipping")]
-            public static extern void SetClipping(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_SetClipping", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetClipping(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_SetClippingBox__SWIG_1")]
-            public static extern void SetClippingBox(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_SetClippingBox__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetClippingBox(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_SetTouchConsumed")]
-            public static extern void SetTouchConsumed(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_SetTouchConsumed", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTouchConsumed(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_IsTouchConsumed")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_IsTouchConsumed", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsTouchConsumed(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsTouchConsumed(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_SetHoverConsumed")]
-            public static extern void SetHoverConsumed(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_SetHoverConsumed", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetHoverConsumed(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_IsHoverConsumed")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Layer_IsHoverConsumed", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsHoverConsumed(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsHoverConsumed(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Libraries.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Libraries.cs
@@ -25,3 +25,5 @@ namespace Tizen.NUI
         }
     }
 }
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.LinearConstrainer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.LinearConstrainer.cs
@@ -15,35 +15,44 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class LinearConstrainer
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearConstrainer_Property_VALUE_get")]
-            public static extern int ValueGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearConstrainer_Property_VALUE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ValueGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearConstrainer_Property_PROGRESS_get")]
-            public static extern int ProgressGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearConstrainer_Property_PROGRESS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ProgressGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearConstrainer_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearConstrainer_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_LinearConstrainer")]
-            public static extern void DeleteLinearConstrainer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_LinearConstrainer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteLinearConstrainer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearConstrainer_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearConstrainer_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearConstrainer_Apply__SWIG_0")]
-            public static extern void Apply(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, global::System.Runtime.InteropServices.HandleRef jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearConstrainer_Apply__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Apply(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4, IntPtr jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearConstrainer_Apply__SWIG_1")]
-            public static extern void Apply(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearConstrainer_Apply__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Apply(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearConstrainer_Remove")]
-            public static extern void Remove(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearConstrainer_Remove", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Remove(IntPtr jarg1, IntPtr jarg2);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.LinearGradient.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.LinearGradient.cs
@@ -15,20 +15,29 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class LinearGradient
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearGradient_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearGradient_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearGradient_SetBounds")]
-            public static extern void SetBounds(global::System.Runtime.InteropServices.HandleRef linearGradient, global::System.Runtime.InteropServices.HandleRef firstPoint, global::System.Runtime.InteropServices.HandleRef secondPoint);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearGradient_SetBounds", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetBounds(IntPtr linearGradient, IntPtr firstPoint, IntPtr secondPoint);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearGradient_GetBounds")]
-            public static extern void GetBounds(global::System.Runtime.InteropServices.HandleRef linearGradient, global::System.Runtime.InteropServices.HandleRef firstPoint, global::System.Runtime.InteropServices.HandleRef secondPoint);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LinearGradient_GetBounds", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GetBounds(IntPtr linearGradient, IntPtr firstPoint, IntPtr secondPoint);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.LongPressGesture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.LongPressGesture.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,20 +26,25 @@ namespace Tizen.NUI
         internal static partial class LongPressGesture
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGesture_New")]
-            public static extern global::System.IntPtr New(int jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGesture_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_LongPressGesture")]
-            public static extern void DeleteLongPressGesture(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_LongPressGesture", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteLongPressGesture(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGesture_numberOfTouches_get")]
-            public static extern uint NumberOfTouchesGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGesture_numberOfTouches_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint NumberOfTouchesGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGesture_screenPoint_get")]
-            public static extern global::System.IntPtr ScreenPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGesture_screenPoint_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ScreenPointGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGesture_localPoint_get")]
-            public static extern global::System.IntPtr LocalPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGesture_localPoint_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr LocalPointGet(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.LongPressGestureDetectedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.LongPressGestureDetectedSignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class LongPressGestureDetectedSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetectedSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetectedSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetectedSignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetectedSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetectedSignal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetectedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetectedSignal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetectedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetectedSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetectedSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_LongPressGestureDetectedSignal")]
-            public static extern global::System.IntPtr NewLongPressGestureDetectedSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_LongPressGestureDetectedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewLongPressGestureDetectedSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_LongPressGestureDetectedSignal")]
-            public static extern void DeleteLongPressGestureDetectedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_LongPressGestureDetectedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteLongPressGestureDetectedSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.LongPressGestureDetector.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.LongPressGestureDetector.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,38 +26,43 @@ namespace Tizen.NUI
         internal static partial class LongPressGestureDetector
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetector_New__SWIG_0")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetector_New__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetector_New__SWIG_1")]
-            public static extern global::System.IntPtr New(uint jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetector_New__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(uint jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetector_New__SWIG_2")]
-            public static extern global::System.IntPtr New(uint jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetector_New__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(uint jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_LongPressGestureDetector")]
-            public static extern void DeleteLongPressGestureDetector(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_LongPressGestureDetector", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteLongPressGestureDetector(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_LongPressGestureDetector__SWIG_1")]
-            public static extern global::System.IntPtr NewLongPressGestureDetector(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_LongPressGestureDetector__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewLongPressGestureDetector(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetector_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetector_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetector_SetTouchesRequired__SWIG_0")]
-            public static extern void SetTouchesRequired(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetector_SetTouchesRequired__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTouchesRequired(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetector_SetTouchesRequired__SWIG_1")]
-            public static extern void SetTouchesRequired(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, uint jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetector_SetTouchesRequired__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTouchesRequired(IntPtr jarg1, uint jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetector_GetMinimumTouchesRequired")]
-            public static extern uint GetMinimumTouchesRequired(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetector_GetMinimumTouchesRequired", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetMinimumTouchesRequired(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetector_GetMaximumTouchesRequired")]
-            public static extern uint GetMaximumTouchesRequired(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetector_GetMaximumTouchesRequired", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetMaximumTouchesRequired(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetector_DetectedSignal")]
-            public static extern global::System.IntPtr DetectedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetector_DetectedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DetectedSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.LottieAnimationView.cs
@@ -14,6 +14,11 @@
  * limitations under the License.
  *
  */
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -21,14 +26,19 @@ namespace Tizen.NUI
         internal static partial class LottieAnimationView
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_AnimatedVectorImageVisual_Actions_JUMP_TO_get")]
-            public static extern int AnimatedVectorImageVisualActionJumpToGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_AnimatedVectorImageVisual_Actions_JUMP_TO_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AnimatedVectorImageVisualActionJumpToGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_AnimatedVectorImageVisual_Actions_SET_DYNAMIC_PROPERTY_get")]
-            public static extern int AnimatedVectorImageVisualActionSetDynamicPropertyGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_AnimatedVectorImageVisual_Actions_SET_DYNAMIC_PROPERTY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AnimatedVectorImageVisualActionSetDynamicPropertyGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_AnimatedVectorImageVisual_Actions_FLUSH_get")]
-            public static extern int AnimatedVectorImageVisualActionFlushGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_AnimatedVectorImageVisual_Actions_FLUSH_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AnimatedVectorImageVisualActionFlushGet();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.LowBatterySignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.LowBatterySignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class LowBatterySignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowBatterySignalType_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowBatterySignalType_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool LowBatterySignalTypeEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool LowBatterySignalTypeEmpty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowBatterySignalType_GetConnectionCount")]
-            public static extern uint LowBatterySignalTypeGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowBatterySignalType_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint LowBatterySignalTypeGetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowBatterySignalType_Connect")]
-            public static extern void LowBatterySignalTypeConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowBatterySignalType_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LowBatterySignalTypeConnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowBatterySignalType_Disconnect")]
-            public static extern void LowBatterySignalTypeDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowBatterySignalType_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LowBatterySignalTypeDisconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowBatterySignalType_Emit")]
-            public static extern void LowBatterySignalTypeEmit(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowBatterySignalType_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LowBatterySignalTypeEmit(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_new_LowBatterySignalType")]
-            public static extern global::System.IntPtr NewLowBatterySignalType();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_new_LowBatterySignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewLowBatterySignalType();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_delete_LowBatterySignalType")]
-            public static extern void DeleteLowBatterySignalType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_delete_LowBatterySignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteLowBatterySignalType(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.LowMemorySignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.LowMemorySignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class LowMemorySignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowMemorySignalType_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowMemorySignalType_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowMemorySignalType_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowMemorySignalType_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowMemorySignalType_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowMemorySignalType_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowMemorySignalType_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowMemorySignalType_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowMemorySignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowMemorySignalType_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_new_LowMemorySignalType")]
-            public static extern global::System.IntPtr NewLowMemorySignalType();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_new_LowMemorySignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewLowMemorySignalType();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_delete_LowMemorySignalType")]
-            public static extern void DeleteLowMemorySignalType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_delete_LowMemorySignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteLowMemorySignalType(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.MaskEffect.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.MaskEffect.cs
@@ -1,30 +1,53 @@
+﻿/*
+ * Copyright(c) 2026 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
-    using global::System;
-    using global::System.Runtime.InteropServices;
-
     internal static partial class Interop
     {
         internal static partial class MaskEffect
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MaskEffect_New__SWIG_0")]
-            public static extern global::System.IntPtr New(HandleRef control);
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MaskEffect_New__SWIG_1")]
-            public static extern global::System.IntPtr New(HandleRef control, MaskEffectMode maskMode, float positionX, float positionY, float scaleX, float scaleY);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MaskEffect_New__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(IntPtr control);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MaskEffect_New__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(IntPtr control, MaskEffectMode maskMode, float positionX, float positionY, float scaleX, float scaleY);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MaskEffect_SetTargetMaskOnce")]
-            public static extern void SetTargetMaskOnce(HandleRef effect, bool targetMaskOnce);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MaskEffect_SetTargetMaskOnce", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTargetMaskOnce(IntPtr effect, [MarshalAs(UnmanagedType.U1)] bool targetMaskOnce);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MaskEffect_GetTargetMaskOnce")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MaskEffect_GetTargetMaskOnce", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool GetTargetMaskOnce(HandleRef effect);
+            public static partial bool GetTargetMaskOnce(IntPtr effect);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MaskEffect_SetSourceMaskOnce")]
-            public static extern void SetSourceMaskOnce(HandleRef effect, bool sourceMaskOnce);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MaskEffect_SetSourceMaskOnce", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetSourceMaskOnce(IntPtr effect, [MarshalAs(UnmanagedType.U1)] bool sourceMaskOnce);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MaskEffect_GetSourceMaskOnce")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MaskEffect_GetSourceMaskOnce", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool GetSourceMaskOnce(HandleRef effect);
+            public static partial bool GetSourceMaskOnce(IntPtr effect);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Matrix.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Matrix.cs
@@ -15,208 +15,217 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Matrix
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Matrix__SWIG_0")]
-            public static extern global::System.IntPtr NewMatrix();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Matrix__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewMatrix();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Matrix__SWIG_1")]
-            public static extern global::System.IntPtr NewMatrix(bool jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Matrix__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewMatrix([MarshalAs(UnmanagedType.U1)] bool jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Matrix__SWIG_2")]
-            public static extern global::System.IntPtr NewMatrix([global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] float[] jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Matrix__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewMatrix([global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] float[] jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Matrix__SWIG_3")]
-            public static extern global::System.IntPtr NewMatrixQuaternion(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Matrix__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewMatrixQuaternion(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Matrix__SWIG_4")]
-            public static extern global::System.IntPtr NewMatrix(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Matrix__SWIG_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewMatrix(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_IDENTITY_get")]
-            public static extern global::System.IntPtr IdentityGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_IDENTITY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr IdentityGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetIdentity")]
-            public static extern void SetIdentity(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetIdentity", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetIdentity(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetIdentityAndScale")]
-            public static extern void SetIdentityAndScale(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetIdentityAndScale", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetIdentityAndScale(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_InvertTransform")]
-            public static extern void InvertTransform(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_InvertTransform", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void InvertTransform(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_Invert")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_Invert", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Invert(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Invert(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_Transpose")]
-            public static extern void Transpose(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_Transpose", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Transpose(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_GetXAxis")]
-            public static extern global::System.IntPtr GetXAxis(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_GetXAxis", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetXAxis(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_GetYAxis")]
-            public static extern global::System.IntPtr GetYAxis(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_GetYAxis", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetYAxis(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_GetZAxis")]
-            public static extern global::System.IntPtr GetZAxis(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_GetZAxis", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetZAxis(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetXAxis")]
-            public static extern void SetXAxis(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetXAxis", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetXAxis(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetYAxis")]
-            public static extern void SetYAxis(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetYAxis", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetYAxis(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetZAxis")]
-            public static extern void SetZAxis(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetZAxis", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetZAxis(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_GetTranslation")]
-            public static extern global::System.IntPtr GetTranslation(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_GetTranslation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetTranslation(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_GetTranslation3")]
-            public static extern global::System.IntPtr GetTranslation3(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_GetTranslation3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetTranslation3(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetTranslation__SWIG_0")]
-            public static extern void SetTranslationVector4(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetTranslation__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTranslationVector4(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetTranslation__SWIG_1")]
-            public static extern void SetTranslationVector3(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetTranslation__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTranslationVector3(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_OrthoNormalize")]
-            public static extern void OrthoNormalize(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_OrthoNormalize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void OrthoNormalize(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_Multiply__SWIG_0")]
-            public static extern void Multiply(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_Multiply__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Multiply(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_Multiply__SWIG_1")]
-            public static extern void MultiplyQuaternion(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_Multiply__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void MultiplyQuaternion(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_Multiply__SWIG_2")]
-            public static extern global::System.IntPtr MultiplyVector4(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_Multiply__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr MultiplyVector4(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_Multiply__SWIG_4")]
-            public static extern global::System.IntPtr Multiply(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_Multiply__SWIG_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Multiply(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_MultiplyAssign")]
-            public static extern global::System.IntPtr MultiplyAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_MultiplyAssign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr MultiplyAssign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_EqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_EqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool EqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool EqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_NotEqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_NotEqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool NotEqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool NotEqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetTransformComponents")]
-            public static extern void SetTransformComponents(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetTransformComponents", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTransformComponents(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetInverseTransformComponents__SWIG_0")]
-            public static extern void SetInverseTransformComponents(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetInverseTransformComponents__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetInverseTransformComponents(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetInverseTransformComponents__SWIG_1")]
-            public static extern void SetInverseTransformComponents(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, global::System.Runtime.InteropServices.HandleRef jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetInverseTransformComponents__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetInverseTransformComponents(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4, IntPtr jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_GetTransformComponents")]
-            public static extern void GetTransformComponents(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_GetTransformComponents", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GetTransformComponents(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_ValueOfIndex__SWIG_0")]
-            public static extern float ValueOfIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_ValueOfIndex__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float ValueOfIndex(IntPtr jarg1, uint index);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_ValueOfIndex__SWIG_1")]
-            public static extern float ValueOfIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint indexRow, uint indexColumn);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_ValueOfIndex__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float ValueOfIndex(IntPtr jarg1, uint indexRow, uint indexColumn);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetValueAtIndex__SWIG_0")]
-            public static extern void SetValueAtIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint index, float val);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetValueAtIndex__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetValueAtIndex(IntPtr jarg1, uint index, float val);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetValueAtIndex__SWIG_1")]
-            public static extern void SetValueAtIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint indexRow, uint indexColumn, float val);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetValueAtIndex__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetValueAtIndex(IntPtr jarg1, uint indexRow, uint indexColumn, float val);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Matrix")]
-            public static extern void DeleteMatrix(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Matrix", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteMatrix(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_IDENTITY_get")]
-            public static extern global::System.IntPtr Matrix3IdentityGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_IDENTITY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Matrix3IdentityGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Matrix3__SWIG_0")]
-            public static extern global::System.IntPtr NewMatrix3();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Matrix3__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewMatrix3();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Matrix3__SWIG_1")]
-            public static extern global::System.IntPtr NewMatrix3(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Matrix3__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewMatrix3(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Matrix3__SWIG_2")]
-            public static extern global::System.IntPtr NewMatrix3Matrix(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Matrix3__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewMatrix3Matrix(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Matrix3__SWIG_3")]
-            public static extern global::System.IntPtr NewMatrix3(float jarg1, float jarg2, float jarg3, float jarg4, float jarg5, float jarg6, float jarg7, float jarg8, float jarg9);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Matrix3__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewMatrix3(float jarg1, float jarg2, float jarg3, float jarg4, float jarg5, float jarg6, float jarg7, float jarg8, float jarg9);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Assign__SWIG_0")]
-            public static extern global::System.IntPtr Matrix3Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Assign__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Matrix3Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Assign__SWIG_1")]
-            public static extern global::System.IntPtr Matrix3AssignMatrix(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Assign__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Matrix3AssignMatrix(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_EqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_EqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Matrix3EqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool Matrix3EqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_NotEqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_NotEqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Matrix3NotEqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool Matrix3NotEqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Matrix3")]
-            public static extern void DeleteMatrix3(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Matrix3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteMatrix3(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_SetIdentity")]
-            public static extern void Matrix3SetIdentity(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_SetIdentity", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Matrix3SetIdentity(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Invert")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Invert", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Matrix3Invert(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Matrix3Invert(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Transpose")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Transpose", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Matrix3Transpose(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Matrix3Transpose(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Scale")]
-            public static extern void Matrix3Scale(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Scale", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Matrix3Scale(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Magnitude")]
-            public static extern float Matrix3Magnitude(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Magnitude", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float Matrix3Magnitude(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_ScaledInverseTranspose")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_ScaledInverseTranspose", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Matrix3ScaledInverseTranspose(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Matrix3ScaledInverseTranspose(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Multiply")]
-            public static extern void Matrix3Multiply(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Multiply", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Matrix3Multiply(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Multiply__SWIG_1")]
-            public static extern global::System.IntPtr Matrix3MultiplyVector3(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Multiply__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Matrix3MultiplyVector3(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Multiply__SWIG_3")]
-            public static extern global::System.IntPtr Matrix3Multiply(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Multiply__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Matrix3Multiply(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_MultiplyAssign")]
-            public static extern global::System.IntPtr Matrix3MultiplyAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_MultiplyAssign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Matrix3MultiplyAssign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_ValueOfIndex__SWIG_0")]
-            public static extern float Matrix3ValueOfIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_ValueOfIndex__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float Matrix3ValueOfIndex(IntPtr jarg1, uint index);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_ValueOfIndex__SWIG_1")]
-            public static extern float Matrix3ValueOfIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint indexRow, uint indexColumn);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_ValueOfIndex__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float Matrix3ValueOfIndex(IntPtr jarg1, uint indexRow, uint indexColumn);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_SetValueAtIndex__SWIG_0")]
-            public static extern void Matrix3SetValueAtIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint index, float val);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_SetValueAtIndex__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Matrix3SetValueAtIndex(IntPtr jarg1, uint index, float val);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_SetValueAtIndex__SWIG_1")]
-            public static extern void Matrix3SetValueAtIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint indexRow, uint indexColumn, float val);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_SetValueAtIndex__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Matrix3SetValueAtIndex(IntPtr jarg1, uint indexRow, uint indexColumn, float val);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.MouseInOut.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.MouseInOut.cs
@@ -15,35 +15,44 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class MouseInOut
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_MouseInOutEvent__SWIG_0")]
-            public static extern global::System.IntPtr NewMouseInOut(int jarg1, uint jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, uint jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_MouseInOutEvent__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewMouseInOut(int jarg1, uint jarg2, IntPtr jarg3, uint jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_MouseInOutEvent")]
-            public static extern void DeleteMouseInOut(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_MouseInOutEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteMouseInOut(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseInOutEvent_type_get")]
-            public static extern int TypeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseInOutEvent_type_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TypeGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseInOutEvent_modifiers_get")]
-            public static extern uint ModifiersGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseInOutEvent_modifiers_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint ModifiersGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseInOutEvent_point_get")]
-            public static extern global::System.IntPtr PointGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseInOutEvent_point_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr PointGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseInOutEvent_timeStamp_get")]
-            public static extern uint TimeStampGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseInOutEvent_timeStamp_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint TimeStampGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseInOutEvent_GetDeviceClass")]
-            public static extern int DeviceClassGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseInOutEvent_GetDeviceClass", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DeviceClassGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseInOutEvent_GetDeviceSubClass")]
-            public static extern int DeviceSubClassGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseInOutEvent_GetDeviceSubClass", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DeviceSubClassGet(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.MouseReleative.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.MouseReleative.cs
@@ -15,38 +15,47 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class MouseRelative
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_MouseRelativeEvent__SWIG_0")]
-            public static extern global::System.IntPtr NewMouseRelative(int jarg1, uint jarg2, uint jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, global::System.Runtime.InteropServices.HandleRef jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_MouseRelativeEvent__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewMouseRelative(int jarg1, uint jarg2, uint jarg3, IntPtr jarg4, IntPtr jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_MouseRelativeEvent")]
-            public static extern void DeleteMouseRelative(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_MouseRelativeEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteMouseRelative(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseRelativeEvent_type_get")]
-            public static extern int TypeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseRelativeEvent_type_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TypeGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseRelativeEvent_modifiers_get")]
-            public static extern uint ModifiersGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseRelativeEvent_modifiers_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint ModifiersGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseRelativeEvent_diff_position_get")]
-            public static extern global::System.IntPtr DiffPositionGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseRelativeEvent_diff_position_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DiffPositionGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseRelativeEvent_unaccelated_position_get")]
-            public static extern global::System.IntPtr UnaccelatedPositionGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseRelativeEvent_unaccelated_position_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr UnaccelatedPositionGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseRelativeEvent_timeStamp_get")]
-            public static extern uint TimeStampGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseRelativeEvent_timeStamp_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint TimeStampGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseRelativeEvent_GetDeviceClass")]
-            public static extern int DeviceClassGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseRelativeEvent_GetDeviceClass", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DeviceClassGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseRelativeEvent_GetDeviceSubClass")]
-            public static extern int DeviceSubClassGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseRelativeEvent_GetDeviceSubClass", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DeviceSubClassGet(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.NDalic.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.NDalic.cs
@@ -15,112 +15,121 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class NDalic
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DaliAssertMessage")]
-            public static extern void DaliAssertMessage(string jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DaliAssertMessage", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DaliAssertMessage(string jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NextPowerOfTwo")]
-            public static extern uint NextPowerOfTwo(uint jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NextPowerOfTwo", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint NextPowerOfTwo(uint jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IsPowerOfTwo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IsPowerOfTwo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsPowerOfTwo(uint jarg1);
+            public static partial bool IsPowerOfTwo(uint jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetRangedEpsilon")]
-            public static extern float GetRangedEpsilon(float jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetRangedEpsilon", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetRangedEpsilon(float jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EqualsZero")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EqualsZero", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool EqualsZero(float jarg1);
+            public static partial bool EqualsZero(float jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Equals__SWIG_0")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Equals__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Equals(float jarg1, float jarg2);
+            public static partial bool Equals(float jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Equals__SWIG_1")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Equals__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Equals(float jarg1, float jarg2, float jarg3);
+            public static partial bool Equals(float jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Round")]
-            public static extern float Round(float jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Round", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float Round(float jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WrapInDomain")]
-            public static extern float WrapInDomain(float jarg1, float jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WrapInDomain", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float WrapInDomain(float jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShortestDistanceInDomain")]
-            public static extern float ShortestDistanceInDomain(float jarg1, float jarg2, float jarg3, float jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShortestDistanceInDomain", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float ShortestDistanceInDomain(float jarg1, float jarg2, float jarg3, float jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetName")]
-            public static extern string GetName(int jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetName(int jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetImplementation")]
-            public static extern global::System.IntPtr GetImplementation(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetImplementation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetImplementation(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_HasAlpha")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_HasAlpha", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool HasAlpha(int jarg1);
+            public static partial bool HasAlpha(int jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetBytesPerPixel")]
-            public static extern uint GetBytesPerPixel(int jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetBytesPerPixel", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetBytesPerPixel(int jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetAlphaOffsetAndMask")]
-            public static extern void GetAlphaOffsetAndMask(int jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetAlphaOffsetAndMask", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GetAlphaOffsetAndMask(int jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetDeviceName")]
-            public static extern string GetDeviceName(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetDeviceName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetDeviceName(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetDeviceClass")]
-            public static extern int GetDeviceClass(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetDeviceClass", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetDeviceClass(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetDeviceSubClass")]
-            public static extern int GetDeviceSubClass(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetDeviceSubClass", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetDeviceSubClass(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Raise")]
-            public static extern void Raise(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Raise", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Raise(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Lower")]
-            public static extern void Lower(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Lower", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Lower(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RaiseToTop")]
-            public static extern void RaiseToTop(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RaiseToTop", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RaiseToTop(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LowerToBottom")]
-            public static extern void LowerToBottom(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LowerToBottom", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LowerToBottom(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RaiseAbove")]
-            public static extern void RaiseAbove(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RaiseAbove", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RaiseAbove(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LowerBelow")]
-            public static extern void LowerBelow(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LowerBelow", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LowerBelow(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetCustomAlgorithm")]
-            public static extern void SetCustomAlgorithm(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetCustomAlgorithm", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetCustomAlgorithm(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AnimatablePropertyRegistration__SWIG_0")]
-            public static extern global::System.IntPtr NewAnimatablePropertyRegistration(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, int jarg3, int jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AnimatablePropertyRegistration__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewAnimatablePropertyRegistration(IntPtr jarg1, string jarg2, int jarg3, int jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AnimatablePropertyRegistration__SWIG_1")]
-            public static extern global::System.IntPtr NewAnimatablePropertyRegistration(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, int jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_AnimatablePropertyRegistration__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewAnimatablePropertyRegistration(IntPtr jarg1, string jarg2, int jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_AnimatablePropertyRegistration")]
-            public static extern void DeleteAnimatablePropertyRegistration(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_AnimatablePropertyRegistration", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteAnimatablePropertyRegistration(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ChildPropertyRegistration")]
-            public static extern global::System.IntPtr NewChildPropertyRegistration(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, int jarg3, int jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ChildPropertyRegistration", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewChildPropertyRegistration(IntPtr jarg1, string jarg2, int jarg3, int jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ChildPropertyRegistration")]
-            public static extern void DeleteChildPropertyRegistration(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ChildPropertyRegistration", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteChildPropertyRegistration(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_RelayoutContainer")]
-            public static extern void DeleteRelayoutContainer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_RelayoutContainer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteRelayoutContainer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RelayoutContainer_Add")]
-            public static extern void RelayoutContainerAdd(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RelayoutContainer_Add", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RelayoutContainerAdd(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.NDalicMeshVisual.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.NDalicMeshVisual.cs
@@ -15,32 +15,41 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class NDalicMeshVisual
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MESH_VISUAL_OBJECT_URL_get")]
-            public static extern int MeshVisualObjectUrlGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MESH_VISUAL_OBJECT_URL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MeshVisualObjectUrlGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MESH_VISUAL_MATERIAL_URL_get")]
-            public static extern int MeshVisualMaterialUrlGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MESH_VISUAL_MATERIAL_URL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MeshVisualMaterialUrlGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MESH_VISUAL_TEXTURES_PATH_get")]
-            public static extern int MeshVisualTexturesPathGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MESH_VISUAL_TEXTURES_PATH_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MeshVisualTexturesPathGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MESH_VISUAL_SHADING_MODE_get")]
-            public static extern int MeshVisualShadingModeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MESH_VISUAL_SHADING_MODE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MeshVisualShadingModeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MESH_VISUAL_USE_MIPMAPPING_get")]
-            public static extern int MeshVisualUseMipmappingGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MESH_VISUAL_USE_MIPMAPPING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MeshVisualUseMipmappingGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MESH_VISUAL_USE_SOFT_NORMALS_get")]
-            public static extern int MeshVisualUseSoftNormalsGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MESH_VISUAL_USE_SOFT_NORMALS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MeshVisualUseSoftNormalsGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MESH_VISUAL_LIGHT_POSITION_get")]
-            public static extern int MeshVisualLightPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MESH_VISUAL_LIGHT_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MeshVisualLightPositionGet();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.NDalicPrimitive.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.NDalicPrimitive.cs
@@ -15,47 +15,56 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class NdalicPrimitive
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_SHAPE_get")]
-            public static extern int PrimitiveVisualShapeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_SHAPE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PrimitiveVisualShapeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_MIX_COLOR_get")]
-            public static extern int PrimitiveVisualMixColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_MIX_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PrimitiveVisualMixColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_SLICES_get")]
-            public static extern int PrimitiveVisualSlicesGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_SLICES_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PrimitiveVisualSlicesGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_STACKS_get")]
-            public static extern int PrimitiveVisualStacksGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_STACKS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PrimitiveVisualStacksGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_SCALE_TOP_RADIUS_get")]
-            public static extern int PrimitiveVisualScaleTopRadiusGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_SCALE_TOP_RADIUS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PrimitiveVisualScaleTopRadiusGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_SCALE_BOTTOM_RADIUS_get")]
-            public static extern int PrimitiveVisualScaleBottomRadiusGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_SCALE_BOTTOM_RADIUS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PrimitiveVisualScaleBottomRadiusGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_SCALE_HEIGHT_get")]
-            public static extern int PrimitiveVisualScaleHeightGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_SCALE_HEIGHT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PrimitiveVisualScaleHeightGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_SCALE_RADIUS_get")]
-            public static extern int PrimitiveVisualScaleRadiusGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_SCALE_RADIUS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PrimitiveVisualScaleRadiusGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_SCALE_DIMENSIONS_get")]
-            public static extern int PrimitiveVisualScaleDimensionsGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_SCALE_DIMENSIONS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PrimitiveVisualScaleDimensionsGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_BEVEL_PERCENTAGE_get")]
-            public static extern int PrimitiveVisualBevelPercentageGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_BEVEL_PERCENTAGE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PrimitiveVisualBevelPercentageGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_BEVEL_SMOOTHNESS_get")]
-            public static extern int PrimitiveVisualBevelSmoothnessGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_BEVEL_SMOOTHNESS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PrimitiveVisualBevelSmoothnessGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_LIGHT_POSITION_get")]
-            public static extern int PrimitiveVisualLightPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PRIMITIVE_VISUAL_LIGHT_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PrimitiveVisualLightPositionGet();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.NDalicText.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.NDalicText.cs
@@ -15,38 +15,47 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class NDalicText
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TEXT_VISUAL_TEXT_get")]
-            public static extern int TextVisualTextGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TEXT_VISUAL_TEXT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TextVisualTextGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TEXT_VISUAL_FONT_FAMILY_get")]
-            public static extern int TextVisualFontFamilyGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TEXT_VISUAL_FONT_FAMILY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TextVisualFontFamilyGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TEXT_VISUAL_FONT_STYLE_get")]
-            public static extern int TextVisualFontStyleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TEXT_VISUAL_FONT_STYLE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TextVisualFontStyleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TEXT_VISUAL_POINT_SIZE_get")]
-            public static extern int TextVisualPointSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TEXT_VISUAL_POINT_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TextVisualPointSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TEXT_VISUAL_MULTI_LINE_get")]
-            public static extern int TextVisualMultiLineGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TEXT_VISUAL_MULTI_LINE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TextVisualMultiLineGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TEXT_VISUAL_HORIZONTAL_ALIGNMENT_get")]
-            public static extern int TextVisualHorizontalAlignmentGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TEXT_VISUAL_HORIZONTAL_ALIGNMENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TextVisualHorizontalAlignmentGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TEXT_VISUAL_VERTICAL_ALIGNMENT_get")]
-            public static extern int TextVisualVerticalAlignmentGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TEXT_VISUAL_VERTICAL_ALIGNMENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TextVisualVerticalAlignmentGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TEXT_VISUAL_TEXT_COLOR_get")]
-            public static extern int TextVisualTextColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TEXT_VISUAL_TEXT_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TextVisualTextColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TEXT_VISUAL_ENABLE_MARKUP_get")]
-            public static extern int TextVisualEnableMarkupGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TEXT_VISUAL_ENABLE_MARKUP_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TextVisualEnableMarkupGet();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.NDalicToolTip.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.NDalicToolTip.cs
@@ -15,53 +15,62 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class NDalicToolTip
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_CONTENT_get")]
-            public static extern int TooltipContentGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_CONTENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TooltipContentGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_LAYOUT_get")]
-            public static extern int TooltipLayoutGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_LAYOUT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TooltipLayoutGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_WAIT_TIME_get")]
-            public static extern int TooltipWaitTimeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_WAIT_TIME_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TooltipWaitTimeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_BACKGROUND_get")]
-            public static extern int TooltipBackgroundGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_BACKGROUND_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TooltipBackgroundGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_TAIL_get")]
-            public static extern int TooltipTailGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_TAIL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TooltipTailGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_POSITION_get")]
-            public static extern int TooltipPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TooltipPositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_HOVER_POINT_OFFSET_get")]
-            public static extern int TooltipHoverPointOffsetGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_HOVER_POINT_OFFSET_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TooltipHoverPointOffsetGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_MOVEMENT_THRESHOLD_get")]
-            public static extern int TooltipMovementThresholdGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_MOVEMENT_THRESHOLD_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TooltipMovementThresholdGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_DISAPPEAR_ON_MOVEMENT_get")]
-            public static extern int TooltipDisappearOnMovementGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_DISAPPEAR_ON_MOVEMENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TooltipDisappearOnMovementGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_BACKGROUND_VISUAL_get")]
-            public static extern int TooltipBackgroundVisualGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_BACKGROUND_VISUAL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TooltipBackgroundVisualGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_BACKGROUND_BORDER_get")]
-            public static extern int TooltipBackgroundBorderGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_BACKGROUND_BORDER_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TooltipBackgroundBorderGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_TAIL_VISIBILITY_get")]
-            public static extern int TooltipTailVisibilityGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_TAIL_VISIBILITY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TooltipTailVisibilityGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_TAIL_ABOVE_VISUAL_get")]
-            public static extern int TooltipTailAboveVisualGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_TAIL_ABOVE_VISUAL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TooltipTailAboveVisualGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_TAIL_BELOW_VISUAL_get")]
-            public static extern int TooltipTailBelowVisualGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TOOLTIP_TAIL_BELOW_VISUAL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TooltipTailBelowVisualGet();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.NDalicVisual.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.NDalicVisual.cs
@@ -15,32 +15,41 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class NDalicVisual
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VISUAL_PROPERTY_TYPE_get")]
-            public static extern int VisualPropertyTypeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VISUAL_PROPERTY_TYPE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int VisualPropertyTypeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VISUAL_PROPERTY_SHADER_get")]
-            public static extern int VisualPropertyShaderGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VISUAL_PROPERTY_SHADER_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int VisualPropertyShaderGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VISUAL_SHADER_VERTEX_get")]
-            public static extern int VisualShaderVertexGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VISUAL_SHADER_VERTEX_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int VisualShaderVertexGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VISUAL_SHADER_FRAGMENT_get")]
-            public static extern int VisualShaderFragmentGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VISUAL_SHADER_FRAGMENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int VisualShaderFragmentGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VISUAL_SHADER_SUBDIVIDE_GRID_X_get")]
-            public static extern int VisualShaderSubdivideGridXGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VISUAL_SHADER_SUBDIVIDE_GRID_X_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int VisualShaderSubdivideGridXGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VISUAL_SHADER_SUBDIVIDE_GRID_Y_get")]
-            public static extern int VisualShaderSubdivideGridYGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VISUAL_SHADER_SUBDIVIDE_GRID_Y_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int VisualShaderSubdivideGridYGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VISUAL_SHADER_HINTS_get")]
-            public static extern int VisualShaderHintsGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VISUAL_SHADER_HINTS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int VisualShaderHintsGet();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.NativeImageInterface.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.NativeImageInterface.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class NativeImageInterface
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageInterface_TargetTexture")]
-            public static extern uint TargetTexture(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageInterface_TargetTexture", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint TargetTexture(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageInterface_PrepareTexture")]
-            public static extern void PrepareTexture(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageInterface_PrepareTexture", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PrepareTexture(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageInterface_GetWidth")]
-            public static extern uint GetWidth(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageInterface_GetWidth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetWidth(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageInterface_GetHeight")]
-            public static extern uint GetHeight(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageInterface_GetHeight", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetHeight(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageInterface_RequiresBlending")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageInterface_RequiresBlending", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool RequiresBlending(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool RequiresBlending(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageInterface_GenerateUrl")]
-            public static extern global::System.IntPtr GenerateUrl(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageInterface_GenerateUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GenerateUrl(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageInterface_GenerateUrl_With_PreMultiplied")]
-            public static extern global::System.IntPtr GenerateUrl(global::System.Runtime.InteropServices.HandleRef jarg1, bool preMultiplied);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageInterface_GenerateUrl_With_PreMultiplied", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GenerateUrl(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool preMultiplied);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.NativeImageQueue.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.NativeImageQueue.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,46 +15,54 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
-    using global::System;
     internal static partial class Interop
     {
         internal static partial class NativeImageQueue
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_NativeImageQueuePtr_2")]
-            public static extern IntPtr NewHandle(uint queueCount, uint width, uint height, int colorFormat);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_NativeImageQueuePtr_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr NewHandle(uint queueCount, uint width, uint height, int colorFormat);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_GetPtr")]
-            public static extern IntPtr Get(IntPtr queue);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_GetPtr", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr Get(IntPtr queue);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_NativeImageQueuePtr")]
-            public static extern void Delete(IntPtr queue);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_NativeImageQueuePtr", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Delete(IntPtr queue);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_CanDequeueBuffer")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_CanDequeueBuffer", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool CanDequeueBuffer(IntPtr queue);
+            public static partial bool CanDequeueBuffer(IntPtr queue);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_DequeueBuffer")]
-            public static extern IntPtr DequeueBuffer(IntPtr queue, ref int width, ref int height, ref int colorDepth);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_DequeueBuffer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr DequeueBuffer(IntPtr queue, ref int width, ref int height, ref int colorDepth);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_EnqueueBuffer")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_EnqueueBuffer", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool EnqueueBuffer(IntPtr queue, IntPtr buffer);
+            public static partial bool EnqueueBuffer(IntPtr queue, IntPtr buffer);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_GetQueueCount")]
-            public static extern uint GetQueueCount(IntPtr queue);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_GetQueueCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetQueueCount(IntPtr queue);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_GenerateUrl")]
-            public static extern IntPtr GenerateUrl(IntPtr queue);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_GenerateUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GenerateUrl(IntPtr queue);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_GenerateUrl_With_PreMultiplied")]
-            public static extern IntPtr GenerateUrl(IntPtr queue, bool preMultiplied);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_GenerateUrl_With_PreMultiplied", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GenerateUrl(IntPtr queue, [MarshalAs(UnmanagedType.U1)] bool preMultiplied);
 
             // Platform dependency methods
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueuePtr_New_Handle_With_TbmQueue")]
-            public static extern IntPtr NewHandleWithTbmQueue(IntPtr csTbmQueue);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueuePtr_New_Handle_With_TbmQueue", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr NewHandleWithTbmQueue(IntPtr csTbmQueue);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.NativeImageSource.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.NativeImageSource.cs
@@ -15,41 +15,49 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
-    using global::System;
     internal static partial class Interop
     {
         internal static partial class NativeImageSource
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_New")]
-            public static extern IntPtr New(IntPtr handle);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr New(IntPtr handle);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_Delete")]
-            public static extern void Delete(IntPtr jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_Delete", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Delete(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_New_Handle")]
-            public static extern IntPtr NewHandle(uint jarg1, uint jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_New_Handle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr NewHandle(uint jarg1, uint jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_AcquireBuffer")]
-            public static extern IntPtr AcquireBuffer(IntPtr jarg1, ref int jarg2, ref int jarg3, ref int jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_AcquireBuffer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AcquireBuffer(IntPtr jarg1, ref int jarg2, ref int jarg3, ref int jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_ReleaseBuffer")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_ReleaseBuffer", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool ReleaseBuffer(IntPtr jarg1);
+            public static partial bool ReleaseBuffer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_GenerateUrl")]
-            public static extern IntPtr GenerateUrl(IntPtr handle);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_GenerateUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GenerateUrl(IntPtr handle);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_GenerateUrl_With_PreMultiplied")]
-            public static extern IntPtr GenerateUrl(IntPtr handle, bool preMultiplied);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_GenerateUrl_With_PreMultiplied", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GenerateUrl(IntPtr handle, [MarshalAs(UnmanagedType.U1)] bool preMultiplied);
 
             // Platform dependency methods
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_New_Handle_With_TbmSurface")]
-            public static extern IntPtr NewHandleWithTbmSurface(IntPtr csTbmSurface);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_New_Handle_With_TbmSurface", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr NewHandleWithTbmSurface(IntPtr csTbmSurface);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_SetSource")]
-            public static extern void SetSource(IntPtr handle, IntPtr csTbmSurface);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_SetSource", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetSource(IntPtr handle, IntPtr csTbmSurface);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PaddingType.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PaddingType.cs
@@ -15,59 +15,68 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class PaddingType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PaddingType__SWIG_0")]
-            public static extern global::System.IntPtr NewPaddingType();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PaddingType__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPaddingType();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PaddingType__SWIG_1")]
-            public static extern global::System.IntPtr NewPaddingType(float jarg1, float jarg2, float jarg3, float jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PaddingType__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPaddingType(float jarg1, float jarg2, float jarg3, float jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_Set")]
-            public static extern void Set(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4, float jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_Set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Set(IntPtr jarg1, float jarg2, float jarg3, float jarg4, float jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_left_set")]
-            public static extern void LeftSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_left_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LeftSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_left_get")]
-            public static extern float LeftGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_left_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float LeftGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_start_set")]
-            public static extern void StartSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_start_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void StartSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_start_get")]
-            public static extern float StartGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_start_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float StartGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_right_set")]
-            public static extern void RightSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_right_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RightSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_right_get")]
-            public static extern float RightGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_right_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RightGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_end_set")]
-            public static extern void EndSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_end_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EndSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_end_get")]
-            public static extern float EndGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_end_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float EndGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_bottom_set")]
-            public static extern void BottomSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_bottom_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void BottomSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_bottom_get")]
-            public static extern float BottomGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_bottom_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float BottomGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_top_set")]
-            public static extern void TopSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_top_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TopSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_top_get")]
-            public static extern float TopGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PaddingType_top_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float TopGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PaddingType")]
-            public static extern void DeletePaddingType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PaddingType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePaddingType(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PanGestureDetector.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PanGestureDetector.cs
@@ -15,159 +15,168 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class PanGestureDetector
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_SWIGUpcast")]
-            public static extern global::System.IntPtr PanGestureUpcast(global::System.IntPtr jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_SWIGUpcast", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr PanGestureUpcast(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_Property_SCREEN_POSITION_get")]
-            public static extern int ScreenPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_Property_SCREEN_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScreenPositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_Property_SCREEN_DISPLACEMENT_get")]
-            public static extern int ScreenDisplacementGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_Property_SCREEN_DISPLACEMENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScreenDisplacementGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_Property_SCREEN_VELOCITY_get")]
-            public static extern int ScreenVelocityGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_Property_SCREEN_VELOCITY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScreenVelocityGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_Property_LOCAL_POSITION_get")]
-            public static extern int LocalPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_Property_LOCAL_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LocalPositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_Property_LOCAL_DISPLACEMENT_get")]
-            public static extern int LocalDisplacementGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_Property_LOCAL_DISPLACEMENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LocalDisplacementGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_Property_LOCAL_VELOCITY_get")]
-            public static extern int LocalVelocityGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_Property_LOCAL_VELOCITY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LocalVelocityGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_Property_PANNING_get")]
-            public static extern int PanningGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_Property_PANNING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PanningGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PanGestureDetector")]
-            public static extern void DeletePanGestureDetector(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PanGestureDetector", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePanGestureDetector(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PanGestureDetector__SWIG_1")]
-            public static extern global::System.IntPtr NewPanGestureDetector(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PanGestureDetector__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPanGestureDetector(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_SetMinimumTouchesRequired")]
-            public static extern void SetMinimumTouchesRequired(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_SetMinimumTouchesRequired", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMinimumTouchesRequired(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_SetMaximumTouchesRequired")]
-            public static extern void SetMaximumTouchesRequired(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_SetMaximumTouchesRequired", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMaximumTouchesRequired(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_SetMaximumMotionEventAge")]
-            public static extern void SetMaximumMotionEventAge(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_SetMaximumMotionEventAge", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMaximumMotionEventAge(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_GetMinimumTouchesRequired")]
-            public static extern uint GetMinimumTouchesRequired(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_GetMinimumTouchesRequired", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetMinimumTouchesRequired(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_GetMaximumTouchesRequired")]
-            public static extern uint GetMaximumTouchesRequired(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_GetMaximumTouchesRequired", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetMaximumTouchesRequired(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_GetMaximumMotionEventAge")]
-            public static extern uint GetMaximumMotionEventAge(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_GetMaximumMotionEventAge", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetMaximumMotionEventAge(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_AddAngle__SWIG_0")]
-            public static extern void AddAngle(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_AddAngle__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddAngle(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_AddAngle__SWIG_1")]
-            public static extern void AddAngle(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_AddAngle__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddAngle(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_AddDirection__SWIG_0")]
-            public static extern void AddDirection(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_AddDirection__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddDirection(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_AddDirection__SWIG_1")]
-            public static extern void AddDirection(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_AddDirection__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddDirection(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_GetAngleCount")]
-            public static extern uint GetAngleCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_GetAngleCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetAngleCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_GetAngle")]
-            public static extern global::System.IntPtr GetAngle(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_GetAngle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetAngle(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_ClearAngles")]
-            public static extern void ClearAngles(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_ClearAngles", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ClearAngles(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_RemoveAngle")]
-            public static extern void RemoveAngle(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_RemoveAngle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemoveAngle(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_RemoveDirection")]
-            public static extern void RemoveDirection(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_RemoveDirection", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemoveDirection(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_DetectedSignal")]
-            public static extern global::System.IntPtr DetectedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_DetectedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DetectedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_SetPanGestureProperties")]
-            public static extern void SetPanGestureProperties(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_SetPanGestureProperties", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPanGestureProperties(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_New")]
-            public static extern global::System.IntPtr PanGestureNew(int jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr PanGestureNew(int jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PanGesture")]
-            public static extern void DeletePanGesture(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PanGesture", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePanGesture(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_velocity_get")]
-            public static extern global::System.IntPtr PanGestureVelocityGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_velocity_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr PanGestureVelocityGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_displacement_get")]
-            public static extern global::System.IntPtr PanGestureDisplacementGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_displacement_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr PanGestureDisplacementGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_position_get")]
-            public static extern global::System.IntPtr PanGesturePositionGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_position_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr PanGesturePositionGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_screenVelocity_get")]
-            public static extern global::System.IntPtr PanGestureScreenVelocityGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_screenVelocity_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr PanGestureScreenVelocityGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_screenDisplacement_get")]
-            public static extern global::System.IntPtr PanGestureScreenDisplacementGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_screenDisplacement_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr PanGestureScreenDisplacementGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_screenPosition_get")]
-            public static extern global::System.IntPtr PanGestureScreenPositionGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_screenPosition_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr PanGestureScreenPositionGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_numberOfTouches_get")]
-            public static extern uint PanGestureNumberOfTouchesGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_numberOfTouches_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint PanGestureNumberOfTouchesGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_GetSpeed")]
-            public static extern float PanGestureGetSpeed(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_GetSpeed", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float PanGestureGetSpeed(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_GetDistance")]
-            public static extern float PanGestureGetDistance(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_GetDistance", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float PanGestureGetDistance(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_GetScreenSpeed")]
-            public static extern float PanGestureGetScreenSpeed(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_GetScreenSpeed", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float PanGestureGetScreenSpeed(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_GetScreenDistance")]
-            public static extern float PanGestureGetScreenDistance(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_GetScreenDistance", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float PanGestureGetScreenDistance(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetectedSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetectedSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool PanGestureDetectedSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool PanGestureDetectedSignalEmpty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetectedSignal_GetConnectionCount")]
-            public static extern uint PanGestureDetectedSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetectedSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint PanGestureDetectedSignalGetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetectedSignal_Connect")]
-            public static extern void PanGestureDetectedSignalConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetectedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PanGestureDetectedSignalConnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetectedSignal_Disconnect")]
-            public static extern void PanGestureDetectedSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetectedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PanGestureDetectedSignalDisconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetectedSignal_Emit")]
-            public static extern void PanGestureDetectedSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetectedSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PanGestureDetectedSignalEmit(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PanGestureDetectedSignal")]
-            public static extern global::System.IntPtr NewPanGestureDetectedSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PanGestureDetectedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPanGestureDetectedSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PanGestureDetectedSignal")]
-            public static extern void DeletePanGestureDetectedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PanGestureDetectedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePanGestureDetectedSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Particle.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Particle.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2023 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,8 +15,9 @@
  *
  */
 
-using System;
+using global::System;
 using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI.ParticleSystem
 {
@@ -24,30 +25,35 @@ namespace Tizen.NUI.ParticleSystem
     {
         internal static partial class Particle
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Particle_ReadFloat")]
-            internal static extern float ReadFloat(global::System.Runtime.InteropServices.HandleRef jarg1, uint streamIndex, uint particleIndex);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Particle_ReadFloat", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern float ReadFloat(IntPtr jarg1, uint streamIndex, uint particleIndex);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Particle_ReadVector2")]
-            internal static extern global::System.IntPtr ReadVector2(global::System.Runtime.InteropServices.HandleRef jarg1, uint streamIndex, uint particleIndex);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Particle_ReadVector2", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern global::System.IntPtr ReadVector2(IntPtr jarg1, uint streamIndex, uint particleIndex);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Particle_ReadVector3")]
-            internal static extern global::System.IntPtr ReadVector3(global::System.Runtime.InteropServices.HandleRef jarg1, uint streamIndex, uint particleIndex);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Particle_ReadVector3", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern global::System.IntPtr ReadVector3(IntPtr jarg1, uint streamIndex, uint particleIndex);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Particle_ReadVector4")]
-            internal static extern global::System.IntPtr ReadVector4(global::System.Runtime.InteropServices.HandleRef jarg1, uint streamIndex, uint particleIndex);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Particle_ReadVector4", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern global::System.IntPtr ReadVector4(IntPtr jarg1, uint streamIndex, uint particleIndex);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Particle_WriteFloat")]
-            internal static extern void WriteFloat(global::System.Runtime.InteropServices.HandleRef jarg1, uint streamIndex, uint particleIndex, float value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Particle_WriteFloat", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern void WriteFloat(IntPtr jarg1, uint streamIndex, uint particleIndex, float value);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Particle_WriteVector2")]
-            internal static extern void WriteVector2(global::System.Runtime.InteropServices.HandleRef jarg1, uint streamIndex, uint particleIndex, HandleRef value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Particle_WriteVector2", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern void WriteVector2(IntPtr jarg1, uint streamIndex, uint particleIndex, IntPtr value);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Particle_WriteVector3")]
-            internal static extern void WriteVector3(global::System.Runtime.InteropServices.HandleRef jarg1, uint streamIndex, uint particleIndex, HandleRef value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Particle_WriteVector3", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern void WriteVector3(IntPtr jarg1, uint streamIndex, uint particleIndex, IntPtr value);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Particle_WriteVector4")]
-            internal static extern void WriteVector4(global::System.Runtime.InteropServices.HandleRef jarg1, uint streamIndex, uint particleIndex, HandleRef value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Particle_WriteVector4", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern void WriteVector4(IntPtr jarg1, uint streamIndex, uint particleIndex, IntPtr value);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ParticleEmitter.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ParticleEmitter.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2023 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,9 @@
  *
  */
 
+using global::System;
 using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI.ParticleSystem
 {
@@ -23,105 +25,110 @@ namespace Tizen.NUI.ParticleSystem
     {
         internal static partial class ParticleEmitter
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ParticleEmitter")]
-            internal static extern void DeleteParticleEmitter(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ParticleEmitter", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern void DeleteParticleEmitter(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_New_SWIG_0")]
-            internal static extern global::System.IntPtr New(HandleRef view);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_New_SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern global::System.IntPtr New(IntPtr view);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_Assign")]
-            internal static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_SetSource")]
-            internal static extern void SetSource(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_SetSource", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern void SetSource(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_SetDomain")]
-            internal static extern void SetDomain(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_SetDomain", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern void SetDomain(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_SetRenderer")]
-            internal static extern void SetRenderer(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_SetRenderer", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern void SetRenderer(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_AddModifier")]
-            internal static extern void AddModifier(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_AddModifier", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern void AddModifier(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_SetParticleCount")]
-            internal static extern void SetParticleCount(global::System.Runtime.InteropServices.HandleRef jarg1, uint count);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_SetParticleCount", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern void SetParticleCount(IntPtr jarg1, uint count);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_GetParticleCount")]
-            internal static extern uint GetParticleCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_GetParticleCount", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern uint GetParticleCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_SetEmissionRate")]
-            internal static extern void SetEmissionRate(global::System.Runtime.InteropServices.HandleRef jarg1, uint count);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_SetEmissionRate", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern void SetEmissionRate(IntPtr jarg1, uint count);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_SetInitialParticleCount")]
-            internal static extern void SetInitialParticleCount(global::System.Runtime.InteropServices.HandleRef jarg1, uint count);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_SetInitialParticleCount", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern void SetInitialParticleCount(IntPtr jarg1, uint count);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_SetActiveParticlesLimit")]
-            internal static extern void SetActiveParticlesLimit(global::System.Runtime.InteropServices.HandleRef jarg1, uint count);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_SetActiveParticlesLimit", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern void SetActiveParticlesLimit(IntPtr jarg1, uint count);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_Start")]
-            internal static extern void Start(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_Start", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern void Start(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_Stop")]
-            internal static extern void Stop(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_Stop", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern void Stop(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_RemoveModifierAt")]
-            internal static extern void RemoveModifierAt(global::System.Runtime.InteropServices.HandleRef jarg1, uint index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_RemoveModifierAt", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern void RemoveModifierAt(IntPtr jarg1, uint index);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_GetParticleList")]
-            internal static extern global::System.IntPtr GetParticleList(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_GetParticleList", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern global::System.IntPtr GetParticleList(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_GetSource")]
-            internal static extern global::System.IntPtr GetSource(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_GetSource", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern global::System.IntPtr GetSource(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_GetDomain")]
-            internal static extern global::System.IntPtr GetDomain(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_GetDomain", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern global::System.IntPtr GetDomain(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_GetRenderer")]
-            internal static extern global::System.IntPtr GetRenderer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_GetRenderer", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern global::System.IntPtr GetRenderer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_GetEmissionRate")]
-            internal static extern uint GetEmissionRate(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_GetEmissionRate", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern uint GetEmissionRate(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_GetInitialParticleCount")]
-            internal static extern uint GetInitialParticleCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_GetInitialParticleCount", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern uint GetInitialParticleCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_GetActiveParticleLimit")]
-            internal static extern uint GetActiveParticleLimit(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_GetActiveParticleLimit", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern uint GetActiveParticleLimit(IntPtr jarg1);
 
             // ParticleRenderer
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleRenderer_SetTexture")]
-            internal static extern void SetTexture(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleRenderer_SetTexture", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern void SetTexture(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleRenderer_SetBlendingMode")]
-            internal static extern void SetBlendingMode(global::System.Runtime.InteropServices.HandleRef jarg1, ParticleBlendingMode mode);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleRenderer_SetBlendingMode", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern void SetBlendingMode(IntPtr jarg1, ParticleBlendingMode mode);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleRenderer_GetBlendingMode")]
-            internal static extern int GetBlendingMode(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleRenderer_GetBlendingMode", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern int GetBlendingMode(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_NewParticle")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_NewParticle", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern int NewParticle(global::System.IntPtr emitter, float lifetime);
 
             // ParticleList
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleList_AddLocalStreamInt")]
-            internal static extern uint AddLocalStreamInt(global::System.Runtime.InteropServices.HandleRef jarg1, int defaultValue);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleList_AddLocalStreamInt", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern uint AddLocalStreamInt(IntPtr jarg1, int defaultValue);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleList_AddLocalStreamFloat")]
-            internal static extern uint AddLocalStreamFloat(global::System.Runtime.InteropServices.HandleRef jarg1, float defaultValue);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleList_AddLocalStreamFloat", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern uint AddLocalStreamFloat(IntPtr jarg1, float defaultValue);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleList_AddLocalStreamVector2")]
-            internal static extern uint AddLocalStreamVector2(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.IntPtr defaultValue);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleList_AddLocalStreamVector2", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern uint AddLocalStreamVector2(IntPtr jarg1, global::System.IntPtr defaultValue);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleList_AddLocalStreamVector3")]
-            internal static extern uint AddLocalStreamVector3(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.IntPtr defaultValue);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleList_AddLocalStreamVector3", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern uint AddLocalStreamVector3(IntPtr jarg1, global::System.IntPtr defaultValue);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleList_AddLocalStreamVector4")]
-            internal static extern uint AddLocalStreamVector4(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.IntPtr defaultValue);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleList_AddLocalStreamVector4", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern uint AddLocalStreamVector4(IntPtr jarg1, global::System.IntPtr defaultValue);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleList_GetDefaultStreamIndex")]
-            internal static extern int GetDefaultStreamIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint builtInStream );
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleList_GetDefaultStreamIndex", StringMarshalling = StringMarshalling.Utf8)]
+            internal static extern int GetDefaultStreamIndex(IntPtr jarg1, uint builtInStream );
 
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ParticleModifier.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ParticleModifier.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2023 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,9 +15,10 @@
  *
  */
 
+using global::System;
 using global::System.Runtime.InteropServices;
-using System.Reflection;
-using System;
+using global::System.Runtime.InteropServices.Marshalling;
+using global::System.Reflection;
 
 namespace Tizen.NUI.ParticleSystem
 {
@@ -27,8 +28,10 @@ namespace Tizen.NUI.ParticleSystem
         {
             internal delegate void ParticleModifierUpdateInvokerType(IntPtr ptr, IntPtr particleListPtr, uint first, uint count);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleModifier_New_SWIG_0")]
-            public static extern global::System.IntPtr New(ParticleModifierUpdateInvokerType updateInvoker, out IntPtr basePtr);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleModifier_New_SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(ParticleModifierUpdateInvokerType updateInvoker, out IntPtr basePtr);
         }
     }
 }
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ParticleSource.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ParticleSource.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2023 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,9 +15,10 @@
  *
  */
 
+using global::System;
 using global::System.Runtime.InteropServices;
-using System.Reflection;
-using System;
+using global::System.Runtime.InteropServices.Marshalling;
+using global::System.Reflection;
 
 namespace Tizen.NUI.ParticleSystem
 {
@@ -28,8 +29,10 @@ namespace Tizen.NUI.ParticleSystem
             internal delegate void ParticleSourceInitInvokerType(IntPtr ptr);
             internal delegate uint ParticleSourceUpdateInvokerType(IntPtr ptr, uint count);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleSource_New_SWIG_0")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleSource_New_SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
             internal static extern global::System.IntPtr New(ParticleSourceInitInvokerType initInvoker, ParticleSourceUpdateInvokerType updateInvoker, out IntPtr refObject);
         }
     }
 }
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Path.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Path.cs
@@ -15,44 +15,53 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Path
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_Property_POINTS_get")]
-            public static extern int PointsGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_Property_POINTS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PointsGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_Property_CONTROL_POINTS_get")]
-            public static extern int ControlPointsGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_Property_CONTROL_POINTS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ControlPointsGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Path")]
-            public static extern void DeletePath(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Path", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePath(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_AddPoint")]
-            public static extern void AddPoint(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_AddPoint", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddPoint(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_AddControlPoint")]
-            public static extern void AddControlPoint(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_AddControlPoint", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddControlPoint(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_GenerateControlPoints")]
-            public static extern void GenerateControlPoints(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_GenerateControlPoints", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GenerateControlPoints(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_Sample")]
-            public static extern void Sample(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_Sample", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Sample(IntPtr jarg1, float jarg2, IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_GetPoint")]
-            public static extern global::System.IntPtr GetPoint(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_GetPoint", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetPoint(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_GetControlPoint")]
-            public static extern global::System.IntPtr GetControlPoint(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_GetControlPoint", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetControlPoint(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_GetPointCount")]
-            public static extern uint GetPointCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Path_GetPointCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetPointCount(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PathConstrainer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PathConstrainer.cs
@@ -15,38 +15,47 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class PathConstrainer
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PathConstrainer_Property_FORWARD_get")]
-            public static extern int ForwardGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PathConstrainer_Property_FORWARD_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ForwardGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PathConstrainer_Property_POINTS_get")]
-            public static extern int PointsGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PathConstrainer_Property_POINTS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PointsGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PathConstrainer_Property_CONTROL_POINTS_get")]
-            public static extern int ControlPointsGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PathConstrainer_Property_CONTROL_POINTS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ControlPointsGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PathConstrainer_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PathConstrainer_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PathConstrainer")]
-            public static extern void DeletePathConstrainer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PathConstrainer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePathConstrainer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PathConstrainer_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PathConstrainer_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PathConstrainer_Apply__SWIG_0")]
-            public static extern void Apply(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, global::System.Runtime.InteropServices.HandleRef jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PathConstrainer_Apply__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Apply(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4, IntPtr jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PathConstrainer_Apply__SWIG_1")]
-            public static extern void Apply(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PathConstrainer_Apply__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Apply(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PathConstrainer_Remove")]
-            public static extern void Remove(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PathConstrainer_Remove", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Remove(IntPtr jarg1, IntPtr jarg2);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Picture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Picture.cs
@@ -15,25 +15,34 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Picture
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Picture_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Picture_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Picture_Load")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Picture_Load", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Load(global::System.Runtime.InteropServices.HandleRef picture, string url);
+            public static partial bool Load(IntPtr picture, string url);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Picture_SetSize")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Picture_SetSize", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SetSize(global::System.Runtime.InteropServices.HandleRef picture, global::System.Runtime.InteropServices.HandleRef size);
+            public static partial bool SetSize(IntPtr picture, IntPtr size);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Picture_GetSize")]
-            public static extern global::System.IntPtr GetSize(global::System.Runtime.InteropServices.HandleRef picture);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Picture_GetSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetSize(IntPtr picture);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PinchGesture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PinchGesture.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,60 +26,65 @@ namespace Tizen.NUI
         internal static partial class PinchGesture
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetector_New")]
-            public static extern global::System.IntPtr PinchGestureDetectorNew();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetector_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr PinchGestureDetectorNew();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PinchGestureDetector")]
-            public static extern void DeletePinchGestureDetector(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PinchGestureDetector", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePinchGestureDetector(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PinchGestureDetector__SWIG_1")]
-            public static extern global::System.IntPtr NewPinchGestureDetector(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PinchGestureDetector__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPinchGestureDetector(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetector_Assign")]
-            public static extern global::System.IntPtr PinchGestureDetectorAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetector_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr PinchGestureDetectorAssign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetector_DetectedSignal")]
-            public static extern global::System.IntPtr PinchGestureDetectorDetectedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetector_DetectedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr PinchGestureDetectorDetectedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGesture_New")]
-            public static extern global::System.IntPtr New(int jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGesture_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PinchGesture")]
-            public static extern void DeletePinchGesture(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PinchGesture", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePinchGesture(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGesture_scale_get")]
-            public static extern float ScaleGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGesture_scale_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float ScaleGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGesture_speed_get")]
-            public static extern float SpeedGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGesture_speed_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float SpeedGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGesture_screenCenterPoint_get")]
-            public static extern global::System.IntPtr ScreenCenterPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGesture_screenCenterPoint_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ScreenCenterPointGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGesture_localCenterPoint_get")]
-            public static extern global::System.IntPtr LocalCenterPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGesture_localCenterPoint_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr LocalCenterPointGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetectedSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetectedSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool PinchGestureDetectedSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool PinchGestureDetectedSignalEmpty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetectedSignal_GetConnectionCount")]
-            public static extern uint PinchGestureDetectedSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetectedSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint PinchGestureDetectedSignalGetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetectedSignal_Connect")]
-            public static extern void PinchGestureDetectedSignalConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetectedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PinchGestureDetectedSignalConnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetectedSignal_Disconnect")]
-            public static extern void PinchGestureDetectedSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetectedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PinchGestureDetectedSignalDisconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetectedSignal_Emit")]
-            public static extern void PinchGestureDetectedSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetectedSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PinchGestureDetectedSignalEmit(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PinchGestureDetectedSignal")]
-            public static extern global::System.IntPtr NewPinchGestureDetectedSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PinchGestureDetectedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPinchGestureDetectedSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PinchGestureDetectedSignal")]
-            public static extern void DeletePinchGestureDetectedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PinchGestureDetectedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePinchGestureDetectedSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PixelBuffer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PixelBuffer.cs
@@ -15,71 +15,79 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
-
     internal static partial class Interop
     {
         internal static partial class PixelBuffer
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_New")]
-            public static extern global::System.IntPtr New(uint jarg1, uint jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(uint jarg1, uint jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PixelBuffer")]
-            public static extern void DeletePixelBuffer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PixelBuffer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePixelBuffer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PixelBuffer__SWIG_1")]
-            public static extern global::System.IntPtr NewPixelBuffer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PixelBuffer__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPixelBuffer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_Convert")]
-            public static extern global::System.IntPtr Convert(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_Convert", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Convert(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_CreatePixelData")]
-            public static extern global::System.IntPtr CreatePixelData(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_CreatePixelData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CreatePixelData(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_GetBuffer")]
-            public static extern global::System.IntPtr GetBuffer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_GetBuffer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetBuffer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_GetWidth")]
-            public static extern uint GetWidth(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_GetWidth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetWidth(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_GetHeight")]
-            public static extern uint GetHeight(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_GetHeight", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetHeight(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_GetPixelFormat")]
-            public static extern int GetPixelFormat(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_GetPixelFormat", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetPixelFormat(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_GetStrideBytes")]
-            public static extern uint GetStrideBytes(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_GetStrideBytes", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetStrideBytes(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_ApplyMask__SWIG_0")]
-            public static extern void ApplyMask(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, float jarg3, bool jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_ApplyMask__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ApplyMask(IntPtr jarg1, IntPtr jarg2, float jarg3, [MarshalAs(UnmanagedType.U1)] bool jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_ApplyMask__SWIG_1")]
-            public static extern void ApplyMask(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_ApplyMask__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ApplyMask(IntPtr jarg1, IntPtr jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_ApplyMask__SWIG_2")]
-            public static extern void ApplyMask(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_ApplyMask__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ApplyMask(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_ApplyGaussianBlur")]
-            public static extern void ApplyGaussianBlur(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_ApplyGaussianBlur", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ApplyGaussianBlur(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_Crop")]
-            public static extern void Crop(global::System.Runtime.InteropServices.HandleRef jarg1, ushort jarg2, ushort jarg3, ushort jarg4, ushort jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_Crop", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Crop(IntPtr jarg1, ushort jarg2, ushort jarg3, ushort jarg4, ushort jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_Resize")]
-            public static extern void Resize(global::System.Runtime.InteropServices.HandleRef jarg1, ushort jarg2, ushort jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_Resize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Resize(IntPtr jarg1, ushort jarg2, ushort jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_Rotate")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_Rotate", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Rotate(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool Rotate(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_GetBrightness")]
-            public static extern uint GetBrightness(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelBuffer_GetBrightness", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetBrightness(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PixelData.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PixelData.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,29 +26,34 @@ namespace Tizen.NUI
         internal static partial class PixelData
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelData_New")]
-            public static extern global::System.IntPtr New([global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] byte[] jarg1, uint jarg2, uint jarg3, uint jarg4, int jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelData_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New([global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] byte[] jarg1, uint jarg2, uint jarg3, uint jarg4, int jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PixelData")]
-            public static extern void DeletePixelData(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PixelData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePixelData(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelData_GetWidth")]
-            public static extern uint GetWidth(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelData_GetWidth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetWidth(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelData_GetHeight")]
-            public static extern uint GetHeight(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelData_GetHeight", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetHeight(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelData_GetPixelFormat")]
-            public static extern int GetPixelFormat(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelData_GetPixelFormat", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetPixelFormat(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelData_GetStrideBytes")]
-            public static extern uint GetStrideBytes(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelData_GetStrideBytes", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetStrideBytes(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelData_GenerateUrl")]
-            public static extern global::System.IntPtr GenerateUrl(global::System.IntPtr handle);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelData_GenerateUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GenerateUrl(global::System.IntPtr handle);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelData_GenerateUrl_With_PreMultiplied")]
-            public static extern global::System.IntPtr GenerateUrl(global::System.IntPtr handle, bool preMultiplied);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelData_GenerateUrl_With_PreMultiplied", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GenerateUrl(global::System.IntPtr handle, [MarshalAs(UnmanagedType.U1)] bool preMultiplied);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PointerConstraints.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PointerConstraints.cs
@@ -15,31 +15,40 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class PointerConstraints
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PointerConstraintsEvent__SWIG_0")]
-            public static extern global::System.IntPtr NewPointerConstraints(int x, int y, bool locked, bool confined);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PointerConstraintsEvent__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPointerConstraints(int x, int y, [MarshalAs(UnmanagedType.U1)] bool locked, [MarshalAs(UnmanagedType.U1)] bool confined);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PointerConstraintsEvent")]
-            public static extern void DeletePointerConstraints(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PointerConstraintsEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePointerConstraints(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PointerConstraintsEvent_x_get")]
-            public static extern int XGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PointerConstraintsEvent_x_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int XGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PointerConstraintsEvent_y_get")]
-            public static extern int YGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PointerConstraintsEvent_y_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int YGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PointerConstraintsEvent_locked_get")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PointerConstraintsEvent_locked_get", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool LockedGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool LockedGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PointerConstraintsEvent_confined_get")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PointerConstraintsEvent_confined_get", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool ConfinedGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool ConfinedGet(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PreFocusSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PreFocusSignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class PreFocusSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardPreFocusChangeSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardPreFocusChangeSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardPreFocusChangeSignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardPreFocusChangeSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardPreFocusChangeSignal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, Tizen.NUI.FocusManager.PreFocusChangeEventCallback delegate1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardPreFocusChangeSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, Tizen.NUI.FocusManager.PreFocusChangeEventCallback delegate1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardPreFocusChangeSignal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardPreFocusChangeSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardPreFocusChangeSignal_Emit")]
-            public static extern global::System.IntPtr Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, int jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardPreFocusChangeSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Emit(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, int jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_new_KeyboardPreFocusChangeSignal")]
-            public static extern global::System.IntPtr NewPreFocusChangeSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_new_KeyboardPreFocusChangeSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPreFocusChangeSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_delete_KeyboardPreFocusChangeSignal")]
-            public static extern void DeletePreFocusChangeSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_delete_KeyboardPreFocusChangeSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePreFocusChangeSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ProcessorController.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ProcessorController.cs
@@ -15,29 +15,38 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class ProcessorController
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ProcessorController_Without_Initialize")]
-            public static extern global::System.IntPtr NewWithoutInitialize();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ProcessorController_Without_Initialize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewWithoutInitialize();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ProcessorController")]
-            public static extern void DeleteProcessorController(global::System.Runtime.InteropServices.HandleRef processorController);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ProcessorController", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteProcessorController(IntPtr processorController);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ProcessorController_Initialize")]
-            public static extern void Initialize(global::System.Runtime.InteropServices.HandleRef processorController);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ProcessorController_Initialize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Initialize(IntPtr processorController);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ProcessorController_SetCallback")]
-            public static extern void SetCallback(global::System.Runtime.InteropServices.HandleRef processorController, Tizen.NUI.ProcessorController.ProcessorEventHandler processorCallback);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ProcessorController_SetCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetCallback(IntPtr processorController, Tizen.NUI.ProcessorController.ProcessorEventHandler processorCallback);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ProcessorController_RemoveCallback")]
-            public static extern void RemoveCallback(global::System.Runtime.InteropServices.HandleRef processorController, Tizen.NUI.ProcessorController.ProcessorEventHandler processorCallback);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ProcessorController_RemoveCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemoveCallback(IntPtr processorController, Tizen.NUI.ProcessorController.ProcessorEventHandler processorCallback);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ProcessorController_Awake")]
-            public static extern void Awake(global::System.Runtime.InteropServices.HandleRef processorController);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ProcessorController_Awake", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Awake(IntPtr processorController);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Property.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Property.cs
@@ -15,135 +15,144 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Property
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_INVALID_INDEX_get")]
-            public static extern int InvalidIndexGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_INVALID_INDEX_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InvalidIndexGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_INVALID_KEY_get")]
-            public static extern int InvalidKeyGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_INVALID_KEY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InvalidKeyGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_INVALID_COMPONENT_INDEX_get")]
-            public static extern int InvalidComponentIndexGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_INVALID_COMPONENT_INDEX_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InvalidComponentIndexGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property__SWIG_0")]
-            public static extern global::System.IntPtr NewProperty(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewProperty(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property__SWIG_2")]
-            public static extern global::System.IntPtr NewProperty(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewProperty(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Property")]
-            public static extern void DeleteProperty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Property", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteProperty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property__object_set")]
-            public static extern void ObjectSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property__object_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ObjectSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property__object_get")]
-            public static extern global::System.IntPtr ObjectGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property__object_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ObjectGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_propertyIndex_set")]
-            public static extern void PropertyIndexSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_propertyIndex_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PropertyIndexSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_propertyIndex_get")]
-            public static extern int PropertyIndexGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_propertyIndex_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PropertyIndexGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Array__SWIG_0")]
-            public static extern global::System.IntPtr NewPropertyArray();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Array__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyArray();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Array__SWIG_1")]
-            public static extern global::System.IntPtr NewPropertyArray(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Array__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyArray(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Property_Array")]
-            public static extern void DeletePropertyArray(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Property_Array", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePropertyArray(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_Size")]
-            public static extern uint ArraySize(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_Size", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint ArraySize(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_Count")]
-            public static extern uint ArrayCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_Count", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint ArrayCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool ArrayEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool ArrayEmpty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_Clear")]
-            public static extern void ArrayClear(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_Clear", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ArrayClear(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_Reserve")]
-            public static extern void ArrayReserve(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_Reserve", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ArrayReserve(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_Resize")]
-            public static extern void ArrayResize(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_Resize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ArrayResize(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_Capacity")]
-            public static extern uint ArrayCapacity(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_Capacity", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint ArrayCapacity(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_PushBack")]
-            public static extern void ArrayPushBack(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_PushBack", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ArrayPushBack(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_Add")]
-            public static extern global::System.IntPtr ArrayAdd(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_Add", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ArrayAdd(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_GetElementAt__SWIG_0")]
-            public static extern global::System.IntPtr ArrayGetElementAt(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_GetElementAt__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ArrayGetElementAt(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_ValueOfIndex__SWIG_0")]
-            public static extern global::System.IntPtr ArrayValueOfIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Array_ValueOfIndex__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ArrayValueOfIndex(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_type_set")]
-            public static extern void KeyTypeSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_type_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void KeyTypeSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_type_get")]
-            public static extern int KeyTypeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_type_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int KeyTypeGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_indexKey_set")]
-            public static extern void KeyIndexKeySet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_indexKey_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void KeyIndexKeySet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_indexKey_get")]
-            public static extern int KeyIndexKeyGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_indexKey_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int KeyIndexKeyGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_stringKey_set")]
-            public static extern void KeyStringKeySet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_stringKey_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void KeyStringKeySet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_stringKey_get")]
-            public static extern string KeyStringKeyGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_stringKey_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string KeyStringKeyGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Key__SWIG_0")]
-            public static extern global::System.IntPtr NewPropertyKey(string jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Key__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyKey(string jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Key__SWIG_1")]
-            public static extern global::System.IntPtr NewPropertyKey(int jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Key__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyKey(int jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_EqualTo__SWIG_0")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_EqualTo__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool KeyEqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            public static partial bool KeyEqualTo(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_EqualTo__SWIG_1")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_EqualTo__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool KeyEqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            public static partial bool KeyEqualTo(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_EqualTo__SWIG_2")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_EqualTo__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool KeyEqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool KeyEqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_NotEqualTo__SWIG_0")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_NotEqualTo__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool KeyNotEqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            public static partial bool KeyNotEqualTo(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_NotEqualTo__SWIG_1")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_NotEqualTo__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool KeyNotEqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            public static partial bool KeyNotEqualTo(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_NotEqualTo__SWIG_2")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Key_NotEqualTo__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool KeyNotEqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool KeyNotEqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Property_Key")]
-            public static extern void DeletePropertyKey(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Property_Key", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePropertyKey(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PropertyBridge.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PropertyBridge.cs
@@ -14,8 +14,9 @@
  * limitations under the License.
  *
  */
-using System;
-using System.Runtime.InteropServices;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -23,8 +24,13 @@ namespace Tizen.NUI
     {
         internal static partial class PropertyBridge
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyBridge_RegisterStringGetter")]
-            public static extern void RegisterStringGetter(IntPtr getter);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyBridge_RegisterStringGetter", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterStringGetter(IntPtr getter);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PropertyBuffer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PropertyBuffer.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,17 +26,22 @@ namespace Tizen.NUI
         internal static partial class PropertyBuffer
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VertexBuffer_New")]
-            public static extern global::System.IntPtr New(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VertexBuffer_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VertexBuffer")]
-            public static extern void DeletePropertyBuffer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VertexBuffer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePropertyBuffer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VertexBuffer_SetData")]
-            public static extern void SetData(global::System.Runtime.InteropServices.HandleRef jarg1, System.IntPtr jarg2, uint jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VertexBuffer_SetData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetData(IntPtr jarg1, System.IntPtr jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VertexBuffer_GetSize")]
-            public static extern uint GetSize(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VertexBuffer_GetSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetSize(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PropertyCondition.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PropertyCondition.cs
@@ -15,41 +15,50 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class PropertyCondition
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PropertyCondition__SWIG_0")]
-            public static extern global::System.IntPtr NewPropertyCondition();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PropertyCondition__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyCondition();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PropertyCondition")]
-            public static extern void DeletePropertyCondition(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PropertyCondition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePropertyCondition(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyCondition_GetArgumentCount")]
-            public static extern uint GetArgumentCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyCondition_GetArgumentCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetArgumentCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyCondition_GetArgument")]
-            public static extern float GetArgument(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyCondition_GetArgument", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetArgument(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LessThanCondition")]
-            public static extern global::System.IntPtr LessThanCondition(float jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LessThanCondition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr LessThanCondition(float jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GreaterThanCondition")]
-            public static extern global::System.IntPtr GreaterThanCondition(float jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GreaterThanCondition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GreaterThanCondition(float jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InsideCondition")]
-            public static extern global::System.IntPtr InsideCondition(float jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InsideCondition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr InsideCondition(float jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_OutsideCondition")]
-            public static extern global::System.IntPtr OutsideCondition(float jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_OutsideCondition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr OutsideCondition(float jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StepCondition__SWIG_0")]
-            public static extern global::System.IntPtr StepCondition(float jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StepCondition__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr StepCondition(float jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StepCondition__SWIG_1")]
-            public static extern global::System.IntPtr StepCondition(float jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StepCondition__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr StepCondition(float jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PropertyInputContainer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PropertyInputContainer.cs
@@ -15,45 +15,54 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class PropertyInputContainer
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetCount")]
-            public static extern uint GetCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetType")]
-            public static extern int GetPropertyType(global::System.Runtime.InteropServices.HandleRef jarg1, uint index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetPropertyType(IntPtr jarg1, uint index);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetBoolean")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetBoolean", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetBoolean(global::System.Runtime.InteropServices.HandleRef jarg1, uint index);
+            public static partial bool GetBoolean(IntPtr jarg1, uint index);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetFloat")]
-            public static extern float GetFloat(global::System.Runtime.InteropServices.HandleRef jarg1, uint index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetFloat", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetFloat(IntPtr jarg1, uint index);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetInteger")]
-            public static extern int GetInteger(global::System.Runtime.InteropServices.HandleRef jarg1, uint index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetInteger", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetInteger(IntPtr jarg1, uint index);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetVector2_Componentwise")]
-            public static extern void GetVector2Componentwise(global::System.Runtime.InteropServices.HandleRef jarg1, uint index, out float x, out float y);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetVector2_Componentwise", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GetVector2Componentwise(IntPtr jarg1, uint index, out float x, out float y);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetVector3_Componentwise")]
-            public static extern void GetVector3Componentwise(global::System.Runtime.InteropServices.HandleRef jarg1, uint index, out float x, out float y, out float z);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetVector3_Componentwise", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GetVector3Componentwise(IntPtr jarg1, uint index, out float x, out float y, out float z);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetVector4_Componentwise")]
-            public static extern void GetVector4Componentwise(global::System.Runtime.InteropServices.HandleRef jarg1, uint index, out float x, out float y, out float z, out float w);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetVector4_Componentwise", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GetVector4Componentwise(IntPtr jarg1, uint index, out float x, out float y, out float z, out float w);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetMatrix3")]
-            public static extern global::System.IntPtr GetMatrix3(global::System.Runtime.InteropServices.HandleRef jarg1, uint index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetMatrix3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetMatrix3(IntPtr jarg1, uint index);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetMatrix")]
-            public static extern global::System.IntPtr GetMatrix(global::System.Runtime.InteropServices.HandleRef jarg1, uint index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetMatrix", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetMatrix(IntPtr jarg1, uint index);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetQuaternion")]
-            public static extern global::System.IntPtr GetRotation(global::System.Runtime.InteropServices.HandleRef jarg1, uint index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyInputContainer_GetQuaternion", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetRotation(IntPtr jarg1, uint index);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PropertyMap.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PropertyMap.cs
@@ -14,8 +14,9 @@
  * limitations under the License.
  *
  */
-using System;
-using System.Runtime.InteropServices;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -23,179 +24,184 @@ namespace Tizen.NUI
     {
         internal static partial class PropertyMap
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Map__SWIG_0")]
-            public static extern global::System.IntPtr NewPropertyMap();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Map__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyMap();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Map__SWIG_1")]
-            public static extern global::System.IntPtr NewPropertyMap(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Map__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyMap(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Property_Map")]
-            public static extern void DeletePropertyMap(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Property_Map", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePropertyMap(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Count")]
-            public static extern uint Count(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Count", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint Count(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Insert__SWIG_0")]
-            public static extern void Insert(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Insert__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Insert(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Insert__SWIG_2")]
-            public static extern void Insert(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Insert__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Insert(IntPtr jarg1, int jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add__SWIG_0")]
-            public static extern global::System.IntPtr Add(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Add(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add__SWIG_2")]
-            public static extern global::System.IntPtr Add(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Add(IntPtr jarg1, int jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Remove__SWIG_0")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Remove__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Remove(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            public static partial bool Remove(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Remove__SWIG_1")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Remove__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Remove(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            public static partial bool Remove(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_GetValue")]
-            public static extern global::System.IntPtr GetValue(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_GetValue", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetValue(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_GetKeyAt")]
-            public static extern global::System.IntPtr GetKeyAt(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_GetKeyAt", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetKeyAt(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Find__SWIG_0")]
-            public static extern global::System.IntPtr Find(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Find__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Find(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Find__SWIG_2")]
-            public static extern global::System.IntPtr Find(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Find__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Find(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Find__SWIG_3")]
-            public static extern global::System.IntPtr Find(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, string jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Find__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Find(IntPtr jarg1, int jarg2, string jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Clear")]
-            public static extern void Clear(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Clear", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Clear(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Merge")]
-            public static extern void Merge(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Merge", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Merge(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_ValueOfIndex__SWIG_0")]
-            public static extern global::System.IntPtr ValueOfIndex(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_ValueOfIndex__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ValueOfIndex(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_ValueOfIndex__SWIG_2")]
-            public static extern global::System.IntPtr ValueOfIndex(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_ValueOfIndex__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ValueOfIndex(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_SetValue_StringKey")]
-            public static extern void SetValueStringKey(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_SetValue_StringKey", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetValueStringKey(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_SetValue_IntKey")]
-            public static extern void SetValueIntKey(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_SetValue_IntKey", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetValueIntKey(IntPtr jarg1, int jarg2, IntPtr jarg3);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_None")]
-            public static extern IntPtr AddNone(HandleRef propertyMap, int key);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_None", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddNone(IntPtr propertyMap, int key);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Str_None")]
-            public static extern IntPtr AddNone(HandleRef propertyMap, string key);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Str_None", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddNone(IntPtr propertyMap, string key);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Int_None")]
-            public static extern IntPtr SetNone(HandleRef propertyMap, int key);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Int_None", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr SetNone(IntPtr propertyMap, int key);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Str_None")]
-            public static extern IntPtr SetNone(HandleRef propertyMap, string key);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Str_None", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr SetNone(IntPtr propertyMap, string key);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_Bool")]
-            public static extern IntPtr AddBool(HandleRef propertyMap, int key, bool value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_Bool", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddBool(IntPtr propertyMap, int key, [MarshalAs(UnmanagedType.U1)] bool value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Str_Bool")]
-            public static extern IntPtr AddBool(HandleRef propertyMap, string key, bool value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Str_Bool", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddBool(IntPtr propertyMap, string key, [MarshalAs(UnmanagedType.U1)] bool value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Int_Bool")]
-            public static extern IntPtr SetBool(HandleRef propertyMap, int key, bool value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Int_Bool", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr SetBool(IntPtr propertyMap, int key, [MarshalAs(UnmanagedType.U1)] bool value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Str_Bool")]
-            public static extern IntPtr SetBool(HandleRef propertyMap, string key, bool value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Str_Bool", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr SetBool(IntPtr propertyMap, string key, [MarshalAs(UnmanagedType.U1)] bool value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_Int")]
-            public static extern IntPtr AddInt(HandleRef propertyMap, int key, int value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_Int", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddInt(IntPtr propertyMap, int key, int value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Str_Int")]
-            public static extern IntPtr AddInt(HandleRef propertyMap, string key, int value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Str_Int", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddInt(IntPtr propertyMap, string key, int value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Int_Int")]
-            public static extern IntPtr SetInt(HandleRef propertyMap, int key, int value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Int_Int", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr SetInt(IntPtr propertyMap, int key, int value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Str_Int")]
-            public static extern IntPtr SetInt(HandleRef propertyMap, string key, int value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Str_Int", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr SetInt(IntPtr propertyMap, string key, int value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_Float")]
-            public static extern IntPtr AddFloat(HandleRef propertyMap, int key, float value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_Float", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddFloat(IntPtr propertyMap, int key, float value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Str_Float")]
-            public static extern IntPtr AddFloat(HandleRef propertyMap, string key, float value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Str_Float", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddFloat(IntPtr propertyMap, string key, float value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Int_Float")]
-            public static extern IntPtr SetFloat(HandleRef propertyMap, int key, float value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Int_Float", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr SetFloat(IntPtr propertyMap, int key, float value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Str_Float")]
-            public static extern IntPtr SetFloat(HandleRef propertyMap, string key, float value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Str_Float", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr SetFloat(IntPtr propertyMap, string key, float value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_Str")]
-            public static extern IntPtr AddString(HandleRef propertyMap, int key, string value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_Str", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddString(IntPtr propertyMap, int key, string value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Str_Str")]
-            public static extern IntPtr AddString(HandleRef propertyMap, string key, string value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Str_Str", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddString(IntPtr propertyMap, string key, string value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Int_Str")]
-            public static extern IntPtr SetString(HandleRef propertyMap, int key, string value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Int_Str", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr SetString(IntPtr propertyMap, int key, string value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Str_Str")]
-            public static extern IntPtr SetString(HandleRef propertyMap, string key, string value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Str_Str", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr SetString(IntPtr propertyMap, string key, string value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_Vector2")]
-            public static extern IntPtr AddVector2(HandleRef propertyMap, int key, HandleRef value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_Vector2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddVector2(IntPtr propertyMap, int key, IntPtr value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Str_Vector2")]
-            public static extern IntPtr AddVector2(HandleRef propertyMap, string key, HandleRef value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Str_Vector2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddVector2(IntPtr propertyMap, string key, IntPtr value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_NVector2")]
-            public static extern IntPtr AddVector2(HandleRef propertyMap, int key, float x, float y);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_NVector2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddVector2(IntPtr propertyMap, int key, float x, float y);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Str_NVector2")]
-            public static extern IntPtr AddVector2(HandleRef propertyMap, string key, float x, float y);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Str_NVector2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddVector2(IntPtr propertyMap, string key, float x, float y);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Int_NVector2")]
-            public static extern IntPtr SetVector2(HandleRef propertyMap, int key, float x, float y);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Int_NVector2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr SetVector2(IntPtr propertyMap, int key, float x, float y);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Str_NVector2")]
-            public static extern IntPtr SetVector2(HandleRef propertyMap, string key, float x, float y);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Str_NVector2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr SetVector2(IntPtr propertyMap, string key, float x, float y);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_Vector3")]
-            public static extern IntPtr AddVector3(HandleRef propertyMap, int key, HandleRef value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_Vector3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddVector3(IntPtr propertyMap, int key, IntPtr value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_Vector4")]
-            public static extern IntPtr AddVector4(HandleRef propertyMap, int key, HandleRef value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_Vector4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddVector4(IntPtr propertyMap, int key, IntPtr value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_NVector4")]
-            public static extern IntPtr AddVector4(HandleRef propertyMap, int key, float x, float y, float z, float w);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_NVector4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddVector4(IntPtr propertyMap, int key, float x, float y, float z, float w);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Str_NVector4")]
-            public static extern IntPtr AddVector4(HandleRef propertyMap, string key, float x, float y, float z, float w);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Str_NVector4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddVector4(IntPtr propertyMap, string key, float x, float y, float z, float w);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Int_NVector4")]
-            public static extern IntPtr SetVector4(HandleRef propertyMap, int key, float x, float y, float z, float w);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Int_NVector4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr SetVector4(IntPtr propertyMap, int key, float x, float y, float z, float w);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Str_NVector4")]
-            public static extern IntPtr SetVector4(HandleRef propertyMap, string key, float x, float y, float z, float w);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Str_NVector4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr SetVector4(IntPtr propertyMap, string key, float x, float y, float z, float w);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_Rectangle")]
-            public static extern IntPtr AddRectangle(HandleRef propertyMap, int key, HandleRef value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_Rectangle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddRectangle(IntPtr propertyMap, int key, IntPtr value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Int_Rectangle")]
-            public static extern IntPtr SetRectangle(HandleRef propertyMap, int key, HandleRef value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Set_Int_Rectangle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr SetRectangle(IntPtr propertyMap, int key, IntPtr value);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_Map")]
-            public static extern IntPtr AddPropertyMap(HandleRef propertyMap, int key, HandleRef value);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int_Map", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr AddPropertyMap(IntPtr propertyMap, int key, IntPtr value);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PropertyNotification.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PropertyNotification.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,39 +26,44 @@ namespace Tizen.NUI
         internal static partial class PropertyNotification
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PropertyNotification__SWIG_0")]
-            public static extern global::System.IntPtr NewPropertyNotification();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PropertyNotification__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyNotification();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PropertyNotification")]
-            public static extern void DeletePropertyNotification(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PropertyNotification", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePropertyNotification(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PropertyNotification__SWIG_1")]
-            public static extern global::System.IntPtr NewPropertyNotification(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PropertyNotification__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyNotification(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotification_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotification_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotification_GetCondition__SWIG_0")]
-            public static extern global::System.IntPtr GetCondition(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotification_GetCondition__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetCondition(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotification_GetTarget")]
-            public static extern global::System.IntPtr GetTarget(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotification_GetTarget", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetTarget(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotification_GetTargetProperty")]
-            public static extern int GetTargetProperty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotification_GetTargetProperty", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetTargetProperty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotification_SetNotifyMode")]
-            public static extern void SetNotifyMode(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotification_SetNotifyMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetNotifyMode(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotification_GetNotifyMode")]
-            public static extern int GetNotifyMode(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotification_GetNotifyMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetNotifyMode(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotification_GetNotifyResult")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotification_GetNotifyResult", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetNotifyResult(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool GetNotifyResult(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotification_NotifySignal")]
-            public static extern global::System.IntPtr NotifySignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotification_NotifySignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NotifySignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PropertyNotifySignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PropertyNotifySignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class PropertyNotifySignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotifySignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotifySignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotifySignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotifySignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotifySignal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotifySignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotifySignal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotifySignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotifySignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotifySignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PropertyNotifySignal")]
-            public static extern global::System.IntPtr NewPropertyNotifySignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PropertyNotifySignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyNotifySignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PropertyNotifySignal")]
-            public static extern void DeletePropertyNotifySignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PropertyNotifySignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePropertyNotifySignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PropertyValue.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PropertyValue.cs
@@ -15,220 +15,229 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class PropertyValue
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_0")]
-            public static extern global::System.IntPtr NewPropertyValue();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValue();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_1")]
-            public static extern global::System.IntPtr NewPropertyValue(bool jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValue([MarshalAs(UnmanagedType.U1)] bool jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_2")]
-            public static extern global::System.IntPtr NewPropertyValue(int jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValue(int jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_3")]
-            public static extern global::System.IntPtr NewPropertyValue(float jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValue(float jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_4")]
-            public static extern global::System.IntPtr NewPropertyValueVector2(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValueVector2(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_5")]
-            public static extern global::System.IntPtr NewPropertyValueVector3(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_5", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValueVector3(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_6")]
-            public static extern global::System.IntPtr NewPropertyValueVector4(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_6", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValueVector4(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_7")]
-            public static extern global::System.IntPtr NewPropertyValueMatrix3(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_7", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValueMatrix3(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_8")]
-            public static extern global::System.IntPtr NewPropertyValueMatrix(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_8", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValueMatrix(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_9")]
-            public static extern global::System.IntPtr NewPropertyValueRect(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_9", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValueRect(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_10")]
-            public static extern global::System.IntPtr NewPropertyValueAngleAxis(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_10", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValueAngleAxis(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_11")]
-            public static extern global::System.IntPtr NewPropertyValueQuaternion(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_11", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValueQuaternion(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_12")]
-            public static extern global::System.IntPtr NewPropertyValueString(string jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_12", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValueString(string jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_14")]
-            public static extern global::System.IntPtr NewPropertyValueArray(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_14", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValueArray(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_15")]
-            public static extern global::System.IntPtr NewPropertyValueMap(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_15", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValueMap(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_16")]
-            public static extern global::System.IntPtr NewPropertyValueExtents(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_16", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValueExtents(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_17")]
-            public static extern global::System.IntPtr NewPropertyValueType(int jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_17", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValueType(int jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_18")]
-            public static extern global::System.IntPtr NewPropertyValueValue(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value__SWIG_18", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValueValue(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_EqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_EqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool EqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool EqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_NotEqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_NotEqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool NotEqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool NotEqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Property_Value")]
-            public static extern void DeletePropertyValue(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Property_Value", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePropertyValue(IntPtr jarg1);
 
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Property_Value")]
-            public static extern void DeletePropertyValueIntPtr(global::System.IntPtr jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Property_Value", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeletePropertyValueIntPtr(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_GetType")]
-            public static extern int PropertyValueGetType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_GetType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PropertyValueGetType(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_1")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool PropertyValueGet(global::System.Runtime.InteropServices.HandleRef jarg1, out bool jarg2);
+            public static partial bool PropertyValueGet(IntPtr jarg1, out bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_2")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool PropertyValueGet(global::System.Runtime.InteropServices.HandleRef jarg1, out float jarg2);
+            public static partial bool PropertyValueGet(IntPtr jarg1, out float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_3")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool PropertyValueGet(global::System.Runtime.InteropServices.HandleRef jarg1, out int jarg2);
+            public static partial bool PropertyValueGet(IntPtr jarg1, out int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_4")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_4", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetRect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool GetRect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_5")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_5", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetVector2(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool GetVector2(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_6")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_6", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetVector3(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool GetVector3(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_7")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_7", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetVector4(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool GetVector4(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_8")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_8", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetMatrix3(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool GetMatrix3(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_9")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_9", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetMatrix(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool GetMatrix(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_10")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_10", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetAngleAxis(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool GetAngleAxis(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_11")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_11", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetQuaternion(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool GetQuaternion(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_12")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_12", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetString(global::System.Runtime.InteropServices.HandleRef jarg1, out string jarg2);
+            public static partial bool GetString(IntPtr jarg1, out string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_13")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_13", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetArray(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool GetArray(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_14")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_14", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetMap(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool GetMap(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_15")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_15", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetExtents(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool GetExtents(IntPtr jarg1, IntPtr jarg2);
 
             // For internal managed memory optimization
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value_Vector2_Componentwise")]
-            public static extern global::System.IntPtr NewPropertyValueVector2Componentwise(float jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value_Vector2_Componentwise", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValueVector2Componentwise(float jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value_Vector3_Componentwise")]
-            public static extern global::System.IntPtr NewPropertyValueVector3Componentwise(float jarg1, float jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value_Vector3_Componentwise", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValueVector3Componentwise(float jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value_Vector4_Componentwise")]
-            public static extern global::System.IntPtr NewPropertyValueVector4Componentwise(float jarg1, float jarg2, float jarg3, float jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value_Vector4_Componentwise", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewPropertyValueVector4Componentwise(float jarg1, float jarg2, float jarg3, float jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get_Vector2_Componentwise")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get_Vector2_Componentwise", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool PropertyValueGetVector2Componentwise(global::System.Runtime.InteropServices.HandleRef jarg1, out float jarg2, out float jarg3);
+            public static partial bool PropertyValueGetVector2Componentwise(IntPtr jarg1, out float jarg2, out float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get_Vector3_Componentwise")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get_Vector3_Componentwise", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool PropertyValueGetVector3Componentwise(global::System.Runtime.InteropServices.HandleRef jarg1, out float jarg2, out float jarg3, out float jarg4);
+            public static partial bool PropertyValueGetVector3Componentwise(IntPtr jarg1, out float jarg2, out float jarg3, out float jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get_Vector4_Componentwise")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get_Vector4_Componentwise", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool PropertyValueGetVector4Componentwise(global::System.Runtime.InteropServices.HandleRef jarg1, out float jarg2, out float jarg3, out float jarg4, out float jarg5);
+            public static partial bool PropertyValueGetVector4Componentwise(IntPtr jarg1, out float jarg2, out float jarg3, out float jarg4, out float jarg5);
 
             // Internal Assign API
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_1")]
-            public static extern void SetBoolean(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetBoolean(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_2")]
-            public static extern void SetFloat(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFloat(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_3")]
-            public static extern void SetInteger(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetInteger(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_5")]
-            public static extern void SetVector2(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_5", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetVector2(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_6")]
-            public static extern void SetVector3(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_6", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetVector3(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_7")]
-            public static extern void SetVector4(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_7", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetVector4(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_8")]
-            public static extern void SetMatrix3(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_8", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMatrix3(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_9")]
-            public static extern void SetMatrix(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_9", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMatrix(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_10")]
-            public static extern void SetRect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_10", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetRect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_11")]
-            public static extern void SetAngleAxis(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_11", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetAngleAxis(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_12")]
-            public static extern void SetQuaternion(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_12", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetQuaternion(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_13")]
-            public static extern void SetString(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_13", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetString(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_14")]
-            public static extern void SetArray(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_14", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetArray(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_15")]
-            public static extern void SetMap(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_15", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMap(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_16")]
-            public static extern void SetExtents(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set__SWIG_16", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetExtents(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set_Vector2_Componentwise")]
-            public static extern void PropertyValueSetVector2Componentwise(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set_Vector2_Componentwise", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PropertyValueSetVector2Componentwise(IntPtr jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set_Vector3_Componentwise")]
-            public static extern void PropertyValueSetVector3Componentwise(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set_Vector3_Componentwise", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PropertyValueSetVector3Componentwise(IntPtr jarg1, float jarg2, float jarg3, float jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set_Vector4_Componentwise")]
-            public static extern void PropertyValueSetVector4Componentwise(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4, float jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Set_Vector4_Componentwise", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PropertyValueSetVector4Componentwise(IntPtr jarg1, float jarg2, float jarg3, float jarg4, float jarg5);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.RadialGradient.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.RadialGradient.cs
@@ -15,20 +15,29 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class RadialGradient
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RadialGradient_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RadialGradient_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RadialGradient_SetBounds")]
-            public static extern void SetBounds(global::System.Runtime.InteropServices.HandleRef linearGradient, global::System.Runtime.InteropServices.HandleRef centerPoint, float radius);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RadialGradient_SetBounds", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetBounds(IntPtr linearGradient, IntPtr centerPoint, float radius);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RadialGradient_GetBounds")]
-            public unsafe static extern void GetBounds(global::System.Runtime.InteropServices.HandleRef linearGradient, global::System.Runtime.InteropServices.HandleRef centerPoint, void* radius);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RadialGradient_GetBounds", StringMarshalling = StringMarshalling.Utf8)]
+            public unsafe static extern void GetBounds(IntPtr linearGradient, IntPtr centerPoint, void* radius);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Radian.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Radian.cs
@@ -15,32 +15,41 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Radian
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Radian__SWIG_0")]
-            public static extern global::System.IntPtr NewRadian();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Radian__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRadian();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Radian__SWIG_1")]
-            public static extern global::System.IntPtr NewRadian(float jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Radian__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRadian(float jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Radian__SWIG_2")]
-            public static extern global::System.IntPtr NewRadian(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Radian__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRadian(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Radian_ConvertToFloat")]
-            public static extern float ConvertToFloat(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Radian_ConvertToFloat", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float ConvertToFloat(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Radian_radian_set")]
-            public static extern void RadianSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Radian_radian_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RadianSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Radian_radian_get")]
-            public static extern float RadianGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Radian_radian_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RadianGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Radian")]
-            public static extern void DeleteRadian(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Radian", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteRadian(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Rectangle.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Rectangle.cs
@@ -15,98 +15,107 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Rectangle
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Rectangle__SWIG_0")]
-            public static extern global::System.IntPtr NewRectangle();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Rectangle__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRectangle();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Rectangle__SWIG_1")]
-            public static extern global::System.IntPtr NewRectangle(int jarg1, int jarg2, int jarg3, int jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Rectangle__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRectangle(int jarg1, int jarg2, int jarg3, int jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_Set")]
-            public static extern void Set(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3, int jarg4, int jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_Set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Set(IntPtr jarg1, int jarg2, int jarg3, int jarg4, int jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_IsEmpty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_IsEmpty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsEmpty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_Left")]
-            public static extern int Left(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_Left", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int Left(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_Right")]
-            public static extern int Right(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_Right", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int Right(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_Top")]
-            public static extern int Top(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_Top", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int Top(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_Bottom")]
-            public static extern int Bottom(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_Bottom", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int Bottom(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_Area")]
-            public static extern int Area(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_Area", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int Area(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_Intersects")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_Intersects", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Intersects(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool Intersects(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_Contains")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_Contains", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Contains(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool Contains(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_x_set")]
-            public static extern void XSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_x_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void XSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_x_get")]
-            public static extern int XGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_x_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int XGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_left_set")]
-            public static extern void LeftSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_left_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LeftSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_left_get")]
-            public static extern int LeftGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_left_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LeftGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_y_set")]
-            public static extern void YSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_y_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void YSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_y_get")]
-            public static extern int YGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_y_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int YGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_right_set")]
-            public static extern void RightSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_right_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RightSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_right_get")]
-            public static extern int RightGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_right_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RightGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_width_set")]
-            public static extern void WidthSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_width_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void WidthSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_width_get")]
-            public static extern int WidthGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_width_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WidthGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_bottom_set")]
-            public static extern void BottomSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_bottom_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void BottomSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_bottom_get")]
-            public static extern int BottomGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_bottom_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BottomGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_height_set")]
-            public static extern void HeightSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_height_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void HeightSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_height_get")]
-            public static extern int HeightGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_height_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int HeightGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_top_set")]
-            public static extern void TopSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_top_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TopSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_top_get")]
-            public static extern int TopGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rectangle_top_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TopGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Rectangle")]
-            public static extern void DeleteRectangle(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Rectangle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteRectangle(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.RefObject.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.RefObject.cs
@@ -15,23 +15,32 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class RefObject
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RefObject_Reference")]
-            public static extern void Reference(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RefObject_Reference", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Reference(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RefObject_Unreference")]
-            public static extern void Unreference(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RefObject_Unreference", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Unreference(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RefObject_ReferenceCount")]
-            public static extern int ReferenceCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RefObject_ReferenceCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ReferenceCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetRefObjectPtr")]
-            public static extern global::System.IntPtr GetRefObjectPtr(global::System.IntPtr jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetRefObjectPtr", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetRefObjectPtr(global::System.IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.RenderEffect.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.RenderEffect.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2025 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,26 +15,30 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
-    using global::System;
-    using global::System.Runtime.InteropServices;
-
     internal static partial class Interop
     {
         internal static class RenderEffect
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderEffect_Activate")]
-            public static extern void Activate(HandleRef effect);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderEffect_Activate", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Activate(IntPtr effect);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderEffect_Deactivate")]
-            public static extern void Deactivate(HandleRef effect);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderEffect_Deactivate", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Deactivate(IntPtr effect);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderEffect_Refresh")]
-            public static extern void Refresh(HandleRef effect);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderEffect_Refresh", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Refresh(IntPtr effect);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderEffect_IsActivated")]
-            public static extern bool IsActivated(HandleRef effect);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderEffect_IsActivated", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial bool IsActivated(IntPtr effect);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.RenderTask.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.RenderTask.cs
@@ -15,167 +15,176 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class RenderTask
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RenderTaskList__SWIG_0")]
-            public static extern global::System.IntPtr NewRenderTaskList();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RenderTaskList__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRenderTaskList();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_RenderTaskList")]
-            public static extern void DeleteRenderTaskList(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_RenderTaskList", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteRenderTaskList(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTaskList_Assign")]
-            public static extern global::System.IntPtr RenderTaskListAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTaskList_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr RenderTaskListAssign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTaskList_CreateTask")]
-            public static extern global::System.IntPtr RenderTaskListCreateTask(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTaskList_CreateTask", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr RenderTaskListCreateTask(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTaskList_RemoveTask")]
-            public static extern void RenderTaskListRemoveTask(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTaskList_RemoveTask", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RenderTaskListRemoveTask(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTaskList_GetTaskCount")]
-            public static extern uint RenderTaskListGetTaskCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTaskList_GetTaskCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint RenderTaskListGetTaskCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTaskList_GetTask")]
-            public static extern global::System.IntPtr RenderTaskListGetTask(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTaskList_GetTask", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr RenderTaskListGetTask(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_Property_VIEWPORT_POSITION_get")]
-            public static extern int ViewportPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_Property_VIEWPORT_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ViewportPositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_Property_VIEWPORT_SIZE_get")]
-            public static extern int ViewportSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_Property_VIEWPORT_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ViewportSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_Property_CLEAR_COLOR_get")]
-            public static extern int ClearColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_Property_CLEAR_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ClearColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_Property_REQUIRES_SYNC_get")]
-            public static extern int RequiresSyncGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_Property_REQUIRES_SYNC_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RequiresSyncGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RenderTask__SWIG_0")]
-            public static extern global::System.IntPtr NewRenderTask();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RenderTask__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRenderTask();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_RenderTask")]
-            public static extern void DeleteRenderTask(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_RenderTask", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteRenderTask(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RenderTask__SWIG_1")]
-            public static extern global::System.IntPtr NewRenderTask(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RenderTask__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRenderTask(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetSourceActor")]
-            public static extern void SetSourceActor(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetSourceActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetSourceActor(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetSourceActor")]
-            public static extern global::System.IntPtr GetSourceActor(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetSourceActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetSourceActor(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetExclusive")]
-            public static extern void SetExclusive(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetExclusive", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetExclusive(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_IsExclusive")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_IsExclusive", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsExclusive(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsExclusive(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetInputEnabled")]
-            public static extern void SetInputEnabled(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetInputEnabled", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetInputEnabled(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetInputEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetInputEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetInputEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool GetInputEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetCameraActor")]
-            public static extern void SetCameraActor(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetCameraActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetCameraActor(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetCameraActor")]
-            public static extern global::System.IntPtr GetCameraActor(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetCameraActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetCameraActor(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetFrameBuffer")]
-            public static extern void SetFrameBuffer(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetFrameBuffer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFrameBuffer(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetFrameBuffer")]
-            public static extern global::System.IntPtr GetFrameBuffer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetFrameBuffer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetFrameBuffer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetScreenToFrameBufferMappingActor")]
-            public static extern void SetScreenToFrameBufferMappingActor(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetScreenToFrameBufferMappingActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetScreenToFrameBufferMappingActor(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetScreenToFrameBufferMappingActor")]
-            public static extern global::System.IntPtr GetScreenToFrameBufferMappingActor(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetScreenToFrameBufferMappingActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetScreenToFrameBufferMappingActor(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetViewportPosition")]
-            public static extern void SetViewportPosition(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetViewportPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetViewportPosition(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetCurrentViewportPosition")]
-            public static extern global::System.IntPtr GetCurrentViewportPosition(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetCurrentViewportPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetCurrentViewportPosition(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetViewportSize")]
-            public static extern void SetViewportSize(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetViewportSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetViewportSize(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetCurrentViewportSize")]
-            public static extern global::System.IntPtr GetCurrentViewportSize(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetCurrentViewportSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetCurrentViewportSize(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetViewport")]
-            public static extern void SetViewport(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetViewport", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetViewport(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetViewport")]
-            public static extern global::System.IntPtr GetViewport(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetViewport", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetViewport(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetClearColor")]
-            public static extern void SetClearColor(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetClearColor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetClearColor(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetClearColor")]
-            public static extern global::System.IntPtr GetClearColor(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetClearColor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetClearColor(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetClearEnabled")]
-            public static extern void SetClearEnabled(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetClearEnabled", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetClearEnabled(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetClearEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetClearEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetClearEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool GetClearEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetCullMode")]
-            public static extern void SetCullMode(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetCullMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetCullMode(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetCullMode")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetCullMode", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetCullMode(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool GetCullMode(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetRefreshRate")]
-            public static extern void SetRefreshRate(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetRefreshRate", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetRefreshRate(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetRefreshRate")]
-            public static extern uint GetRefreshRate(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetRefreshRate", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetRefreshRate(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_WorldToViewport")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_WorldToViewport", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool WorldToViewport(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, out float jarg3, out float jarg4);
+            public static partial bool WorldToViewport(IntPtr jarg1, IntPtr jarg2, out float jarg3, out float jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_ViewportToLocal")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_ViewportToLocal", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool ViewportToLocal(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, float jarg3, float jarg4, out float jarg5, out float jarg6);
+            public static partial bool ViewportToLocal(IntPtr jarg1, IntPtr jarg2, float jarg3, float jarg4, out float jarg5, out float jarg6);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetRenderPassTag")]
-            public static extern void SetRenderPassTag(global::System.Runtime.InteropServices.HandleRef nuiRenderTask, uint renderPassTag);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetRenderPassTag", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetRenderPassTag(IntPtr nuiRenderTask, uint renderPassTag);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetRenderPassTag")]
-            public static extern uint GetRenderPassTag(global::System.Runtime.InteropServices.HandleRef nuiRenderTask);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetRenderPassTag", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetRenderPassTag(IntPtr nuiRenderTask);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetOrderIndex")]
-            public static extern void SetOrderIndex(global::System.Runtime.InteropServices.HandleRef nuiRenderTask, int orderIndex);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetOrderIndex", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetOrderIndex(IntPtr nuiRenderTask, int orderIndex);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetOrderIndex")]
-            public static extern int GetOrderIndex(global::System.Runtime.InteropServices.HandleRef nuiRenderTask);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetOrderIndex", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetOrderIndex(IntPtr nuiRenderTask);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetRenderTaskId")]
-            public static extern uint GetRenderTaskId(global::System.Runtime.InteropServices.HandleRef nuiRenderTask);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetRenderTaskId", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetRenderTaskId(IntPtr nuiRenderTask);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_RenderUntil")]
-            public static extern void RenderUntil(global::System.Runtime.InteropServices.HandleRef nuiRenderTask, global::System.Runtime.InteropServices.HandleRef nuiStopperView);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_RenderUntil", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RenderUntil(IntPtr nuiRenderTask, IntPtr nuiStopperView);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetStopperActor")]
-            public static extern global::System.IntPtr GetStopperView(global::System.Runtime.InteropServices.HandleRef nuiRenderTask);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetStopperActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetStopperView(IntPtr nuiRenderTask);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Renderer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Renderer.cs
@@ -15,149 +15,158 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Renderer
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Range_BACKGROUND_EFFECT_get")]
-            public static extern int RangesBackgroundEffectGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Range_BACKGROUND_EFFECT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RangesBackgroundEffectGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Range_BACKGROUND_get")]
-            public static extern int RangesBackgroundGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Range_BACKGROUND_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RangesBackgroundGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Range_CONTENT_get")]
-            public static extern int RangesContentGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Range_CONTENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RangesContentGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Range_DECORATION_get")]
-            public static extern int RangesDecorationGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Range_DECORATION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RangesDecorationGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Range_FOREGROUND_EFFECT_get")]
-            public static extern int RangesForegroundEffectGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Range_FOREGROUND_EFFECT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RangesForegroundEffectGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_DEPTH_INDEX_get")]
-            public static extern int DepthIndexGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_DEPTH_INDEX_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DepthIndexGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_FACE_CULLING_MODE_get")]
-            public static extern int FaceCullingModeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_FACE_CULLING_MODE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int FaceCullingModeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_MODE_get")]
-            public static extern int BlendModeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_MODE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BlendModeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_EQUATION_RGB_get")]
-            public static extern int BlendEquationRgbGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_EQUATION_RGB_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BlendEquationRgbGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_EQUATION_ALPHA_get")]
-            public static extern int BlendEquationAlphaGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_EQUATION_ALPHA_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BlendEquationAlphaGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_FACTOR_SRC_RGB_get")]
-            public static extern int BlendFactorSrcRgbGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_FACTOR_SRC_RGB_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BlendFactorSrcRgbGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_FACTOR_DEST_RGB_get")]
-            public static extern int BlendFactorDestRgbGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_FACTOR_DEST_RGB_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BlendFactorDestRgbGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_FACTOR_SRC_ALPHA_get")]
-            public static extern int BlendFactorSrcAlphaGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_FACTOR_SRC_ALPHA_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BlendFactorSrcAlphaGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_FACTOR_DEST_ALPHA_get")]
-            public static extern int BlendFactorDestAlphaGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_FACTOR_DEST_ALPHA_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BlendFactorDestAlphaGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_COLOR_get")]
-            public static extern int BlendColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BlendColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_PRE_MULTIPLIED_ALPHA_get")]
-            public static extern int BlendPreMultipliedAlphaGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_PRE_MULTIPLIED_ALPHA_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BlendPreMultipliedAlphaGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_INDEX_RANGE_FIRST_get")]
-            public static extern int IndexRangeFirstGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_INDEX_RANGE_FIRST_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int IndexRangeFirstGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_INDEX_RANGE_COUNT_get")]
-            public static extern int IndexRangeCountGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_INDEX_RANGE_COUNT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int IndexRangeCountGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_DEPTH_WRITE_MODE_get")]
-            public static extern int DepthWriteModeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_DEPTH_WRITE_MODE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DepthWriteModeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_DEPTH_FUNCTION_get")]
-            public static extern int DepthFunctionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_DEPTH_FUNCTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DepthFunctionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_DEPTH_TEST_MODE_get")]
-            public static extern int DepthTestModeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_DEPTH_TEST_MODE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DepthTestModeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_RENDER_MODE_get")]
-            public static extern int RenderModeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_RENDER_MODE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RenderModeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_STENCIL_FUNCTION_get")]
-            public static extern int StencilFunctionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_STENCIL_FUNCTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int StencilFunctionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_STENCIL_FUNCTION_MASK_get")]
-            public static extern int StencilFunctionMaskGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_STENCIL_FUNCTION_MASK_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int StencilFunctionMaskGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_STENCIL_FUNCTION_REFERENCE_get")]
-            public static extern int StencilFunctionReferenceGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_STENCIL_FUNCTION_REFERENCE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int StencilFunctionReferenceGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_STENCIL_MASK_get")]
-            public static extern int StencilMaskGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_STENCIL_MASK_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int StencilMaskGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_STENCIL_OPERATION_ON_FAIL_get")]
-            public static extern int StencilOperationOnFailGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_STENCIL_OPERATION_ON_FAIL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int StencilOperationOnFailGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_STENCIL_OPERATION_ON_Z_FAIL_get")]
-            public static extern int StencilOperationOnZFailGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_STENCIL_OPERATION_ON_Z_FAIL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int StencilOperationOnZFailGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_STENCIL_OPERATION_ON_Z_PASS_get")]
-            public static extern int StencilOperationOnZPassGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_STENCIL_OPERATION_ON_Z_PASS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int StencilOperationOnZPassGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_MIX_COLOR_get")]
-            public static extern int MixColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_MIX_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MixColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_MIX_COLOR_RED_get")]
-            public static extern int MixColorRedGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_MIX_COLOR_RED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MixColorRedGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_MIX_COLOR_GREEN_get")]
-            public static extern int MixColorGreenGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_MIX_COLOR_GREEN_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MixColorGreenGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_MIX_COLOR_BLUE_get")]
-            public static extern int MixColorBlueGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_MIX_COLOR_BLUE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MixColorBlueGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_OPACITY_get")]
-            public static extern int MixColorOpacityGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_OPACITY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MixColorOpacityGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_RENDERING_BEHAVIOR_get")]
-            public static extern int RenderingBehaviorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_RENDERING_BEHAVIOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RenderingBehaviorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_EQUATION_get")]
-            public static extern int BlendEquationGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_BLEND_EQUATION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BlendEquationGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_INSTANCE_COUNT_get")]
-            public static extern int InstanceCountGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_INSTANCE_COUNT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InstanceCountGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_UPDATE_AREA_EXTENTS_get")]
-            public static extern int UpdateAreaExtentsGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_UPDATE_AREA_EXTENTS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int UpdateAreaExtentsGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_New")]
-            public static extern global::System.IntPtr New(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_NewWithoutGeometryAndShader")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_NewWithoutGeometryAndShader", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Renderer")]
-            public static extern void DeleteRenderer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Renderer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteRenderer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_SetGeometry")]
-            public static extern void SetGeometry(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_SetGeometry", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetGeometry(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_SetIndexRange")]
-            public static extern void SetIndexRange(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_SetIndexRange", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetIndexRange(IntPtr jarg1, int jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_SetTextures")]
-            public static extern void SetTextures(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_SetTextures", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTextures(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_GetTextures")]
-            public static extern global::System.IntPtr GetTextures(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_GetTextures", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetTextures(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_SetShader")]
-            public static extern void SetShader(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_SetShader", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetShader(IntPtr jarg1, IntPtr jarg2);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ResizedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ResizedSignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class ResizeSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ResizeSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ResizeSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ResizeSignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ResizeSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ResizeSignal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ResizeSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ResizeSignal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ResizeSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ResizeSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ResizeSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ResizeSignal")]
-            public static extern global::System.IntPtr NewResizeSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ResizeSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewResizeSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ResizeSignal")]
-            public static extern void DeleteResizeSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ResizeSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteResizeSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Rotation.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Rotation.cs
@@ -15,144 +15,153 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Rotation
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Rotation_0")]
-            public static extern global::System.IntPtr NewRotation();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Rotation_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRotation();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Rotation_1")]
-            public static extern global::System.IntPtr NewRotation(global::System.Runtime.InteropServices.HandleRef radianAngle, global::System.Runtime.InteropServices.HandleRef vector3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Rotation_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRotation(IntPtr radianAngle, IntPtr vector3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Rotation_2")]
-            public static extern global::System.IntPtr NewRotation2(global::System.Runtime.InteropServices.HandleRef v0, global::System.Runtime.InteropServices.HandleRef v1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Rotation_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRotation2(IntPtr v0, IntPtr v1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Rotation_3")]
-            public static extern global::System.IntPtr NewRotation3(global::System.Runtime.InteropServices.HandleRef pitch, global::System.Runtime.InteropServices.HandleRef yaw, global::System.Runtime.InteropServices.HandleRef roll);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Rotation_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRotation3(IntPtr pitch, IntPtr yaw, IntPtr roll);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Rotation_4")]
-            public static extern global::System.IntPtr NewRotation4(global::System.Runtime.InteropServices.HandleRef vector4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Rotation_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRotation4(IntPtr vector4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Assign")]
-            public static extern global::System.IntPtr RotationAssign(global::System.Runtime.InteropServices.HandleRef destination, global::System.Runtime.InteropServices.HandleRef source);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr RotationAssign(IntPtr destination, IntPtr source);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Rotation")]
-            public static extern void DeleteRotation(global::System.Runtime.InteropServices.HandleRef rotation);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Rotation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteRotation(IntPtr rotation);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_IDENTITY_get")]
-            public static extern global::System.IntPtr IdentityGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_IDENTITY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr IdentityGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_IsIdentity")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_IsIdentity", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsIdentity(global::System.Runtime.InteropServices.HandleRef rotation);
+            public static partial bool IsIdentity(IntPtr rotation);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_GetAxisAngle")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_GetAxisAngle", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetAxisAngle(global::System.Runtime.InteropServices.HandleRef rotation, global::System.Runtime.InteropServices.HandleRef axis, global::System.Runtime.InteropServices.HandleRef radianAngle);
+            public static partial bool GetAxisAngle(IntPtr rotation, IntPtr axis, IntPtr radianAngle);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_SetEulerAngle")]
-            public static extern void SetEulerAngle(global::System.Runtime.InteropServices.HandleRef rotation, global::System.Runtime.InteropServices.HandleRef pitch, global::System.Runtime.InteropServices.HandleRef yaw, global::System.Runtime.InteropServices.HandleRef roll);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_SetEulerAngle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetEulerAngle(IntPtr rotation, IntPtr pitch, IntPtr yaw, IntPtr roll);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_GetEulerAngle")]
-            public static extern void GetEulerAngle(global::System.Runtime.InteropServices.HandleRef rotation, global::System.Runtime.InteropServices.HandleRef pitch, global::System.Runtime.InteropServices.HandleRef yaw, global::System.Runtime.InteropServices.HandleRef roll);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_GetEulerAngle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GetEulerAngle(IntPtr rotation, IntPtr pitch, IntPtr yaw, IntPtr roll);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Add")]
-            public static extern global::System.IntPtr Add(global::System.Runtime.InteropServices.HandleRef rotation0, global::System.Runtime.InteropServices.HandleRef rotation1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Add", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Add(IntPtr rotation0, IntPtr rotation1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Subtract_0")]
-            public static extern global::System.IntPtr Subtract(global::System.Runtime.InteropServices.HandleRef rotation0, global::System.Runtime.InteropServices.HandleRef rotation1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Subtract_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Subtract(IntPtr rotation0, IntPtr rotation1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Multiply_0")]
-            public static extern global::System.IntPtr MultiplyQuaternion(global::System.Runtime.InteropServices.HandleRef rotation0, global::System.Runtime.InteropServices.HandleRef rotation1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Multiply_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr MultiplyQuaternion(IntPtr rotation0, IntPtr rotation1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Multiply_1")]
-            public static extern global::System.IntPtr MultiplyVector3(global::System.Runtime.InteropServices.HandleRef rotation, global::System.Runtime.InteropServices.HandleRef vector);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Multiply_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr MultiplyVector3(IntPtr rotation, IntPtr vector);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Divide_0")]
-            public static extern global::System.IntPtr Divide(global::System.Runtime.InteropServices.HandleRef rotation0, global::System.Runtime.InteropServices.HandleRef rotation1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Divide_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Divide(IntPtr rotation0, IntPtr rotation1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Multiply_2")]
-            public static extern global::System.IntPtr Multiply(global::System.Runtime.InteropServices.HandleRef rotation, float scale);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Multiply_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Multiply(IntPtr rotation, float scale);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Divide_1")]
-            public static extern global::System.IntPtr Divide(global::System.Runtime.InteropServices.HandleRef rotation, float scale);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Divide_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Divide(IntPtr rotation, float scale);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Subtract_1")]
-            public static extern global::System.IntPtr Subtract(global::System.Runtime.InteropServices.HandleRef rotation);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Subtract_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Subtract(IntPtr rotation);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_AddAssign")]
-            public static extern global::System.IntPtr AddAssign(global::System.Runtime.InteropServices.HandleRef rotation0, global::System.Runtime.InteropServices.HandleRef rotation1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_AddAssign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr AddAssign(IntPtr rotation0, IntPtr rotation1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_SubtractAssign")]
-            public static extern global::System.IntPtr SubtractAssign(global::System.Runtime.InteropServices.HandleRef rotation0, global::System.Runtime.InteropServices.HandleRef rotation1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_SubtractAssign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr SubtractAssign(IntPtr rotation0, IntPtr rotation1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_MultiplyAssign_0")]
-            public static extern global::System.IntPtr MultiplyAssign(global::System.Runtime.InteropServices.HandleRef rotation0, global::System.Runtime.InteropServices.HandleRef rotation1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_MultiplyAssign_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr MultiplyAssign(IntPtr rotation0, IntPtr rotation1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_MultiplyAssign_1")]
-            public static extern global::System.IntPtr MultiplyAssign(global::System.Runtime.InteropServices.HandleRef rotation, float scale);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_MultiplyAssign_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr MultiplyAssign(IntPtr rotation, float scale);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_DivideAssign")]
-            public static extern global::System.IntPtr DivideAssign(global::System.Runtime.InteropServices.HandleRef rotation, float scale);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_DivideAssign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DivideAssign(IntPtr rotation, float scale);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_EqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_EqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool EqualTo(global::System.Runtime.InteropServices.HandleRef rotation0, global::System.Runtime.InteropServices.HandleRef rotation1);
+            public static partial bool EqualTo(IntPtr rotation0, IntPtr rotation1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_NotEqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_NotEqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool NotEqualTo(global::System.Runtime.InteropServices.HandleRef rotation0, global::System.Runtime.InteropServices.HandleRef rotation1);
+            public static partial bool NotEqualTo(IntPtr rotation0, IntPtr rotation1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Length")]
-            public static extern float Length(global::System.Runtime.InteropServices.HandleRef rotation);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Length", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float Length(IntPtr rotation);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_LengthSquared")]
-            public static extern float LengthSquared(global::System.Runtime.InteropServices.HandleRef rotation);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_LengthSquared", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float LengthSquared(IntPtr rotation);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Normalize")]
-            public static extern void Normalize(global::System.Runtime.InteropServices.HandleRef rotation);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Normalize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Normalize(IntPtr rotation);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Normalized")]
-            public static extern global::System.IntPtr Normalized(global::System.Runtime.InteropServices.HandleRef rotation);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Normalized", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Normalized(IntPtr rotation);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Conjugate")]
-            public static extern void Conjugate(global::System.Runtime.InteropServices.HandleRef rotation);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Conjugate", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Conjugate(IntPtr rotation);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Invert")]
-            public static extern void Invert(global::System.Runtime.InteropServices.HandleRef rotation);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Invert", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Invert(IntPtr rotation);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Log")]
-            public static extern global::System.IntPtr Log(global::System.Runtime.InteropServices.HandleRef rotation);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Log", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Log(IntPtr rotation);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Exp")]
-            public static extern global::System.IntPtr Exp(global::System.Runtime.InteropServices.HandleRef rotation);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Exp", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Exp(IntPtr rotation);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Dot")]
-            public static extern float Dot(global::System.Runtime.InteropServices.HandleRef rotation0, global::System.Runtime.InteropServices.HandleRef rotation1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Dot", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float Dot(IntPtr rotation0, IntPtr rotation1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Lerp")]
-            public static extern global::System.IntPtr Lerp(global::System.Runtime.InteropServices.HandleRef rotation0, global::System.Runtime.InteropServices.HandleRef rotation1, float progress);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Lerp", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Lerp(IntPtr rotation0, IntPtr rotation1, float progress);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Slerp")]
-            public static extern global::System.IntPtr Slerp(global::System.Runtime.InteropServices.HandleRef rotation0, global::System.Runtime.InteropServices.HandleRef rotation1, float progress);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Slerp", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Slerp(IntPtr rotation0, IntPtr rotation1, float progress);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_SlerpNoInvert")]
-            public static extern global::System.IntPtr SlerpNoInvert(global::System.Runtime.InteropServices.HandleRef rotation0, global::System.Runtime.InteropServices.HandleRef rotation1, float progress);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_SlerpNoInvert", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr SlerpNoInvert(IntPtr rotation0, IntPtr rotation1, float progress);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Squad")]
-            public static extern global::System.IntPtr Squad(global::System.Runtime.InteropServices.HandleRef start, global::System.Runtime.InteropServices.HandleRef end, global::System.Runtime.InteropServices.HandleRef control0, global::System.Runtime.InteropServices.HandleRef control1, float progress);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Squad", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Squad(IntPtr start, IntPtr end, IntPtr control0, IntPtr control1, float progress);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_AngleBetween")]
-            public static extern float AngleBetween(global::System.Runtime.InteropServices.HandleRef rotation0, global::System.Runtime.InteropServices.HandleRef rotation1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_AngleBetween", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float AngleBetween(IntPtr rotation0, IntPtr rotation1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Rotate_Vector3")]
-            public static extern global::System.IntPtr RotateVector3(global::System.Runtime.InteropServices.HandleRef rotation, global::System.Runtime.InteropServices.HandleRef vector3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Rotate_Vector3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr RotateVector3(IntPtr rotation, IntPtr vector3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Rotate_Vector4")]
-            public static extern global::System.IntPtr RotateVector4(global::System.Runtime.InteropServices.HandleRef rotation, global::System.Runtime.InteropServices.HandleRef vector4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Rotation_Rotate_Vector4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr RotateVector4(IntPtr rotation, IntPtr vector4);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.RotationGesture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.RotationGesture.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,57 +26,62 @@ namespace Tizen.NUI
         internal static partial class RotationGesture
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetector_New")]
-            public static extern global::System.IntPtr RotationGestureDetectorNew();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetector_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr RotationGestureDetectorNew();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_RotationGestureDetector")]
-            public static extern void DeleteRotationGestureDetector(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_RotationGestureDetector", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteRotationGestureDetector(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RotationGestureDetector__SWIG_1")]
-            public static extern global::System.IntPtr NewRotationGestureDetector(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RotationGestureDetector__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRotationGestureDetector(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetector_Assign")]
-            public static extern global::System.IntPtr RotationGestureDetectorAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetector_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr RotationGestureDetectorAssign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetector_DetectedSignal")]
-            public static extern global::System.IntPtr RotationGestureDetectorDetectedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetector_DetectedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr RotationGestureDetectorDetectedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGesture_New")]
-            public static extern global::System.IntPtr New(int jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGesture_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_RotationGesture")]
-            public static extern void DeleteRotationGesture(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_RotationGesture", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteRotationGesture(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGesture_rotation_get")]
-            public static extern float RotationGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGesture_rotation_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RotationGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGesture_screenCenterPoint_get")]
-            public static extern global::System.IntPtr ScreenCenterPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGesture_screenCenterPoint_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ScreenCenterPointGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGesture_localCenterPoint_get")]
-            public static extern global::System.IntPtr LocalCenterPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGesture_localCenterPoint_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr LocalCenterPointGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetectedSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetectedSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool RotationGestureDetectedSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool RotationGestureDetectedSignalEmpty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetectedSignal_GetConnectionCount")]
-            public static extern uint RotationGestureDetectedSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetectedSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint RotationGestureDetectedSignalGetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetectedSignal_Connect")]
-            public static extern void RotationGestureDetectedSignalConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetectedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RotationGestureDetectedSignalConnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetectedSignal_Disconnect")]
-            public static extern void RotationGestureDetectedSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetectedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RotationGestureDetectedSignalDisconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetectedSignal_Emit")]
-            public static extern void RotationGestureDetectedSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetectedSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RotationGestureDetectedSignalEmit(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RotationGestureDetectedSignal")]
-            public static extern global::System.IntPtr NewRotationGestureDetectedSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RotationGestureDetectedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRotationGestureDetectedSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_RotationGestureDetectedSignal")]
-            public static extern void DeleteRotationGestureDetectedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_RotationGestureDetectedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteRotationGestureDetectedSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Ruler.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Ruler.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,260 +26,265 @@ namespace Tizen.NUI
         internal static partial class Ruler
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RulerDomain__SWIG_0")]
-            public static extern global::System.IntPtr NewRulerDomain(float jarg1, float jarg2, bool jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RulerDomain__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRulerDomain(float jarg1, float jarg2, [MarshalAs(UnmanagedType.U1)] bool jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RulerDomain__SWIG_1")]
-            public static extern global::System.IntPtr NewRulerDomain(float jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RulerDomain__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRulerDomain(float jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_min_set")]
-            public static extern void RulerDomainMinSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_min_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RulerDomainMinSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_min_get")]
-            public static extern float RulerDomainMinGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_min_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RulerDomainMinGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_max_set")]
-            public static extern void RulerDomainMaxSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_max_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RulerDomainMaxSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_max_get")]
-            public static extern float RulerDomainMaxGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_max_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RulerDomainMaxGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_enabled_set")]
-            public static extern void RulerDomainEnabledSet(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_enabled_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RulerDomainEnabledSet(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_enabled_get")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_enabled_get", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool RulerDomainEnabledGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool RulerDomainEnabledGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_Clamp__SWIG_0")]
-            public static extern float RulerDomainClamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_Clamp__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RulerDomainClamp(IntPtr jarg1, float jarg2, float jarg3, float jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_Clamp__SWIG_1")]
-            public static extern float RulerDomainClamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_Clamp__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RulerDomainClamp(IntPtr jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_Clamp__SWIG_2")]
-            public static extern float RulerDomainClamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_Clamp__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RulerDomainClamp(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_Clamp__SWIG_3")]
-            public static extern float RulerDomainClamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4, global::System.Runtime.InteropServices.HandleRef jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_Clamp__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RulerDomainClamp(IntPtr jarg1, float jarg2, float jarg3, float jarg4, IntPtr jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_GetSize")]
-            public static extern float RulerDomainGetSize(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerDomain_GetSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RulerDomainGetSize(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_RulerDomain")]
-            public static extern void DeleteRulerDomain(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_RulerDomain", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteRulerDomain(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_Snap__SWIG_0")]
-            public static extern float Snap(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_Snap__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float Snap(IntPtr jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_Snap__SWIG_1")]
-            public static extern float Snap(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_Snap__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float Snap(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_GetPositionFromPage")]
-            public static extern float GetPositionFromPage(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, out uint jarg3, bool jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_GetPositionFromPage", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetPositionFromPage(IntPtr jarg1, uint jarg2, out uint jarg3, [MarshalAs(UnmanagedType.U1)] bool jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_GetPageFromPosition")]
-            public static extern uint GetPageFromPosition(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, bool jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_GetPageFromPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetPageFromPosition(IntPtr jarg1, float jarg2, [MarshalAs(UnmanagedType.U1)] bool jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_GetTotalPages")]
-            public static extern uint GetTotalPages(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_GetTotalPages", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetTotalPages(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_GetType")]
-            public static extern int GetType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_GetType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetType(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_IsEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_IsEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_Enable")]
-            public static extern void Enable(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_Enable", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Enable(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_Disable")]
-            public static extern void Disable(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_Disable", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disable(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_SetDomain")]
-            public static extern void SetDomain(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_SetDomain", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetDomain(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_GetDomain")]
-            public static extern global::System.IntPtr GetDomain(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_GetDomain", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetDomain(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_DisableDomain")]
-            public static extern void DisableDomain(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_DisableDomain", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DisableDomain(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_Clamp__SWIG_0")]
-            public static extern float Clamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_Clamp__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float Clamp(IntPtr jarg1, float jarg2, float jarg3, float jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_Clamp__SWIG_1")]
-            public static extern float Clamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_Clamp__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float Clamp(IntPtr jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_Clamp__SWIG_2")]
-            public static extern float Clamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_Clamp__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float Clamp(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_Clamp__SWIG_3")]
-            public static extern float Clamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4, global::System.Runtime.InteropServices.HandleRef jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_Clamp__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float Clamp(IntPtr jarg1, float jarg2, float jarg3, float jarg4, IntPtr jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_SnapAndClamp__SWIG_0")]
-            public static extern float SnapAndClamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4, float jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_SnapAndClamp__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float SnapAndClamp(IntPtr jarg1, float jarg2, float jarg3, float jarg4, float jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_SnapAndClamp__SWIG_1")]
-            public static extern float SnapAndClamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_SnapAndClamp__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float SnapAndClamp(IntPtr jarg1, float jarg2, float jarg3, float jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_SnapAndClamp__SWIG_2")]
-            public static extern float SnapAndClamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_SnapAndClamp__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float SnapAndClamp(IntPtr jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_SnapAndClamp__SWIG_3")]
-            public static extern float SnapAndClamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_SnapAndClamp__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float SnapAndClamp(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_SnapAndClamp__SWIG_4")]
-            public static extern float SnapAndClamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4, float jarg5, global::System.Runtime.InteropServices.HandleRef jarg6);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Ruler_SnapAndClamp__SWIG_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float SnapAndClamp(IntPtr jarg1, float jarg2, float jarg3, float jarg4, float jarg5, IntPtr jarg6);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_DefaultRuler")]
-            public static extern global::System.IntPtr NewDefaultRuler();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_DefaultRuler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewDefaultRuler();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DefaultRuler_Snap")]
-            public static extern float DefaultRulerSnap(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DefaultRuler_Snap", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float DefaultRulerSnap(IntPtr jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DefaultRuler_GetPositionFromPage")]
-            public static extern float DefaultRulerGetPositionFromPage(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, out uint jarg3, bool jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DefaultRuler_GetPositionFromPage", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float DefaultRulerGetPositionFromPage(IntPtr jarg1, uint jarg2, out uint jarg3, [MarshalAs(UnmanagedType.U1)] bool jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DefaultRuler_GetPageFromPosition")]
-            public static extern uint DefaultRulerGetPageFromPosition(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, bool jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DefaultRuler_GetPageFromPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint DefaultRulerGetPageFromPosition(IntPtr jarg1, float jarg2, [MarshalAs(UnmanagedType.U1)] bool jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DefaultRuler_GetTotalPages")]
-            public static extern uint DefaultRulerGetTotalPages(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DefaultRuler_GetTotalPages", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint DefaultRulerGetTotalPages(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_DefaultRuler")]
-            public static extern void DeleteDefaultRuler(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_DefaultRuler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteDefaultRuler(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FixedRuler__SWIG_0")]
-            public static extern global::System.IntPtr NewFixedRuler(float jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FixedRuler__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewFixedRuler(float jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FixedRuler__SWIG_1")]
-            public static extern global::System.IntPtr NewFixedRuler();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FixedRuler__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewFixedRuler();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FixedRuler_Snap")]
-            public static extern float FixedRulerSnap(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FixedRuler_Snap", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float FixedRulerSnap(IntPtr jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FixedRuler_GetPositionFromPage")]
-            public static extern float FixedRulerGetPositionFromPage(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, out uint jarg3, bool jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FixedRuler_GetPositionFromPage", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float FixedRulerGetPositionFromPage(IntPtr jarg1, uint jarg2, out uint jarg3, [MarshalAs(UnmanagedType.U1)] bool jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FixedRuler_GetPageFromPosition")]
-            public static extern uint FixedRulerGetPageFromPosition(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, bool jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FixedRuler_GetPageFromPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint FixedRulerGetPageFromPosition(IntPtr jarg1, float jarg2, [MarshalAs(UnmanagedType.U1)] bool jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FixedRuler_GetTotalPages")]
-            public static extern uint FixedRulerGetTotalPages(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FixedRuler_GetTotalPages", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint FixedRulerGetTotalPages(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FixedRuler")]
-            public static extern void DeleteFixedRuler(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FixedRuler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteFixedRuler(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RulerPtr__SWIG_0")]
-            public static extern global::System.IntPtr NewRulerPtr();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RulerPtr__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRulerPtr();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RulerPtr__SWIG_1")]
-            public static extern global::System.IntPtr NewRulerPtr(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RulerPtr__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRulerPtr(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RulerPtr__SWIG_2")]
-            public static extern global::System.IntPtr NewRulerPtrPtr(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RulerPtr__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRulerPtrPtr(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_RulerPtr")]
-            public static extern void DeleteRulerPtr(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_RulerPtr", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteRulerPtr(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Get")]
-            public static extern global::System.IntPtr RulerPtrGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr RulerPtrGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr___deref__")]
-            public static extern global::System.IntPtr RulerPtrDeref(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr___deref__", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr RulerPtrDeref(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr___ref__")]
-            public static extern global::System.IntPtr RulerPtrRef(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr___ref__", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr RulerPtrRef(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Assign__SWIG_0")]
-            public static extern global::System.IntPtr AssignPtr(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Assign__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr AssignPtr(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Assign__SWIG_1")]
-            public static extern global::System.IntPtr RulerPtrAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Assign__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr RulerPtrAssign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Reset__SWIG_0")]
-            public static extern void RulerPtrReset(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Reset__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RulerPtrReset(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Reset__SWIG_1")]
-            public static extern void RulerPtrReset(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Reset__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RulerPtrReset(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Detach")]
-            public static extern global::System.IntPtr RulerPtrDetach(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Detach", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr RulerPtrDetach(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Snap__SWIG_0")]
-            public static extern float RulerPtrSnap(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Snap__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RulerPtrSnap(IntPtr jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Snap__SWIG_1")]
-            public static extern float RulerPtrSnap(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Snap__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RulerPtrSnap(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_GetPositionFromPage")]
-            public static extern float RulerPtrGetPositionFromPage(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, out uint jarg3, bool jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_GetPositionFromPage", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RulerPtrGetPositionFromPage(IntPtr jarg1, uint jarg2, out uint jarg3, [MarshalAs(UnmanagedType.U1)] bool jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_GetPageFromPosition")]
-            public static extern uint RulerPtrGetPageFromPosition(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, bool jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_GetPageFromPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint RulerPtrGetPageFromPosition(IntPtr jarg1, float jarg2, [MarshalAs(UnmanagedType.U1)] bool jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_GetTotalPages")]
-            public static extern uint RulerPtrGetTotalPages(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_GetTotalPages", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint RulerPtrGetTotalPages(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_GetType")]
-            public static extern int RulerPtrGetType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_GetType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RulerPtrGetType(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_IsEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_IsEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool RulerPtrIsEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool RulerPtrIsEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Enable")]
-            public static extern void RulerPtrEnable(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Enable", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RulerPtrEnable(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Disable")]
-            public static extern void RulerPtrDisable(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Disable", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RulerPtrDisable(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_SetDomain")]
-            public static extern void RulerPtrSetDomain(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_SetDomain", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RulerPtrSetDomain(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_GetDomain")]
-            public static extern global::System.IntPtr RulerPtrGetDomain(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_GetDomain", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr RulerPtrGetDomain(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_DisableDomain")]
-            public static extern void RulerPtrDisableDomain(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_DisableDomain", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RulerPtrDisableDomain(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Clamp__SWIG_0")]
-            public static extern float RulerPtrClamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Clamp__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RulerPtrClamp(IntPtr jarg1, float jarg2, float jarg3, float jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Clamp__SWIG_1")]
-            public static extern float RulerPtrClamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Clamp__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RulerPtrClamp(IntPtr jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Clamp__SWIG_2")]
-            public static extern float RulerPtrClamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Clamp__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RulerPtrClamp(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Clamp__SWIG_3")]
-            public static extern float RulerPtrClamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4, global::System.Runtime.InteropServices.HandleRef jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Clamp__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RulerPtrClamp(IntPtr jarg1, float jarg2, float jarg3, float jarg4, IntPtr jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_SnapAndClamp__SWIG_0")]
-            public static extern float RulerPtrSnapAndClamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4, float jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_SnapAndClamp__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RulerPtrSnapAndClamp(IntPtr jarg1, float jarg2, float jarg3, float jarg4, float jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_SnapAndClamp__SWIG_1")]
-            public static extern float RulerPtrSnapAndClamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_SnapAndClamp__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RulerPtrSnapAndClamp(IntPtr jarg1, float jarg2, float jarg3, float jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_SnapAndClamp__SWIG_2")]
-            public static extern float RulerPtrSnapAndClamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_SnapAndClamp__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RulerPtrSnapAndClamp(IntPtr jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_SnapAndClamp__SWIG_3")]
-            public static extern float RulerPtrSnapAndClamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_SnapAndClamp__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RulerPtrSnapAndClamp(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_SnapAndClamp__SWIG_4")]
-            public static extern float RulerPtrSnapAndClamp(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4, float jarg5, global::System.Runtime.InteropServices.HandleRef jarg6);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_SnapAndClamp__SWIG_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RulerPtrSnapAndClamp(IntPtr jarg1, float jarg2, float jarg3, float jarg4, float jarg5, IntPtr jarg6);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Reference")]
-            public static extern void RulerPtrReference(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Reference", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RulerPtrReference(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Unreference")]
-            public static extern void RulerPtrUnreference(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_Unreference", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RulerPtrUnreference(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_ReferenceCount")]
-            public static extern int RulerPtrReferenceCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RulerPtr_ReferenceCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RulerPtrReferenceCount(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Sampler.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Sampler.cs
@@ -15,26 +15,35 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Sampler
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Sampler_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Sampler_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Sampler")]
-            public static extern void DeleteSampler(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Sampler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteSampler(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Sampler_SetFilterMode")]
-            public static extern void SetFilterMode(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Sampler_SetFilterMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFilterMode(IntPtr jarg1, int jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Sampler_SetWrapMode__SWIG_0")]
-            public static extern void SetWrapMode(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Sampler_SetWrapMode__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetWrapMode(IntPtr jarg1, int jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Sampler_SetWrapMode__SWIG_1")]
-            public static extern void SetWrapMode(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3, int jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Sampler_SetWrapMode__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetWrapMode(IntPtr jarg1, int jarg2, int jarg3, int jarg4);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ScaleTransitionItem.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ScaleTransitionItem.cs
@@ -15,30 +15,34 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
-    using global::System;
-    using global::System.Runtime.InteropServices;
-
     internal static partial class Interop
     {
         internal static partial class ScaleTransitionItem
         {
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScaleTransition_New_1")]
-            public static extern IntPtr New(HandleRef view, float scale, HandleRef timePeriod);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScaleTransition_New_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr New(IntPtr view, float scale, IntPtr timePeriod);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScaleTransition_New_2")]
-            public static extern IntPtr New(HandleRef view, HandleRef scale, HandleRef timePeriod);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScaleTransition_New_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr New(IntPtr view, IntPtr scale, IntPtr timePeriod);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ScaleTransition")]
-            public static extern void Delete(HandleRef scaleTransition);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ScaleTransition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Delete(IntPtr scaleTransition);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ScaleTransition_Set")]
-            public static extern IntPtr NewScaleTransitionItem(HandleRef scaleTransition);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ScaleTransition_Set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr NewScaleTransitionItem(IntPtr scaleTransition);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScaleTransition_Assign")]
-            public static extern IntPtr Assign(HandleRef destination, HandleRef source);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScaleTransition_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr Assign(IntPtr destination, IntPtr source);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ScrollBar.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ScrollBar.cs
@@ -24,3 +24,5 @@ namespace Tizen.NUI
         }
     }
 }
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ScrollStateChangeSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ScrollStateChangeSignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class ScrollStateChangedSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollStateChangedSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollStateChangedSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollStateChangedSignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollStateChangedSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollStateChangedSignal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollStateChangedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollStateChangedSignal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollStateChangedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollStateChangedSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollStateChangedSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ScrollStateChangedSignal")]
-            public static extern global::System.IntPtr NewScrollStateChangedSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ScrollStateChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewScrollStateChangedSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ScrollStateChangedSignal")]
-            public static extern void DeleteScrollStateChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ScrollStateChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteScrollStateChangedSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ScrollView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ScrollView.cs
@@ -15,329 +15,338 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class ScrollView
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ScrollViewEffect")]
-            public static extern global::System.IntPtr NewScrollViewEffect();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ScrollViewEffect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewScrollViewEffect();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ScrollViewEffect")]
-            public static extern void DeleteScrollViewEffect(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ScrollViewEffect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteScrollViewEffect(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewPagePathEffect_New")]
-            public static extern global::System.IntPtr ScrollViewPagePathEffectNew(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, uint jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewPagePathEffect_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ScrollViewPagePathEffectNew(IntPtr jarg1, IntPtr jarg2, int jarg3, IntPtr jarg4, uint jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewPagePathEffect_ApplyToPage")]
-            public static extern void ScrollViewPagePathEffectApplyToPage(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, uint jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewPagePathEffect_ApplyToPage", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ScrollViewPagePathEffectApplyToPage(IntPtr jarg1, IntPtr jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ScrollViewPagePathEffect")]
-            public static extern void DeleteScrollViewPagePathEffect(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ScrollViewPagePathEffect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteScrollViewPagePathEffect(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SnapEvent_type_set")]
-            public static extern void SnapEventTypeSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SnapEvent_type_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SnapEventTypeSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SnapEvent_type_get")]
-            public static extern int SnapEventTypeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SnapEvent_type_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SnapEventTypeGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SnapEvent_position_set")]
-            public static extern void SnapEventPositionSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SnapEvent_position_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SnapEventPositionSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SnapEvent_position_get")]
-            public static extern global::System.IntPtr SnapEventPositionGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SnapEvent_position_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr SnapEventPositionGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SnapEvent_duration_set")]
-            public static extern void SnapEventDurationSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SnapEvent_duration_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SnapEventDurationSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SnapEvent_duration_get")]
-            public static extern float SnapEventDurationGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SnapEvent_duration_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float SnapEventDurationGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ScrollView_SnapEvent")]
-            public static extern global::System.IntPtr NewScrollViewSnapEvent();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ScrollView_SnapEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewScrollViewSnapEvent();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ScrollView_SnapEvent")]
-            public static extern void DeleteScrollViewSnapEvent(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ScrollView_SnapEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteScrollViewSnapEvent(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_WRAP_ENABLED_get")]
-            public static extern int WrapEnabledGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_WRAP_ENABLED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WrapEnabledGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_PANNING_ENABLED_get")]
-            public static extern int PanningEnabledGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_PANNING_ENABLED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PanningEnabledGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_AXIS_AUTO_LOCK_ENABLED_get")]
-            public static extern int AxisAutoLockEnabledGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_AXIS_AUTO_LOCK_ENABLED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AxisAutoLockEnabledGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_WHEEL_SCROLL_DISTANCE_STEP_get")]
-            public static extern int WheelScrollDistanceStepGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_WHEEL_SCROLL_DISTANCE_STEP_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WheelScrollDistanceStepGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_MODE_get")]
-            public static extern int ScrollModeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_MODE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollModeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_POSITION_get")]
-            public static extern int ScrollPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollPositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_PRE_POSITION_get")]
-            public static extern int ScrollPrePositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_PRE_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollPrePositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_PRE_POSITION_X_get")]
-            public static extern int ScrollPrePositionXGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_PRE_POSITION_X_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollPrePositionXGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_PRE_POSITION_Y_get")]
-            public static extern int ScrollPrePositionYGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_PRE_POSITION_Y_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollPrePositionYGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_PRE_POSITION_MAX_get")]
-            public static extern int ScrollPrePositionMaxGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_PRE_POSITION_MAX_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollPrePositionMaxGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_PRE_POSITION_MAX_X_get")]
-            public static extern int ScrollPrePositionMaxXGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_PRE_POSITION_MAX_X_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollPrePositionMaxXGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_PRE_POSITION_MAX_Y_get")]
-            public static extern int ScrollPrePositionMaxYGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_PRE_POSITION_MAX_Y_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollPrePositionMaxYGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_OVERSHOOT_X_get")]
-            public static extern int OvershootXGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_OVERSHOOT_X_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int OvershootXGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_OVERSHOOT_Y_get")]
-            public static extern int OvershootYGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_OVERSHOOT_Y_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int OvershootYGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_FINAL_get")]
-            public static extern int ScrollFinalGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_FINAL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollFinalGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_FINAL_X_get")]
-            public static extern int ScrollFinalXGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_FINAL_X_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollFinalXGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_FINAL_Y_get")]
-            public static extern int ScrollFinalYGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_FINAL_Y_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollFinalYGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_WRAP_get")]
-            public static extern int WrapGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_WRAP_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WrapGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_PANNING_get")]
-            public static extern int PanningGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_PANNING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PanningGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLLING_get")]
-            public static extern int ScrollingGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLLING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollingGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_DOMAIN_SIZE_get")]
-            public static extern int ScrollDomainSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_DOMAIN_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollDomainSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_DOMAIN_SIZE_X_get")]
-            public static extern int ScrollDomainSizeXGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_DOMAIN_SIZE_X_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollDomainSizeXGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_DOMAIN_SIZE_Y_get")]
-            public static extern int ScrollDomainSizeYGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_DOMAIN_SIZE_Y_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollDomainSizeYGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_DOMAIN_OFFSET_get")]
-            public static extern int ScrollDomainOffsetGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_DOMAIN_OFFSET_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollDomainOffsetGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_POSITION_DELTA_get")]
-            public static extern int ScrollPositionDeltaGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_SCROLL_POSITION_DELTA_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollPositionDeltaGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_START_PAGE_POSITION_get")]
-            public static extern int StartPagePositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_Property_START_PAGE_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int StartPagePositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ScrollView")]
-            public static extern void DeleteScrollView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ScrollView", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteScrollView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetScrollSnapAlphaFunction")]
-            public static extern global::System.IntPtr GetScrollSnapAlphaFunction(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetScrollSnapAlphaFunction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetScrollSnapAlphaFunction(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetScrollSnapAlphaFunction")]
-            public static extern void SetScrollSnapAlphaFunction(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetScrollSnapAlphaFunction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetScrollSnapAlphaFunction(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetScrollFlickAlphaFunction")]
-            public static extern global::System.IntPtr GetScrollFlickAlphaFunction(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetScrollFlickAlphaFunction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetScrollFlickAlphaFunction(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetScrollFlickAlphaFunction")]
-            public static extern void SetScrollFlickAlphaFunction(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetScrollFlickAlphaFunction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetScrollFlickAlphaFunction(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetScrollSnapDuration")]
-            public static extern float GetScrollSnapDuration(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetScrollSnapDuration", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetScrollSnapDuration(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetScrollSnapDuration")]
-            public static extern void SetScrollSnapDuration(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetScrollSnapDuration", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetScrollSnapDuration(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetScrollFlickDuration")]
-            public static extern float GetScrollFlickDuration(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetScrollFlickDuration", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetScrollFlickDuration(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetScrollFlickDuration")]
-            public static extern void SetScrollFlickDuration(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetScrollFlickDuration", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetScrollFlickDuration(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetRulerX")]
-            public static extern void SetRulerX(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetRulerX", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetRulerX(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetRulerY")]
-            public static extern void SetRulerY(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetRulerY", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetRulerY(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetScrollSensitive")]
-            public static extern void SetScrollSensitive(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetScrollSensitive", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetScrollSensitive(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetMaxOvershoot")]
-            public static extern void SetMaxOvershoot(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetMaxOvershoot", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMaxOvershoot(IntPtr jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetSnapOvershootAlphaFunction")]
-            public static extern void SetSnapOvershootAlphaFunction(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetSnapOvershootAlphaFunction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetSnapOvershootAlphaFunction(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetSnapOvershootDuration")]
-            public static extern void SetSnapOvershootDuration(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetSnapOvershootDuration", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetSnapOvershootDuration(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetActorAutoSnap")]
-            public static extern void SetActorAutoSnap(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetActorAutoSnap", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetActorAutoSnap(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetWrapMode")]
-            public static extern void SetWrapMode(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetWrapMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetWrapMode(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetScrollUpdateDistance")]
-            public static extern int GetScrollUpdateDistance(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetScrollUpdateDistance", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetScrollUpdateDistance(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetScrollUpdateDistance")]
-            public static extern void SetScrollUpdateDistance(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetScrollUpdateDistance", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetScrollUpdateDistance(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetAxisAutoLock")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetAxisAutoLock", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetAxisAutoLock(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool GetAxisAutoLock(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetAxisAutoLock")]
-            public static extern void SetAxisAutoLock(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetAxisAutoLock", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetAxisAutoLock(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetAxisAutoLockGradient")]
-            public static extern float GetAxisAutoLockGradient(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetAxisAutoLockGradient", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetAxisAutoLockGradient(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetAxisAutoLockGradient")]
-            public static extern void SetAxisAutoLockGradient(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetAxisAutoLockGradient", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetAxisAutoLockGradient(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetFrictionCoefficient")]
-            public static extern float GetFrictionCoefficient(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetFrictionCoefficient", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetFrictionCoefficient(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetFrictionCoefficient")]
-            public static extern void SetFrictionCoefficient(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetFrictionCoefficient", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFrictionCoefficient(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetFlickSpeedCoefficient")]
-            public static extern float GetFlickSpeedCoefficient(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetFlickSpeedCoefficient", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetFlickSpeedCoefficient(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetFlickSpeedCoefficient")]
-            public static extern void SetFlickSpeedCoefficient(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetFlickSpeedCoefficient", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFlickSpeedCoefficient(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetMinimumDistanceForFlick")]
-            public static extern global::System.IntPtr GetMinimumDistanceForFlick(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetMinimumDistanceForFlick", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetMinimumDistanceForFlick(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetMinimumDistanceForFlick")]
-            public static extern void SetMinimumDistanceForFlick(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetMinimumDistanceForFlick", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMinimumDistanceForFlick(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetMinimumSpeedForFlick")]
-            public static extern float GetMinimumSpeedForFlick(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetMinimumSpeedForFlick", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetMinimumSpeedForFlick(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetMinimumSpeedForFlick")]
-            public static extern void SetMinimumSpeedForFlick(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetMinimumSpeedForFlick", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMinimumSpeedForFlick(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetMaxFlickSpeed")]
-            public static extern float GetMaxFlickSpeed(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetMaxFlickSpeed", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetMaxFlickSpeed(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetMaxFlickSpeed")]
-            public static extern void SetMaxFlickSpeed(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetMaxFlickSpeed", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMaxFlickSpeed(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetCurrentScrollPosition")]
-            public static extern global::System.IntPtr GetCurrentScrollPosition(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetCurrentScrollPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetCurrentScrollPosition(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetCurrentPage")]
-            public static extern uint GetCurrentPage(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_GetCurrentPage", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetCurrentPage(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_0")]
-            public static extern void ScrollToVector2(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ScrollToVector2(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_1")]
-            public static extern void ScrollTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ScrollTo(IntPtr jarg1, IntPtr jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_2")]
-            public static extern void ScrollTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, float jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ScrollTo(IntPtr jarg1, IntPtr jarg2, float jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_3")]
-            public static extern void ScrollTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, float jarg3, int jarg4, int jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ScrollTo(IntPtr jarg1, IntPtr jarg2, float jarg3, int jarg4, int jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_4")]
-            public static extern void ScrollTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, float jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, int jarg5, int jarg6);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ScrollTo(IntPtr jarg1, IntPtr jarg2, float jarg3, IntPtr jarg4, int jarg5, int jarg6);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_5")]
-            public static extern void ScrollTo(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_5", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ScrollTo(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_6")]
-            public static extern void ScrollTo(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_6", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ScrollTo(IntPtr jarg1, uint jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_7")]
-            public static extern void ScrollTo(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, float jarg3, int jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_7", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ScrollTo(IntPtr jarg1, uint jarg2, float jarg3, int jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_8")]
-            public static extern void ScrollToView(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_8", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ScrollToView(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_9")]
-            public static extern void ScrollToViewDuration(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollTo__SWIG_9", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ScrollToViewDuration(IntPtr jarg1, IntPtr jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollToSnapPoint")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ScrollToSnapPoint", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool ScrollToSnapPoint(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool ScrollToSnapPoint(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ApplyConstraintToChildren")]
-            public static extern void ApplyConstraintToChildren(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ApplyConstraintToChildren", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ApplyConstraintToChildren(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ApplyEffect")]
-            public static extern void ApplyEffect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_ApplyEffect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ApplyEffect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_RemoveEffect")]
-            public static extern void RemoveEffect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_RemoveEffect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemoveEffect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_RemoveAllEffects")]
-            public static extern void RemoveAllEffects(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_RemoveAllEffects", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemoveAllEffects(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_BindActor")]
-            public static extern void BindActor(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_BindActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void BindActor(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_UnbindActor")]
-            public static extern void UnbindActor(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_UnbindActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void UnbindActor(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetScrollingDirection__SWIG_0")]
-            public static extern void SetScrollingDirection(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetScrollingDirection__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetScrollingDirection(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetScrollingDirection__SWIG_1")]
-            public static extern void SetScrollingDirection(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SetScrollingDirection__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetScrollingDirection(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_RemoveScrollingDirection")]
-            public static extern void RemoveScrollingDirection(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_RemoveScrollingDirection", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemoveScrollingDirection(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SnapStartedSignal")]
-            public static extern global::System.IntPtr SnapStartedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SnapStartedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr SnapStartedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewSnapStartedSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewSnapStartedSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool ScrollViewSnapStartedSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool ScrollViewSnapStartedSignalEmpty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewSnapStartedSignal_GetConnectionCount")]
-            public static extern uint ScrollViewSnapStartedSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewSnapStartedSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint ScrollViewSnapStartedSignalGetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewSnapStartedSignal_Connect")]
-            public static extern void ScrollViewSnapStartedSignalConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewSnapStartedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ScrollViewSnapStartedSignalConnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewSnapStartedSignal_Disconnect")]
-            public static extern void ScrollViewSnapStartedSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewSnapStartedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ScrollViewSnapStartedSignalDisconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewSnapStartedSignal_Emit")]
-            public static extern void ScrollViewSnapStartedSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewSnapStartedSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ScrollViewSnapStartedSignalEmit(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ScrollViewSnapStartedSignal")]
-            public static extern global::System.IntPtr NewScrollViewSnapStartedSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ScrollViewSnapStartedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewScrollViewSnapStartedSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ScrollViewSnapStartedSignal")]
-            public static extern void DeleteScrollViewSnapStartedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ScrollViewSnapStartedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteScrollViewSnapStartedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewEffect_SWIGUpcast")]
-            public static extern global::System.IntPtr ScrollViewEffectUpcast(global::System.IntPtr jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewEffect_SWIGUpcast", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ScrollViewEffectUpcast(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewPagePathEffect_SWIGUpcast")]
-            public static extern global::System.IntPtr ScrollViewPagePathEffectUpcast(global::System.IntPtr jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewPagePathEffect_SWIGUpcast", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ScrollViewPagePathEffectUpcast(global::System.IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Scrollable.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Scrollable.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,81 +26,86 @@ namespace Tizen.NUI
         internal static partial class Scrollable
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_OVERSHOOT_EFFECT_COLOR_get")]
-            public static extern int OvershootEffectColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_OVERSHOOT_EFFECT_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int OvershootEffectColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_OVERSHOOT_ANIMATION_SPEED_get")]
-            public static extern int OvershootAnimationSpeedGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_OVERSHOOT_ANIMATION_SPEED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int OvershootAnimationSpeedGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_OVERSHOOT_ENABLED_get")]
-            public static extern int OvershootEnabledGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_OVERSHOOT_ENABLED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int OvershootEnabledGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_OVERSHOOT_SIZE_get")]
-            public static extern int OvershootSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_OVERSHOOT_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int OvershootSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_SCROLL_TO_ALPHA_FUNCTION_get")]
-            public static extern int ScrollToAlphaFunctionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_SCROLL_TO_ALPHA_FUNCTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollToAlphaFunctionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_SCROLL_RELATIVE_POSITION_get")]
-            public static extern int ScrollRelativePositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_SCROLL_RELATIVE_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollRelativePositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_SCROLL_POSITION_MIN_get")]
-            public static extern int ScrollPositionMinGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_SCROLL_POSITION_MIN_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollPositionMinGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_SCROLL_POSITION_MIN_X_get")]
-            public static extern int ScrollPositionMinXGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_SCROLL_POSITION_MIN_X_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollPositionMinXGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_SCROLL_POSITION_MIN_Y_get")]
-            public static extern int ScrollPositionMinYGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_SCROLL_POSITION_MIN_Y_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollPositionMinYGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_SCROLL_POSITION_MAX_get")]
-            public static extern int ScrollPositionMaxGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_SCROLL_POSITION_MAX_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollPositionMaxGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_SCROLL_POSITION_MAX_X_get")]
-            public static extern int ScrollPositionMaxXGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_SCROLL_POSITION_MAX_X_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollPositionMaxXGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_SCROLL_POSITION_MAX_Y_get")]
-            public static extern int ScrollPositionMaxYGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_SCROLL_POSITION_MAX_Y_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollPositionMaxYGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_CAN_SCROLL_VERTICAL_get")]
-            public static extern int CanScrollVerticalGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_CAN_SCROLL_VERTICAL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CanScrollVerticalGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_CAN_SCROLL_HORIZONTAL_get")]
-            public static extern int CanScrollHorizontalGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_Property_CAN_SCROLL_HORIZONTAL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CanScrollHorizontalGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Scrollable__SWIG_0")]
-            public static extern global::System.IntPtr NewScrollable();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Scrollable__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewScrollable();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Scrollable")]
-            public static extern void DeleteScrollable(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Scrollable", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteScrollable(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_IsOvershootEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_IsOvershootEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsOvershootEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsOvershootEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_SetOvershootEnabled")]
-            public static extern void SetOvershootEnabled(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_SetOvershootEnabled", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetOvershootEnabled(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_SetOvershootEffectColor")]
-            public static extern void SetOvershootEffectColor(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_SetOvershootEffectColor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetOvershootEffectColor(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_GetOvershootEffectColor")]
-            public static extern global::System.IntPtr GetOvershootEffectColor(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_GetOvershootEffectColor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetOvershootEffectColor(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_SetOvershootAnimationSpeed")]
-            public static extern void SetOvershootAnimationSpeed(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_SetOvershootAnimationSpeed", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetOvershootAnimationSpeed(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_GetOvershootAnimationSpeed")]
-            public static extern float GetOvershootAnimationSpeed(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_GetOvershootAnimationSpeed", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetOvershootAnimationSpeed(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_ScrollStartedSignal")]
-            public static extern global::System.IntPtr ScrollStartedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_ScrollStartedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ScrollStartedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_ScrollUpdatedSignal")]
-            public static extern global::System.IntPtr ScrollUpdatedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_ScrollUpdatedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ScrollUpdatedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_ScrollCompletedSignal")]
-            public static extern global::System.IntPtr ScrollCompletedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Scrollable_ScrollCompletedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ScrollCompletedSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ScrollableSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ScrollableSignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class ScrollableSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollableSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollableSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollableSignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollableSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollableSignal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollableSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollableSignal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollableSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollableSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollableSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ScrollableSignal")]
-            public static extern global::System.IntPtr NewScrollableSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ScrollableSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewScrollableSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ScrollableSignal")]
-            public static extern void DeleteScrollableSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ScrollableSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteScrollableSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Shader.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Shader.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,20 +26,25 @@ namespace Tizen.NUI
         internal static partial class Shader
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shader_Property_PROGRAM_get")]
-            public static extern int ProgramGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shader_Property_PROGRAM_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ProgramGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shader_New__SWIG_0")]
-            public static extern global::System.IntPtr New(string jarg1, string jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shader_New__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(string jarg1, string jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shader_New__SWIG_1")]
-            public static extern global::System.IntPtr New(string jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shader_New__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(string jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shader_New__SWIG_2")]
-            public static extern global::System.IntPtr New(string vertexShaderCode, string fragmentShaderCode, int hints, string shaderName);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shader_New__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(string vertexShaderCode, string fragmentShaderCode, int hints, string shaderName);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Shader")]
-            public static extern void DeleteShader(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Shader", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteShader(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Shape.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Shape.cs
@@ -15,109 +15,118 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Shape
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_AddRect")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_AddRect", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddRect(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4, float jarg5, float jarg6, float jarg7);
+            public static partial bool AddRect(IntPtr jarg1, float jarg2, float jarg3, float jarg4, float jarg5, float jarg6, float jarg7);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_AddCircle")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_AddCircle", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddCircle(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4, float jarg5);
+            public static partial bool AddCircle(IntPtr jarg1, float jarg2, float jarg3, float jarg4, float jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_AddArc")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_AddArc", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddArc(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4, float jarg5, float jarg6, bool jarg7);
+            public static partial bool AddArc(IntPtr jarg1, float jarg2, float jarg3, float jarg4, float jarg5, float jarg6, [MarshalAs(UnmanagedType.U1)] bool jarg7);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_AddMoveTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_AddMoveTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddMoveTo(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3);
+            public static partial bool AddMoveTo(IntPtr jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_AddLineTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_AddLineTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddLineTo(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3);
+            public static partial bool AddLineTo(IntPtr jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_AddCubicTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_AddCubicTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddCubicTo(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4, float jarg5, float jarg6, float jarg7);
+            public static partial bool AddCubicTo(IntPtr jarg1, float jarg2, float jarg3, float jarg4, float jarg5, float jarg6, float jarg7);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_AddPath")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_AddPath", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern void AddPath(global::System.Runtime.InteropServices.HandleRef pShape, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] BaseComponents.VectorGraphics.PathCommandType[] commands, uint commandCount, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] float[] points, uint pointCount);
+            public static partial void AddPath(IntPtr pShape, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] BaseComponents.VectorGraphics.PathCommandType[] commands, uint commandCount, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] float[] points, uint pointCount);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_Close")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_Close", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Close(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Close(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_ResetPath")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_ResetPath", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool ResetPath(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool ResetPath(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_SetFillColor")]
-            public static extern void SetFillColor(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_SetFillColor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFillColor(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_GetFillColor")]
-            public static extern global::System.IntPtr GetFillColor(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_GetFillColor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetFillColor(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_SetFillRule")]
-            public static extern void SetFillRule(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_SetFillRule", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFillRule(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_GetFillRule")]
-            public static extern int GetFillRule(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_GetFillRule", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetFillRule(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_SetStrokeWidth")]
-            public static extern void SetStrokeWidth(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_SetStrokeWidth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetStrokeWidth(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_GetStrokeWidth")]
-            public static extern float GetStrokeWidth(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_GetStrokeWidth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetStrokeWidth(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_SetStrokeColor")]
-            public static extern void SetStrokeColor(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_SetStrokeColor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetStrokeColor(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_GetStrokeColor")]
-            public static extern global::System.IntPtr GetStrokeColor(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_GetStrokeColor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetStrokeColor(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_SetStrokeDash")]
-            public static extern void SetStrokeDash(global::System.Runtime.InteropServices.HandleRef jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] float[] jarg2, uint jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_SetStrokeDash", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetStrokeDash(IntPtr jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] float[] jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_GetStrokeDashIndexOf")]
-            public static extern float GetStrokeDashIndexOf(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_GetStrokeDashIndexOf", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetStrokeDashIndexOf(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_GetStrokeDashCount")]
-            public static extern uint GetStrokeDashCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_GetStrokeDashCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetStrokeDashCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_SetStrokeCap")]
-            public static extern void SetStrokeCap(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_SetStrokeCap", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetStrokeCap(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_GetStrokeCap")]
-            public static extern int GetStrokeCap(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_GetStrokeCap", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetStrokeCap(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_SetStrokeJoin")]
-            public static extern void SetStrokeJoin(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_SetStrokeJoin", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetStrokeJoin(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_GetStrokeJoin")]
-            public static extern int GetStrokeJoin(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shape_GetStrokeJoin", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetStrokeJoin(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shapep_SetFillGradient")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shapep_SetFillGradient", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SetFillGradient(global::System.Runtime.InteropServices.HandleRef pShape, global::System.Runtime.InteropServices.HandleRef pGradient);
+            public static partial bool SetFillGradient(IntPtr pShape, IntPtr pGradient);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shapep_GetFillGradient")]
-            public static extern global::System.IntPtr GetFillGradient(global::System.Runtime.InteropServices.HandleRef pShape);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shapep_GetFillGradient", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetFillGradient(IntPtr pShape);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shapep_SetStrokeGradient")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shapep_SetStrokeGradient", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SetStrokeGradient(global::System.Runtime.InteropServices.HandleRef pShape, global::System.Runtime.InteropServices.HandleRef pGradient);
+            public static partial bool SetStrokeGradient(IntPtr pShape, IntPtr pGradient);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shapep_GetStrokeGradient")]
-            public static extern global::System.IntPtr GetStrokeGradient(global::System.Runtime.InteropServices.HandleRef pShape);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Shapep_GetStrokeGradient", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetStrokeGradient(IntPtr pShape);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.SingalObserver.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.SingalObserver.cs
@@ -15,17 +15,26 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class SignalObserver
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_SignalObserver")]
-            public static extern void DeleteSignalObserver(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_SignalObserver", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteSignalObserver(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SignalObserver_SignalDisconnected")]
-            public static extern void SignalDisconnected(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SignalObserver_SignalDisconnected", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SignalDisconnected(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.SlideTransitionItem.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.SlideTransitionItem.cs
@@ -15,26 +15,30 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
-    using global::System;
-    using global::System.Runtime.InteropServices;
-
     internal static partial class Interop
     {
         internal static partial class SlideTransitionItem
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SlideTransition_New")]
-            public static extern IntPtr New(HandleRef view, HandleRef direction, HandleRef timePeriod);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SlideTransition_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr New(IntPtr view, IntPtr direction, IntPtr timePeriod);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_SlideTransition")]
-            public static extern void Delete(HandleRef slideTransition);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_SlideTransition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Delete(IntPtr slideTransition);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_SlideTransition_Set")]
-            public static extern IntPtr NewSlideTransitionItem(HandleRef slideTransition);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_SlideTransition_Set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr NewSlideTransitionItem(IntPtr slideTransition);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SlideTransition_Assign")]
-            public static extern IntPtr Assign(HandleRef destination, HandleRef source);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SlideTransition_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr Assign(IntPtr destination, IntPtr source);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Stage.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Stage.cs
@@ -14,6 +14,11 @@
  * limitations under the License.
  *
  */
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -24,24 +29,29 @@ namespace Tizen.NUI
             {
             }
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_GetCurrent")]
-            public static extern global::System.IntPtr GetCurrent();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_GetCurrent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetCurrent();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_IsInstalled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_IsInstalled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsInstalled();
+            public static partial bool IsInstalled();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_GetRenderTaskList")]
-            public static extern global::System.IntPtr GetRenderTaskList(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_GetRenderTaskList", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetRenderTaskList(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_GetDpi")]
-            public static extern global::System.IntPtr GetDpi(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_GetDpi", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetDpi(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_SetRenderingBehavior")]
-            public static extern void SetRenderingBehavior(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_SetRenderingBehavior", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetRenderingBehavior(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_GetRenderingBehavior")]
-            public static extern int GetRenderingBehavior(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_GetRenderingBehavior", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetRenderingBehavior(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.StageSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.StageSignal.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,20 +26,25 @@ namespace Tizen.NUI
         internal static partial class StageSignal
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_EventProcessingFinishedSignal")]
-            public static extern global::System.IntPtr EventProcessingFinishedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_EventProcessingFinishedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr EventProcessingFinishedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_WheelEventSignal")]
-            public static extern global::System.IntPtr WheelEventSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_WheelEventSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr WheelEventSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_ContextLostSignal")]
-            public static extern global::System.IntPtr ContextLostSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_ContextLostSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ContextLostSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_ContextRegainedSignal")]
-            public static extern global::System.IntPtr ContextRegainedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_ContextRegainedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ContextRegainedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_SceneCreatedSignal")]
-            public static extern global::System.IntPtr SceneCreatedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_SceneCreatedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr SceneCreatedSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.StateChangeSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.StateChangeSignalType.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class StateChangeSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StateChangedSignalType_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StateChangedSignalType_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StateChangedSignalType_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StateChangedSignalType_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StateChangedSignalType_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StateChangedSignalType_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StateChangedSignalType_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StateChangedSignalType_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StateChangedSignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StateChangedSignalType_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, int jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StateChangedSignalType")]
-            public static extern global::System.IntPtr NewStateChangedSignalType();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StateChangedSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewStateChangedSignalType();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_StateChangedSignalType")]
-            public static extern void DeleteStateChangedSignalType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_StateChangedSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteStateChangedSignalType(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.StatusSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.StatusSignalType.cs
@@ -14,33 +14,43 @@
  * limitations under the License.
  *
  */
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class StatusSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StatusSignalType_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StatusSignalType_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StatusSignalType_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StatusSignalType_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StatusSignalType_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StatusSignalType_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StatusSignalType_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StatusSignalType_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StatusSignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StatusSignalType_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StatusSignalType")]
-            public static extern global::System.IntPtr NewStatusSignalType();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StatusSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewStatusSignalType();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_StatusSignalType")]
-            public static extern void DeleteStatusSignalType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_StatusSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteStatusSignalType(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.StringToVoidSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.StringToVoidSignal.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,9 +14,12 @@
  * limitations under the License.
  *
  */
-using System;
-using System.Collections.Generic;
-using System.Text;
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+using global::System.Collections.Generic;
+using global::System.Text;
 
 namespace Tizen.NUI
 {
@@ -24,11 +27,16 @@ namespace Tizen.NUI
     {
         internal static partial class StringToVoidSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Signal_StringToVoid_GetResult")]
-            public static extern string GetResult(global::System.IntPtr jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Signal_StringToVoid_GetResult", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetResult(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Signal_StringToVoid_SetResult")]
-            public static extern void SetResult(global::System.IntPtr jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Signal_StringToVoid_SetResult", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetResult(global::System.IntPtr jarg1, string jarg2);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.StringValuePair.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.StringValuePair.cs
@@ -15,35 +15,44 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class StringValuePair
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StringValuePair__SWIG_0")]
-            public static extern global::System.IntPtr NewStringValuePair();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StringValuePair__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewStringValuePair();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StringValuePair__SWIG_1")]
-            public static extern global::System.IntPtr NewStringValuePair(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StringValuePair__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewStringValuePair(string jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StringValuePair__SWIG_2")]
-            public static extern global::System.IntPtr NewStringValuePair(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StringValuePair__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewStringValuePair(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StringValuePair_first_set")]
-            public static extern void FirstSet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StringValuePair_first_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FirstSet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StringValuePair_first_get")]
-            public static extern string FirstGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StringValuePair_first_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string FirstGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StringValuePair_second_set")]
-            public static extern void SecondSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StringValuePair_second_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SecondSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StringValuePair_second_get")]
-            public static extern global::System.IntPtr SecondGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StringValuePair_second_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr SecondGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_StringValuePair")]
-            public static extern void DeleteStringValuePair(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_StringValuePair", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteStringValuePair(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.StyleChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.StyleChangedSignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class StyleChangedSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleChangedSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleChangedSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleChangedSignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleChangedSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleChangedSignal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleChangedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleChangedSignal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleChangedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleChangedSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleChangedSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, IntPtr jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StyleChangedSignal")]
-            public static extern global::System.IntPtr NewStyleChangedSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StyleChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewStyleChangedSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_StyleChangedSignal")]
-            public static extern void DeleteStyleChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_StyleChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteStyleChangedSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.StyleManager.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.StyleManager.cs
@@ -15,42 +15,51 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class StyleManager
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StyleManager")]
-            public static extern global::System.IntPtr NewStyleManager();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StyleManager", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewStyleManager();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_Get")]
-            public static extern global::System.IntPtr Get();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_Get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Get();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_ApplyTheme")]
-            public static extern void ApplyTheme(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_ApplyTheme", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ApplyTheme(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_ApplyDefaultTheme")]
-            public static extern void ApplyDefaultTheme(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_ApplyDefaultTheme", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ApplyDefaultTheme(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_SetStyleConstant")]
-            public static extern void SetStyleConstant(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_SetStyleConstant", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetStyleConstant(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_GetStyleConstant")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_GetStyleConstant", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetStyleConstant(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            public static partial bool GetStyleConstant(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_ApplyStyle")]
-            public static extern void ApplyStyle(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, string jarg3, string jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_ApplyStyle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ApplyStyle(IntPtr jarg1, IntPtr jarg2, string jarg3, string jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_StyleChangedSignal")]
-            public static extern global::System.IntPtr StyleChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_StyleChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr StyleChangedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_SetBrokenImageUrl")]
-            public static extern void SetBrokenImageUrl(global::System.Runtime.InteropServices.HandleRef jarg1,uint jarg2, string jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_SetBrokenImageUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetBrokenImageUrl(IntPtr jarg1,uint jarg2, string jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_GetBrokenImageUrl")]
-            public static extern string GetBrokenImageUrl(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_GetBrokenImageUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetBrokenImageUrl(IntPtr jarg1, uint jarg2);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TableView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TableView.cs
@@ -15,168 +15,177 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class TableView
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_Property_ROWS_get")]
-            public static extern int RowsGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_Property_ROWS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RowsGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_Property_COLUMNS_get")]
-            public static extern int ColumnsGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_Property_COLUMNS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ColumnsGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_Property_CELL_PADDING_get")]
-            public static extern int CellPaddingGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_Property_CELL_PADDING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CellPaddingGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_Property_LAYOUT_ROWS_get")]
-            public static extern int LayoutRowsGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_Property_LAYOUT_ROWS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LayoutRowsGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_Property_LAYOUT_COLUMNS_get")]
-            public static extern int LayoutColumnsGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_Property_LAYOUT_COLUMNS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LayoutColumnsGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_ChildProperty_CELL_INDEX_get")]
-            public static extern int ChildPropertyCellIndexGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_ChildProperty_CELL_INDEX_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ChildPropertyCellIndexGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_ChildProperty_ROW_SPAN_get")]
-            public static extern int ChildPropertyRowSpanGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_ChildProperty_ROW_SPAN_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ChildPropertyRowSpanGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_ChildProperty_COLUMN_SPAN_get")]
-            public static extern int ChildPropertyColumnSpanGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_ChildProperty_COLUMN_SPAN_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ChildPropertyColumnSpanGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_ChildProperty_CELL_HORIZONTAL_ALIGNMENT_get")]
-            public static extern int ChildPropertyCellHorizontalAlignmentGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_ChildProperty_CELL_HORIZONTAL_ALIGNMENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ChildPropertyCellHorizontalAlignmentGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_ChildProperty_CELL_VERTICAL_ALIGNMENT_get")]
-            public static extern int ChildPropertyCellVerticalAlignmentGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_ChildProperty_CELL_VERTICAL_ALIGNMENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ChildPropertyCellVerticalAlignmentGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TableView_CellPosition__SWIG_0")]
-            public static extern global::System.IntPtr NewTableViewCellPosition(uint jarg1, uint jarg2, uint jarg3, uint jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TableView_CellPosition__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTableViewCellPosition(uint jarg1, uint jarg2, uint jarg3, uint jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TableView_CellPosition__SWIG_1")]
-            public static extern global::System.IntPtr NewTableViewCellPosition(uint jarg1, uint jarg2, uint jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TableView_CellPosition__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTableViewCellPosition(uint jarg1, uint jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TableView_CellPosition__SWIG_2")]
-            public static extern global::System.IntPtr NewTableViewCellPosition(uint jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TableView_CellPosition__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTableViewCellPosition(uint jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TableView_CellPosition__SWIG_3")]
-            public static extern global::System.IntPtr NewTableViewCellPosition(uint jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TableView_CellPosition__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTableViewCellPosition(uint jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TableView_CellPosition__SWIG_4")]
-            public static extern global::System.IntPtr NewTableViewCellPosition();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TableView_CellPosition__SWIG_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTableViewCellPosition();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_CellPosition_rowIndex_set")]
-            public static extern void CellPositionRowIndexSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_CellPosition_rowIndex_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void CellPositionRowIndexSet(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_CellPosition_rowIndex_get")]
-            public static extern uint CellPositionRowIndexGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_CellPosition_rowIndex_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint CellPositionRowIndexGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_CellPosition_columnIndex_set")]
-            public static extern void CellPositionColumnIndexSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_CellPosition_columnIndex_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void CellPositionColumnIndexSet(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_CellPosition_columnIndex_get")]
-            public static extern uint CellPositionColumnIndexGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_CellPosition_columnIndex_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint CellPositionColumnIndexGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_CellPosition_rowSpan_set")]
-            public static extern void CellPositionRowSpanSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_CellPosition_rowSpan_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void CellPositionRowSpanSet(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_CellPosition_rowSpan_get")]
-            public static extern uint CellPositionRowSpanGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_CellPosition_rowSpan_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint CellPositionRowSpanGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_CellPosition_columnSpan_set")]
-            public static extern void CellPositionColumnSpanSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_CellPosition_columnSpan_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void CellPositionColumnSpanSet(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_CellPosition_columnSpan_get")]
-            public static extern uint CellPositionColumnSpanGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_CellPosition_columnSpan_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint CellPositionColumnSpanGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TableView_CellPosition")]
-            public static extern void DeleteTableViewCellPosition(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TableView_CellPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTableViewCellPosition(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TableView__SWIG_1")]
-            public static extern global::System.IntPtr NewTableView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TableView__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTableView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TableView")]
-            public static extern void DeleteTableView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TableView", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTableView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_New")]
-            public static extern global::System.IntPtr New(uint jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(uint jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_AddChild")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_AddChild", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddChild(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            public static partial bool AddChild(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_GetChildAt")]
-            public static extern global::System.IntPtr GetChildAt(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_GetChildAt", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetChildAt(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_RemoveChildAt")]
-            public static extern global::System.IntPtr RemoveChildAt(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_RemoveChildAt", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr RemoveChildAt(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_FindChildPosition")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_FindChildPosition", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FindChildPosition(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            public static partial bool FindChildPosition(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_InsertRow")]
-            public static extern void InsertRow(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_InsertRow", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void InsertRow(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_DeleteRow__SWIG_0")]
-            public static extern void DeleteRow(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_DeleteRow__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteRow(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_InsertColumn")]
-            public static extern void InsertColumn(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_InsertColumn", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void InsertColumn(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_DeleteColumn__SWIG_0")]
-            public static extern void DeleteColumn(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_DeleteColumn__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteColumn(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_Resize__SWIG_0")]
-            public static extern void Resize(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, uint jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_Resize__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Resize(IntPtr jarg1, uint jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_SetCellPadding")]
-            public static extern void SetCellPadding(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_SetCellPadding", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetCellPadding(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_GetCellPadding")]
-            public static extern global::System.IntPtr GetCellPadding(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_GetCellPadding", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetCellPadding(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_SetFitHeight")]
-            public static extern void SetFitHeight(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_SetFitHeight", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFitHeight(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_IsFitHeight")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_IsFitHeight", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsFitHeight(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            public static partial bool IsFitHeight(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_SetFitWidth")]
-            public static extern void SetFitWidth(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_SetFitWidth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFitWidth(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_IsFitWidth")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_IsFitWidth", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsFitWidth(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            public static partial bool IsFitWidth(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_SetFixedHeight")]
-            public static extern void SetFixedHeight(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_SetFixedHeight", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFixedHeight(IntPtr jarg1, uint jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_GetFixedHeight")]
-            public static extern float GetFixedHeight(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_GetFixedHeight", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetFixedHeight(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_SetRelativeHeight")]
-            public static extern void SetRelativeHeight(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_SetRelativeHeight", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetRelativeHeight(IntPtr jarg1, uint jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_GetRelativeHeight")]
-            public static extern float GetRelativeHeight(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_GetRelativeHeight", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetRelativeHeight(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_SetFixedWidth")]
-            public static extern void SetFixedWidth(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_SetFixedWidth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFixedWidth(IntPtr jarg1, uint jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_GetFixedWidth")]
-            public static extern float GetFixedWidth(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_GetFixedWidth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetFixedWidth(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_SetRelativeWidth")]
-            public static extern void SetRelativeWidth(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_SetRelativeWidth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetRelativeWidth(IntPtr jarg1, uint jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_GetRelativeWidth")]
-            public static extern float GetRelativeWidth(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_GetRelativeWidth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetRelativeWidth(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_SetCellAlignment")]
-            public static extern void SetCellAlignment(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3, int jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TableView_SetCellAlignment", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetCellAlignment(IntPtr jarg1, IntPtr jarg2, int jarg3, int jarg4);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TapGesture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TapGesture.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,24 +26,29 @@ namespace Tizen.NUI
         internal static partial class TapGesture
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_New")]
-            public static extern global::System.IntPtr New(int jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TapGesture")]
-            public static extern void DeleteTapGesture(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TapGesture", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTapGesture(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_numberOfTaps_get")]
-            public static extern uint NumberOfTapsGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_numberOfTaps_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint NumberOfTapsGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_numberOfTouches_get")]
-            public static extern uint NumberOfTouchesGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_numberOfTouches_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint NumberOfTouchesGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_screenPoint_get")]
-            public static extern global::System.IntPtr ScreenPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_screenPoint_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ScreenPointGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_localPoint_get")]
-            public static extern global::System.IntPtr LocalPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_localPoint_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr LocalPointGet(IntPtr jarg1);
 
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TapGestureDetectedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TapGestureDetectedSignal.cs
@@ -14,33 +14,43 @@
  * limitations under the License.
  *
  */
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class TapGestureDetectedSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetectedSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetectedSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetectedSignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetectedSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetectedSignal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetectedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetectedSignal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetectedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetectedSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetectedSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TapGestureDetectedSignal")]
-            public static extern global::System.IntPtr NewTapGestureDetectedSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TapGestureDetectedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTapGestureDetectedSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TapGestureDetectedSignal")]
-            public static extern void DeleteTapGestureDetectedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TapGestureDetectedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTapGestureDetectedSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TapGestureDetector.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TapGestureDetector.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,35 +26,40 @@ namespace Tizen.NUI
         internal static partial class TapGestureDetector
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetector_New__SWIG_0")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetector_New__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetector_New__SWIG_1")]
-            public static extern global::System.IntPtr New(uint jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetector_New__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(uint jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TapGestureDetector")]
-            public static extern void DeleteTapGestureDetector(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TapGestureDetector", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTapGestureDetector(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TapGestureDetector__SWIG_1")]
-            public static extern global::System.IntPtr NewTapGestureDetector(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TapGestureDetector__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTapGestureDetector(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetector_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetector_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetector_SetMinimumTapsRequired")]
-            public static extern void SetMinimumTapsRequired(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetector_SetMinimumTapsRequired", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMinimumTapsRequired(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetector_SetMaximumTapsRequired")]
-            public static extern void SetMaximumTapsRequired(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetector_SetMaximumTapsRequired", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMaximumTapsRequired(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetector_GetMinimumTapsRequired")]
-            public static extern uint GetMinimumTapsRequired(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetector_GetMinimumTapsRequired", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetMinimumTapsRequired(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetector_GetMaximumTapsRequired")]
-            public static extern uint GetMaximumTapsRequired(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetector_GetMaximumTapsRequired", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetMaximumTapsRequired(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetector_DetectedSignal")]
-            public static extern global::System.IntPtr DetectedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetector_DetectedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DetectedSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
@@ -15,337 +15,346 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class TextEditor
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_TEXT_get")]
-            public static extern int TextGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_TEXT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TextGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_TEXT_COLOR_get")]
-            public static extern int TextColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_TEXT_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TextColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_FONT_FAMILY_get")]
-            public static extern int FontFamilyGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_FONT_FAMILY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int FontFamilyGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_FONT_STYLE_get")]
-            public static extern int FontStyleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_FONT_STYLE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int FontStyleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_POINT_SIZE_get")]
-            public static extern int PointSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_POINT_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PointSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_HORIZONTAL_ALIGNMENT_get")]
-            public static extern int HorizontalAlignmentGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_HORIZONTAL_ALIGNMENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int HorizontalAlignmentGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_VERTICAL_ALIGNMENT_get")]
-            public static extern int VerticalAlignmentGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_VERTICAL_ALIGNMENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int VerticalAlignmentGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SCROLL_THRESHOLD_get")]
-            public static extern int ScrollThresholdGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SCROLL_THRESHOLD_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollThresholdGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SCROLL_SPEED_get")]
-            public static extern int ScrollSpeedGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SCROLL_SPEED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollSpeedGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_PRIMARY_CURSOR_COLOR_get")]
-            public static extern int PrimaryCursorColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_PRIMARY_CURSOR_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PrimaryCursorColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SECONDARY_CURSOR_COLOR_get")]
-            public static extern int SecondaryCursorColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SECONDARY_CURSOR_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SecondaryCursorColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_ENABLE_CURSOR_BLINK_get")]
-            public static extern int EnableCursorBlinkGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_ENABLE_CURSOR_BLINK_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableCursorBlinkGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_CURSOR_BLINK_INTERVAL_get")]
-            public static extern int CursorBlinkIntervalGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_CURSOR_BLINK_INTERVAL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CursorBlinkIntervalGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_CURSOR_BLINK_DURATION_get")]
-            public static extern int CursorBlinkDurationGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_CURSOR_BLINK_DURATION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CursorBlinkDurationGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_CURSOR_WIDTH_get")]
-            public static extern int CursorWidthGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_CURSOR_WIDTH_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CursorWidthGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_GRAB_HANDLE_IMAGE_get")]
-            public static extern int GrabHandleImageGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_GRAB_HANDLE_IMAGE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GrabHandleImageGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_GRAB_HANDLE_PRESSED_IMAGE_get")]
-            public static extern int GrabHandlePressedImageGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_GRAB_HANDLE_PRESSED_IMAGE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GrabHandlePressedImageGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTION_POPUP_STYLE_get")]
-            public static extern int SelectionPopupStyleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTION_POPUP_STYLE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectionPopupStyleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTION_HANDLE_IMAGE_LEFT_get")]
-            public static extern int SelectionHandleImageLeftGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTION_HANDLE_IMAGE_LEFT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectionHandleImageLeftGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTION_HANDLE_IMAGE_RIGHT_get")]
-            public static extern int SelectionHandleImageRightGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTION_HANDLE_IMAGE_RIGHT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectionHandleImageRightGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTION_HANDLE_PRESSED_IMAGE_LEFT_get")]
-            public static extern int SelectionHandlePressedImageLeftGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTION_HANDLE_PRESSED_IMAGE_LEFT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectionHandlePressedImageLeftGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTION_HANDLE_PRESSED_IMAGE_RIGHT_get")]
-            public static extern int SelectionHandlePressedImageRightGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTION_HANDLE_PRESSED_IMAGE_RIGHT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectionHandlePressedImageRightGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTION_HANDLE_MARKER_IMAGE_LEFT_get")]
-            public static extern int SelectionHandleMarkerImageLeftGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTION_HANDLE_MARKER_IMAGE_LEFT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectionHandleMarkerImageLeftGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTION_HANDLE_MARKER_IMAGE_RIGHT_get")]
-            public static extern int SelectionHandleMarkerImageRightGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTION_HANDLE_MARKER_IMAGE_RIGHT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectionHandleMarkerImageRightGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTION_HIGHLIGHT_COLOR_get")]
-            public static extern int SelectionHighlightColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTION_HIGHLIGHT_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectionHighlightColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_DECORATION_BOUNDING_BOX_get")]
-            public static extern int DecorationBoundingBoxGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_DECORATION_BOUNDING_BOX_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DecorationBoundingBoxGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_ENABLE_MARKUP_get")]
-            public static extern int EnableMarkupGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_ENABLE_MARKUP_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableMarkupGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_COLOR_get")]
-            public static extern int InputColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_FONT_FAMILY_get")]
-            public static extern int InputFontFamilyGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_FONT_FAMILY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputFontFamilyGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_FONT_STYLE_get")]
-            public static extern int InputFontStyleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_FONT_STYLE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputFontStyleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_POINT_SIZE_get")]
-            public static extern int InputPointSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_POINT_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputPointSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_LINE_SPACING_get")]
-            public static extern int LineSpacingGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_LINE_SPACING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LineSpacingGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_LINE_SPACING_get")]
-            public static extern int InputLineSpacingGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_LINE_SPACING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputLineSpacingGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_RELATIVE_LINE_SIZE_get")]
-            public static extern int RelativeLineHeightGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_RELATIVE_LINE_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RelativeLineHeightGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_UNDERLINE_get")]
-            public static extern int UnderlineGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_UNDERLINE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int UnderlineGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_UNDERLINE_get")]
-            public static extern int InputUnderlineGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_UNDERLINE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputUnderlineGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SHADOW_get")]
-            public static extern int ShadowGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SHADOW_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ShadowGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_SHADOW_get")]
-            public static extern int InputShadowGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_SHADOW_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputShadowGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_EMBOSS_get")]
-            public static extern int EmbossGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_EMBOSS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EmbossGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_EMBOSS_get")]
-            public static extern int InputEmbossGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_EMBOSS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputEmbossGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_OUTLINE_get")]
-            public static extern int OutlineGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_OUTLINE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int OutlineGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_OUTLINE_get")]
-            public static extern int InputOutlineGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_OUTLINE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputOutlineGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_New_With_Style")]
-            public static extern global::System.IntPtr New(bool hasStyle);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_New_With_Style", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New([MarshalAs(UnmanagedType.U1)] bool hasStyle);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextEditor")]
-            public static extern void DeleteTextEditor(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextEditor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTextEditor(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_GetInputMethodContext")]
-            public static extern global::System.IntPtr GetInputMethodContext(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_GetInputMethodContext", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetInputMethodContext(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_TextChangedSignal")]
-            public static extern global::System.IntPtr TextChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_TextChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr TextChangedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_CursorPositionChangedSignal")]
-            public static extern global::System.IntPtr CursorPositionChangedSignal(global::System.Runtime.InteropServices.HandleRef pTextEditor);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_CursorPositionChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CursorPositionChangedSignal(IntPtr pTextEditor);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_MaxLengthReachedSignal")]
-            public static extern global::System.IntPtr MaxLengthReachedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_MaxLengthReachedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr MaxLengthReachedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_SelectionClearedSignal")]
-            public static extern global::System.IntPtr SelectionClearedSignal(global::System.Runtime.InteropServices.HandleRef pTextEditor);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_SelectionClearedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr SelectionClearedSignal(IntPtr pTextEditor);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_SelectionStartedSignal")]
-            public static extern global::System.IntPtr SelectionStartedSignal(global::System.Runtime.InteropServices.HandleRef pTextEditor);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_SelectionStartedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr SelectionStartedSignal(IntPtr pTextEditor);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_AnchorClickedSignal")]
-            public static extern global::System.IntPtr AnchorClickedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_AnchorClickedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr AnchorClickedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_SelectionChangedSignal")]
-            public static extern global::System.IntPtr SelectionChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_SelectionChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr SelectionChangedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditorSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditorSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool TextEditorSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool TextEditorSignalEmpty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditorSignal_GetConnectionCount")]
-            public static extern uint TextEditorSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditorSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint TextEditorSignalGetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditorSignal_Connect")]
-            public static extern void TextEditorSignalConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditorSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TextEditorSignalConnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditorSignal_Disconnect")]
-            public static extern void TextEditorSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditorSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TextEditorSignalDisconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditorSignal_Emit")]
-            public static extern void TextEditorSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditorSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TextEditorSignalEmit(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TextEditorSignal")]
-            public static extern global::System.IntPtr NewTextEditorSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TextEditorSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTextEditorSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextEditorSignal")]
-            public static extern void DeleteTextEditorSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextEditorSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTextEditorSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_ENABLE_SHIFT_SELECTION_get")]
-            public static extern int EnableShiftSelectionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_ENABLE_SHIFT_SELECTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableShiftSelectionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_MATCH_SYSTEM_LANGUAGE_DIRECTION_get")]
-            public static extern int MatchSystemLanguageDirectionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_MATCH_SYSTEM_LANGUAGE_DIRECTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MatchSystemLanguageDirectionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_PIXEL_SIZE_get")]
-            public static extern int PixelSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_PIXEL_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PixelSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_LINE_COUNT_get")]
-            public static extern int LineCountGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_LINE_COUNT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LineCountGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_PLACEHOLDER_TEXT_get")]
-            public static extern int PlaceholderTextGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_PLACEHOLDER_TEXT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PlaceholderTextGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_PLACEHOLDER_TEXT_COLOR_get")]
-            public static extern int PlaceholderTextColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_PLACEHOLDER_TEXT_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PlaceholderTextColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_ENABLE_SELECTION_get")]
-            public static extern int EnableSelectionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_ENABLE_SELECTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableSelectionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_PLACEHOLDER_get")]
-            public static extern int PlaceholderGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_PLACEHOLDER_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PlaceholderGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_SelectWholeText")]
-            public static extern void SelectWholeText(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_SelectWholeText", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SelectWholeText(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_SelectText")]
-            public static extern void SelectText(global::System.Runtime.InteropServices.HandleRef textEditorRef, uint start, uint end);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_SelectText", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SelectText(IntPtr textEditorRef, uint start, uint end);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTED_TEXT_get")]
-            public static extern int SelectedTextGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTED_TEXT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectedTextGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_SelectNone")]
-            public static extern int SelectNone(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_SelectNone", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectNone(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_LINE_WRAP_MODE_get")]
-            public static extern int LineWrapModeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_LINE_WRAP_MODE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LineWrapModeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_SMOOTH_SCROLL_get")]
-            public static extern int SmoothScrollGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_SMOOTH_SCROLL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SmoothScrollGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_SMOOTH_SCROLL_DURATION_get")]
-            public static extern int SmoothScrollDurationGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_SMOOTH_SCROLL_DURATION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SmoothScrollDurationGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_ENABLE_SCROLL_BAR_get")]
-            public static extern int EnableScrollBarGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_ENABLE_SCROLL_BAR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableScrollBarGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_SCROLL_BAR_SHOW_DURATION_get")]
-            public static extern int ScrollBarShowDurationGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_SCROLL_BAR_SHOW_DURATION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollBarShowDurationGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_SCROLL_BAR_FADE_DURATION_get")]
-            public static extern int ScrollBarFadeDurationGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_SCROLL_BAR_FADE_DURATION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollBarFadeDurationGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_MAX_LENGTH_get")]
-            public static extern int MaxLengthGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_MAX_LENGTH_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MaxLengthGet();
 
             //manual pinvoke for text-editor ScrollStateChangedSignal
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_ScrollStateChangedSignal")]
-            public static extern global::System.IntPtr ScrollStateChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_ScrollStateChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ScrollStateChangedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTED_TEXT_START_get")]
-            public static extern int SelectedTextStartGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTED_TEXT_START_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectedTextStartGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTED_TEXT_END_get")]
-            public static extern int SelectedTextEndGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTED_TEXT_END_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectedTextEndGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_ENABLE_EDITING_get")]
-            public static extern int EnableEditingGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_ENABLE_EDITING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableEditingGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_HORIZONTAL_SCROLL_POSITION_get")]
-            public static extern int HorizontalScrollPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_HORIZONTAL_SCROLL_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int HorizontalScrollPositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_VERTICAL_SCROLL_POSITION_get")]
-            public static extern int VerticalScrollPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_VERTICAL_SCROLL_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int VerticalScrollPositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_PRIMARY_CURSOR_POSITION_get")]
-            public static extern int PrimaryCursorPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_PRIMARY_CURSOR_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PrimaryCursorPositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_ScrollBy")]
-            public static extern void ScrollBy(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_ScrollBy", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ScrollBy(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_FONT_SIZE_SCALE_get")]
-            public static extern int FontSizeScaleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_FONT_SIZE_SCALE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int FontSizeScaleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_ENABLE_FONT_SIZE_SCALE_get")]
-            public static extern int EnableFontSizeScaleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_ENABLE_FONT_SIZE_SCALE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableFontSizeScaleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_GRAB_HANDLE_COLOR_get")]
-            public static extern int GrabHandleColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_GRAB_HANDLE_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GrabHandleColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_ENABLE_GRAB_HANDLE_get")]
-            public static extern int EnableGrabHandleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_ENABLE_GRAB_HANDLE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableGrabHandleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_ENABLE_GRAB_HANDLE_POPUP_get")]
-            public static extern int EnableGrabHandlePopupGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_ENABLE_GRAB_HANDLE_POPUP_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableGrabHandlePopupGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_METHOD_SETTINGS_get")]
-            public static extern int InputMethodSettingsGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_METHOD_SETTINGS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputMethodSettingsGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_MIN_LINE_SIZE_get")]
-            public static extern int MinLineSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_MIN_LINE_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MinLineSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_ELLIPSIS_get")]
-            public static extern int EllipsisGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_ELLIPSIS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EllipsisGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_ELLIPSIS_POSITION_get")]
-            public static extern int EllipsisPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_ELLIPSIS_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EllipsisPositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_FILTER_get")]
-            public static extern int InputFilterGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_FILTER_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputFilterGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_InputFilteredSignal")]
-            public static extern global::System.IntPtr InputFilteredSignal(global::System.Runtime.InteropServices.HandleRef textEditorRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_InputFilteredSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr InputFilteredSignal(IntPtr textEditorRef);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_GetTextSize")]
-            public static extern global::System.IntPtr GetTextSize(global::System.Runtime.InteropServices.HandleRef textEditorRef, uint start, uint end);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_GetTextSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetTextSize(IntPtr textEditorRef, uint start, uint end);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_GetTextPosition")]
-            public static extern global::System.IntPtr GetTextPosition(global::System.Runtime.InteropServices.HandleRef textEditorRef, uint start, uint end);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_GetTextPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetTextPosition(IntPtr textEditorRef, uint start, uint end);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_CopyText")]
-            public static extern string CopyText(global::System.Runtime.InteropServices.HandleRef textEditorRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_CopyText", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string CopyText(IntPtr textEditorRef);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_CutText")]
-            public static extern string CutText(global::System.Runtime.InteropServices.HandleRef textEditorRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_CutText", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string CutText(IntPtr textEditorRef);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_PasteText")]
-            public static extern void PasteText(global::System.Runtime.InteropServices.HandleRef textEditorRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_PasteText", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PasteText(IntPtr textEditorRef);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_STRIKETHROUGH_get")]
-            public static extern int StrikethroughGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_STRIKETHROUGH_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int StrikethroughGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_CHARACTER_SPACING_get")]
-            public static extern int CharacterSpacingGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_CHARACTER_SPACING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CharacterSpacingGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_REMOVE_FRONT_INSET_get")]
-            public static extern int RemoveFrontInsetGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_REMOVE_FRONT_INSET_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RemoveFrontInsetGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_REMOVE_BACK_INSET_get")]
-            public static extern int RemoveBackInsetGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_REMOVE_BACK_INSET_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RemoveBackInsetGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_RegisterFontVariationProperty")]
-            public static extern int RegisterFontVariationProperty(global::System.Runtime.InteropServices.HandleRef textEditorRef, string pTag);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_RegisterFontVariationProperty", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RegisterFontVariationProperty(IntPtr textEditorRef, string pTag);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_ENABLE_CURSOR_INSET_get")]
-            public static extern int EnableCursorInsetGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_ENABLE_CURSOR_INSET_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableCursorInsetGet();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
@@ -15,299 +15,308 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class TextField
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_TEXT_get")]
-            public static extern int TextGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_TEXT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TextGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_PLACEHOLDER_TEXT_get")]
-            public static extern int PlaceholderTextGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_PLACEHOLDER_TEXT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PlaceholderTextGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_PLACEHOLDER_TEXT_FOCUSED_get")]
-            public static extern int PlaceholderTextFocusedGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_PLACEHOLDER_TEXT_FOCUSED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PlaceholderTextFocusedGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_FONT_FAMILY_get")]
-            public static extern int FontFamilyGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_FONT_FAMILY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int FontFamilyGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_FONT_STYLE_get")]
-            public static extern int FontStyleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_FONT_STYLE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int FontStyleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_POINT_SIZE_get")]
-            public static extern int PointSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_POINT_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PointSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_MAX_LENGTH_get")]
-            public static extern int MaxLengthGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_MAX_LENGTH_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MaxLengthGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_EXCEED_POLICY_get")]
-            public static extern int ExceedPolicyGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_EXCEED_POLICY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ExceedPolicyGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_HORIZONTAL_ALIGNMENT_get")]
-            public static extern int HorizontalAlignmentGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_HORIZONTAL_ALIGNMENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int HorizontalAlignmentGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_VERTICAL_ALIGNMENT_get")]
-            public static extern int VerticalAlignmentGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_VERTICAL_ALIGNMENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int VerticalAlignmentGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_TEXT_COLOR_get")]
-            public static extern int TextColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_TEXT_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TextColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_PLACEHOLDER_TEXT_COLOR_get")]
-            public static extern int PlaceholderTextColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_PLACEHOLDER_TEXT_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PlaceholderTextColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_PRIMARY_CURSOR_COLOR_get")]
-            public static extern int PrimaryCursorColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_PRIMARY_CURSOR_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PrimaryCursorColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SECONDARY_CURSOR_COLOR_get")]
-            public static extern int SecondaryCursorColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SECONDARY_CURSOR_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SecondaryCursorColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_ENABLE_CURSOR_BLINK_get")]
-            public static extern int EnableCursorBlinkGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_ENABLE_CURSOR_BLINK_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableCursorBlinkGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_CURSOR_BLINK_INTERVAL_get")]
-            public static extern int CursorBlinkIntervalGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_CURSOR_BLINK_INTERVAL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CursorBlinkIntervalGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_CURSOR_BLINK_DURATION_get")]
-            public static extern int CursorBlinkDurationGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_CURSOR_BLINK_DURATION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CursorBlinkDurationGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_CURSOR_WIDTH_get")]
-            public static extern int CursorWidthGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_CURSOR_WIDTH_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CursorWidthGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_GRAB_HANDLE_IMAGE_get")]
-            public static extern int GrabHandleImageGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_GRAB_HANDLE_IMAGE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GrabHandleImageGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_GRAB_HANDLE_PRESSED_IMAGE_get")]
-            public static extern int GrabHandlePressedImageGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_GRAB_HANDLE_PRESSED_IMAGE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GrabHandlePressedImageGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SCROLL_THRESHOLD_get")]
-            public static extern int ScrollThresholdGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SCROLL_THRESHOLD_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollThresholdGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SCROLL_SPEED_get")]
-            public static extern int ScrollSpeedGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SCROLL_SPEED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollSpeedGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTION_POPUP_STYLE_get")]
-            public static extern int SelectionPopupStyleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTION_POPUP_STYLE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectionPopupStyleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTION_HANDLE_IMAGE_LEFT_get")]
-            public static extern int SelectionHandleImageLeftGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTION_HANDLE_IMAGE_LEFT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectionHandleImageLeftGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTION_HANDLE_IMAGE_RIGHT_get")]
-            public static extern int SelectionHandleImageRightGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTION_HANDLE_IMAGE_RIGHT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectionHandleImageRightGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTION_HANDLE_PRESSED_IMAGE_LEFT_get")]
-            public static extern int SelectionHandlePressedImageLeftGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTION_HANDLE_PRESSED_IMAGE_LEFT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectionHandlePressedImageLeftGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTION_HANDLE_PRESSED_IMAGE_RIGHT_get")]
-            public static extern int SelectionHandlePressedImageRightGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTION_HANDLE_PRESSED_IMAGE_RIGHT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectionHandlePressedImageRightGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTION_HANDLE_MARKER_IMAGE_LEFT_get")]
-            public static extern int SelectionHandleMarkerImageLeftGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTION_HANDLE_MARKER_IMAGE_LEFT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectionHandleMarkerImageLeftGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTION_HANDLE_MARKER_IMAGE_RIGHT_get")]
-            public static extern int SelectionHandleMarkerImageRightGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTION_HANDLE_MARKER_IMAGE_RIGHT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectionHandleMarkerImageRightGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTION_HIGHLIGHT_COLOR_get")]
-            public static extern int SelectionHighlightColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTION_HIGHLIGHT_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectionHighlightColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_DECORATION_BOUNDING_BOX_get")]
-            public static extern int DecorationBoundingBoxGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_DECORATION_BOUNDING_BOX_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DecorationBoundingBoxGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_METHOD_SETTINGS_get")]
-            public static extern int InputMethodSettingsGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_METHOD_SETTINGS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputMethodSettingsGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_COLOR_get")]
-            public static extern int InputColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_ENABLE_MARKUP_get")]
-            public static extern int EnableMarkupGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_ENABLE_MARKUP_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableMarkupGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_FONT_FAMILY_get")]
-            public static extern int InputFontFamilyGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_FONT_FAMILY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputFontFamilyGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_FONT_STYLE_get")]
-            public static extern int InputFontStyleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_FONT_STYLE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputFontStyleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_POINT_SIZE_get")]
-            public static extern int InputPointSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_POINT_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputPointSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_UNDERLINE_get")]
-            public static extern int UnderlineGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_UNDERLINE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int UnderlineGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_UNDERLINE_get")]
-            public static extern int InputUnderlineGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_UNDERLINE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputUnderlineGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SHADOW_get")]
-            public static extern int ShadowGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SHADOW_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ShadowGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_SHADOW_get")]
-            public static extern int InputShadowGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_SHADOW_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputShadowGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_EMBOSS_get")]
-            public static extern int EmbossGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_EMBOSS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EmbossGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_EMBOSS_get")]
-            public static extern int InputEmbossGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_EMBOSS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputEmbossGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_OUTLINE_get")]
-            public static extern int OutlineGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_OUTLINE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int OutlineGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_OUTLINE_get")]
-            public static extern int InputOutlineGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_OUTLINE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputOutlineGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_New_With_Style")]
-            public static extern global::System.IntPtr New(bool hasStyle);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_New_With_Style", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New([MarshalAs(UnmanagedType.U1)] bool hasStyle);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextField")]
-            public static extern void DeleteTextField(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextField", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTextField(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_GetInputMethodContext")]
-            public static extern global::System.IntPtr GetInputMethodContext(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_GetInputMethodContext", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetInputMethodContext(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_TextChangedSignal")]
-            public static extern global::System.IntPtr TextChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_TextChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr TextChangedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_CursorPositionChangedSignal")]
-            public static extern global::System.IntPtr CursorPositionChangedSignal(global::System.Runtime.InteropServices.HandleRef pTextField);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_CursorPositionChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CursorPositionChangedSignal(IntPtr pTextField);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_MaxLengthReachedSignal")]
-            public static extern global::System.IntPtr MaxLengthReachedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_MaxLengthReachedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr MaxLengthReachedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_SelectionClearedSignal")]
-            public static extern global::System.IntPtr SelectionClearedSignal(global::System.Runtime.InteropServices.HandleRef pTextField);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_SelectionClearedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr SelectionClearedSignal(IntPtr pTextField);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_SelectionStartedSignal")]
-            public static extern global::System.IntPtr SelectionStartedSignal(global::System.Runtime.InteropServices.HandleRef pTextField);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_SelectionStartedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr SelectionStartedSignal(IntPtr pTextField);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_AnchorClickedSignal")]
-            public static extern global::System.IntPtr AnchorClickedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_AnchorClickedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr AnchorClickedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_SelectionChangedSignal")]
-            public static extern global::System.IntPtr SelectionChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_SelectionChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr SelectionChangedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextFieldSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextFieldSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool TextFieldSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool TextFieldSignalEmpty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextFieldSignal_GetConnectionCount")]
-            public static extern uint TextFieldSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextFieldSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint TextFieldSignalGetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextFieldSignal_Connect")]
-            public static extern void TextFieldSignalConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextFieldSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TextFieldSignalConnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextFieldSignal_Disconnect")]
-            public static extern void TextFieldSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextFieldSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TextFieldSignalDisconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextFieldSignal_Emit")]
-            public static extern void TextFieldSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextFieldSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TextFieldSignalEmit(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TextFieldSignal")]
-            public static extern global::System.IntPtr NewTextFieldSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TextFieldSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTextFieldSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextFieldSignal")]
-            public static extern void DeleteTextFieldSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextFieldSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTextFieldSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_ENABLE_SHIFT_SELECTION_get")]
-            public static extern int EnableShiftSelectionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_ENABLE_SHIFT_SELECTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableShiftSelectionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_MATCH_SYSTEM_LANGUAGE_DIRECTION_get")]
-            public static extern int MatchSystemLanguageDirectionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_MATCH_SYSTEM_LANGUAGE_DIRECTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MatchSystemLanguageDirectionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_HIDDEN_INPUT_SETTINGS_get")]
-            public static extern int HiddenInputSettingsGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_HIDDEN_INPUT_SETTINGS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int HiddenInputSettingsGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_PIXEL_SIZE_get")]
-            public static extern int PixelSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_PIXEL_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PixelSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_ENABLE_SELECTION_get")]
-            public static extern int EnableSelectionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_ENABLE_SELECTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableSelectionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_PLACEHOLDER_get")]
-            public static extern int PlaceholderGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_PLACEHOLDER_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PlaceholderGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_ELLIPSIS_get")]
-            public static extern int EllipsisGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_ELLIPSIS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EllipsisGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_ELLIPSIS_POSITION_get")]
-            public static extern int EllipsisPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_ELLIPSIS_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EllipsisPositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_SelectWholeText")]
-            public static extern void SelectWholeText(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_SelectWholeText", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SelectWholeText(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_SelectText")]
-            public static extern void SelectText(global::System.Runtime.InteropServices.HandleRef textFieldRef, uint start, uint end);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_SelectText", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SelectText(IntPtr textFieldRef, uint start, uint end);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_ENABLE_GRAB_HANDLE_get")]
-            public static extern int EnableGrabHandleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_ENABLE_GRAB_HANDLE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableGrabHandleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_ENABLE_GRAB_HANDLE_POPUP_get")]
-            public static extern int EnableGrabHandlePopupGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_ENABLE_GRAB_HANDLE_POPUP_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableGrabHandlePopupGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTED_TEXT_get")]
-            public static extern int SelectedTextGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTED_TEXT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectedTextGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTED_TEXT_START_get")]
-            public static extern int SelectedTextStartGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTED_TEXT_START_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectedTextStartGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTED_TEXT_END_get")]
-            public static extern int SelectedTextEndGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_SELECTED_TEXT_END_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectedTextEndGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_ENABLE_EDITING_get")]
-            public static extern int EnableEditingGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_ENABLE_EDITING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableEditingGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_PRIMARY_CURSOR_POSITION_get")]
-            public static extern int PrimaryCursorPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_PRIMARY_CURSOR_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PrimaryCursorPositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_SelectNone")]
-            public static extern int SelectNone(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_SelectNone", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectNone(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_FONT_SIZE_SCALE_get")]
-            public static extern int FontSizeScaleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_FONT_SIZE_SCALE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int FontSizeScaleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_ENABLE_FONT_SIZE_SCALE_get")]
-            public static extern int EnableFontSizeScaleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_ENABLE_FONT_SIZE_SCALE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableFontSizeScaleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_GRAB_HANDLE_COLOR_get")]
-            public static extern int GrabHandleColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_GRAB_HANDLE_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GrabHandleColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_FILTER_get")]
-            public static extern int InputFilterGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_INPUT_FILTER_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InputFilterGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_InputFilteredSignal")]
-            public static extern global::System.IntPtr InputFilteredSignal(global::System.Runtime.InteropServices.HandleRef textFieldRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_InputFilteredSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr InputFilteredSignal(IntPtr textFieldRef);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_GetTextSize")]
-            public static extern global::System.IntPtr GetTextSize(global::System.Runtime.InteropServices.HandleRef textFieldRef, uint start, uint end);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_GetTextSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetTextSize(IntPtr textFieldRef, uint start, uint end);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_GetTextPosition")]
-            public static extern global::System.IntPtr GetTextPosition(global::System.Runtime.InteropServices.HandleRef textFieldRef, uint start, uint end);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_GetTextPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetTextPosition(IntPtr textFieldRef, uint start, uint end);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_CopyText")]
-            public static extern string CopyText(global::System.Runtime.InteropServices.HandleRef textFieldRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_CopyText", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string CopyText(IntPtr textFieldRef);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_CutText")]
-            public static extern string CutText(global::System.Runtime.InteropServices.HandleRef textFieldRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_CutText", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string CutText(IntPtr textFieldRef);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_PasteText")]
-            public static extern void PasteText(global::System.Runtime.InteropServices.HandleRef textFieldRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_PasteText", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PasteText(IntPtr textFieldRef);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_STRIKETHROUGH_get")]
-            public static extern int StrikethroughGet();
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_CHARACTER_SPACING_get")]
-            public static extern int CharacterSpacingGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_STRIKETHROUGH_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int StrikethroughGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_CHARACTER_SPACING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CharacterSpacingGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_REMOVE_FRONT_INSET_get")]
-            public static extern int RemoveFrontInsetGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_REMOVE_FRONT_INSET_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RemoveFrontInsetGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_REMOVE_BACK_INSET_get")]
-            public static extern int RemoveBackInsetGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_REMOVE_BACK_INSET_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RemoveBackInsetGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_RegisterFontVariationProperty")]
-            public static extern int RegisterFontVariationProperty(global::System.Runtime.InteropServices.HandleRef textFieldRef, string pTag);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_RegisterFontVariationProperty", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RegisterFontVariationProperty(IntPtr textFieldRef, string pTag);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_ENABLE_CURSOR_INSET_get")]
-            public static extern int EnableCursorInsetGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_ENABLE_CURSOR_INSET_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableCursorInsetGet();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -14,7 +14,10 @@
  * limitations under the License.
  *
  */
-using System.Runtime.InteropServices;
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -22,255 +25,258 @@ namespace Tizen.NUI
     {
         internal static partial class TextLabel
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_TEXT_get")]
-            public static extern int TextGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_TEXT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TextGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_FONT_FAMILY_get")]
-            public static extern int FontFamilyGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_FONT_FAMILY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int FontFamilyGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_FONT_STYLE_get")]
-            public static extern int FontStyleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_FONT_STYLE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int FontStyleGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_POINT_SIZE_get")]
-            public static extern int PointSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_POINT_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PointSizeGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_MULTI_LINE_get")]
-            public static extern int MultiLineGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_MULTI_LINE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MultiLineGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_HORIZONTAL_ALIGNMENT_get")]
-            public static extern int HorizontalAlignmentGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_HORIZONTAL_ALIGNMENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int HorizontalAlignmentGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_VERTICAL_ALIGNMENT_get")]
-            public static extern int VerticalAlignmentGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_VERTICAL_ALIGNMENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int VerticalAlignmentGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_TEXT_COLOR_get")]
-            public static extern int TextColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_TEXT_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TextColorGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ENABLE_MARKUP_get")]
-            public static extern int EnableMarkupGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ENABLE_MARKUP_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableMarkupGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ENABLE_AUTO_SCROLL_get")]
-            public static extern int EnableAutoScrollGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ENABLE_AUTO_SCROLL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableAutoScrollGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_AUTO_SCROLL_SPEED_get")]
-            public static extern int AutoScrollSpeedGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_AUTO_SCROLL_SPEED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AutoScrollSpeedGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_AUTO_SCROLL_LOOP_COUNT_get")]
-            public static extern int AutoScrollLoopCountGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_AUTO_SCROLL_LOOP_COUNT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AutoScrollLoopCountGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_AUTO_SCROLL_GAP_get")]
-            public static extern int AutoScrollGapGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_AUTO_SCROLL_GAP_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AutoScrollGapGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_LINE_SPACING_get")]
-            public static extern int LineSpacingGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_LINE_SPACING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LineSpacingGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_RELATIVE_LINE_SIZE_get")]
-            public static extern int RelativeLineHeightGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_RELATIVE_LINE_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RelativeLineHeightGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_UNDERLINE_get")]
-            public static extern int UnderlineGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_UNDERLINE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int UnderlineGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_SHADOW_get")]
-            public static extern int ShadowGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_SHADOW_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ShadowGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_EMBOSS_get")]
-            public static extern int EmbossGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_EMBOSS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EmbossGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_OUTLINE_get")]
-            public static extern int OutlineGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_OUTLINE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int OutlineGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_New__SWIG_0")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_New__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_New_With_Style")]
-            public static extern global::System.IntPtr New(bool hasStyle);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_New_With_Style", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New([MarshalAs(UnmanagedType.U1)] bool hasStyle);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_New_With_String_Style")]
-            public static extern global::System.IntPtr New(string text, bool hasStyle);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_New_With_String_Style", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(string text, [MarshalAs(UnmanagedType.U1)] bool hasStyle);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextLabel")]
-            public static extern void DeleteTextLabel(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextLabel", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTextLabel(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_PIXEL_SIZE_get")]
-            public static extern int PixelSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_PIXEL_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PixelSizeGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_ELLIPSIS_get")]
-            public static extern int EllipsisGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_ELLIPSIS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EllipsisGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_ELLIPSIS_POSITION_get")]
-            public static extern int EllipsisPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_ELLIPSIS_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EllipsisPositionGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_LINE_COUNT_get")]
-            public static extern int LineCountGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_LINE_COUNT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LineCountGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_LINE_WRAP_MODE_get")]
-            public static extern int LineWrapModeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_LINE_WRAP_MODE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LineWrapModeGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_TEXT_DIRECTION_get")]
-            public static extern int TextDirectionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_TEXT_DIRECTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TextDirectionGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_VERTICAL_LINE_ALIGNMENT_get")]
-            public static extern int VerticalLineAlignmentGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_VERTICAL_LINE_ALIGNMENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int VerticalLineAlignmentGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_AUTO_SCROLL_STOP_MODE_get")]
-            public static extern int AutoScrollStopModeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_AUTO_SCROLL_STOP_MODE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AutoScrollStopModeGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_AUTO_SCROLL_LOOP_DELAY_get")]
-            public static extern int AutoScrollLoopDelayGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_AUTO_SCROLL_LOOP_DELAY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AutoScrollLoopDelayGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_MATCH_SYSTEM_LANGUAGE_DIRECTION_get")]
-            public static extern int MatchSystemLanguageDirectionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_MATCH_SYSTEM_LANGUAGE_DIRECTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MatchSystemLanguageDirectionGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_TEXT_FIT_get")]
-            public static extern int TextFitGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_TEXT_FIT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TextFitGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_TextFitChangedSignal")]
-            public static extern global::System.IntPtr TextFitChangedSignal(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_TextFitChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr TextFitChangedSignal(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_MIN_LINE_SIZE_get")]
-            public static extern int MinLineSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_MIN_LINE_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MinLineSizeGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_FONT_SIZE_SCALE_get")]
-            public static extern int FontSizeScaleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_FONT_SIZE_SCALE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int FontSizeScaleGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ENABLE_FONT_SIZE_SCALE_get")]
-            public static extern int EnableFontSizeScaleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ENABLE_FONT_SIZE_SCALE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EnableFontSizeScaleGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_GetTextSize")]
-            public static extern global::System.IntPtr GetTextSize(HandleRef textLabelRef, uint start, uint end);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_GetTextSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetTextSize(IntPtr textLabelRef, uint start, uint end);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_GetTextPosition")]
-            public static extern global::System.IntPtr GetTextPosition(HandleRef textLabelRef, uint start, uint end);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_GetTextPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetTextPosition(IntPtr textLabelRef, uint start, uint end);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_SetTextFitArray")]
-            public static extern void SetTextFitArray(HandleRef textLabel, bool enable, uint arraySize, float[] pointSizeArray, float[] minLineSizeArray);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_SetTextFitArray", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTextFitArray(IntPtr textLabel, [MarshalAs(UnmanagedType.U1)] bool enable, uint arraySize, float[] pointSizeArray, float[] minLineSizeArray);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_GetTextFitArray")]
-            public static extern global::System.IntPtr GetTextFitArray(HandleRef textLabel);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_GetTextFitArray", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetTextFitArray(IntPtr textLabel);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AnchorClickedSignal")]
-            public static extern global::System.IntPtr AnchorClickedSignal(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AnchorClickedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr AnchorClickedSignal(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool TextLabelSignalEmpty(HandleRef jarg1);
+            public static partial bool TextLabelSignalEmpty(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_GetConnectionCount")]
-            public static extern uint TextLabelSignalGetConnectionCount(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint TextLabelSignalGetConnectionCount(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_Connect")]
-            public static extern void TextLabelSignalConnect(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TextLabelSignalConnect(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_Disconnect")]
-            public static extern void TextLabelSignalDisconnect(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TextLabelSignalDisconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_Emit")]
-            public static extern void TextLabelSignalEmit(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TextLabelSignalEmit(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TextLabelSignal")]
-            public static extern global::System.IntPtr NewTextLabelSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TextLabelSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTextLabelSignal();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextLabelSignal")]
-            public static extern void DeleteTextLabelSignal(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextLabelSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTextLabelSignal(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_STRIKETHROUGH_get")]
-            public static extern int StrikethroughGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_STRIKETHROUGH_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int StrikethroughGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_CHARACTER_SPACING_get")]
-            public static extern int CharacterSpacingGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_CHARACTER_SPACING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CharacterSpacingGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ANCHOR_COLOR_get")]
-            public static extern int AnchorColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ANCHOR_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AnchorColorGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ANCHOR_CLICKED_COLOR_get")]
-            public static extern int AnchorClickedColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ANCHOR_CLICKED_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AnchorClickedColorGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_REMOVE_FRONT_INSET_get")]
-            public static extern int RemoveFrontInsetGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_REMOVE_FRONT_INSET_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RemoveFrontInsetGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_REMOVE_BACK_INSET_get")]
-            public static extern int RemoveBackInsetGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_REMOVE_BACK_INSET_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RemoveBackInsetGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_CUTOUT_get")]
-            public static extern int CutoutGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_CUTOUT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CutoutGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_RENDER_MODE_get")]
-            public static extern int RenderModeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_RENDER_MODE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RenderModeGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_LAYOUT_DIRECTION_POLICY_get")]
-            public static extern int LayoutDirectionPolicyGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_LAYOUT_DIRECTION_POLICY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LayoutDirectionPolicyGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_AUTO_SCROLL_DIRECTION_get")]
-            public static extern int AutoScrollDirectionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_AUTO_SCROLL_DIRECTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AutoScrollDirectionGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ELLIPSIS_MODE_get")]
-            public static extern int EllipsisModeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ELLIPSIS_MODE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EllipsisModeGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_IS_SCROLLING_get")]
-            public static extern int IsScrollingGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_IS_SCROLLING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int IsScrollingGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_MANUAL_RENDERED_get")]
-            public static extern int ManualRenderedGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_MANUAL_RENDERED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ManualRenderedGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_NEED_REQUEST_ASYNC_RENDER_get")]
-            public static extern int NeedRequestAsyncRenderGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_NEED_REQUEST_ASYNC_RENDER_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int NeedRequestAsyncRenderGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ASYNC_LINE_COUNT_get")]
-            public static extern int AsyncLineCountGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ASYNC_LINE_COUNT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AsyncLineCountGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_RENDER_SCALE_get")]
-            public static extern int RenderScaleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_RENDER_SCALE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RenderScaleGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_PIXEL_SNAP_FACTOR_get")]
-            public static extern int PixelSnapFactorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_PIXEL_SNAP_FACTOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PixelSnapFactorGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithFixedSize")]
-            public static extern void RequestAsyncRenderWithFixedSize(HandleRef textLabelRef, float width, float height);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithFixedSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RequestAsyncRenderWithFixedSize(IntPtr textLabelRef, float width, float height);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithFixedWidth")]
-            public static extern void RequestAsyncRenderWithFixedWidth(HandleRef textLabelRef, float width, float heightConstraint);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithFixedWidth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RequestAsyncRenderWithFixedWidth(IntPtr textLabelRef, float width, float heightConstraint);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithFixedHeight")]
-            public static extern void RequestAsyncRenderWithFixedHeight(HandleRef textLabelRef, float widthConstraint, float height);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithFixedHeight", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RequestAsyncRenderWithFixedHeight(IntPtr textLabelRef, float widthConstraint, float height);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithConstraint")]
-            public static extern void RequestAsyncRenderWithConstraint(HandleRef textLabelRef, float widthConstraint, float heightConstraint);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithConstraint", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RequestAsyncRenderWithConstraint(IntPtr textLabelRef, float widthConstraint, float heightConstraint);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncNaturalSize")]
-            public static extern void RequestAsyncNaturalSize(HandleRef textLabelRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncNaturalSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RequestAsyncNaturalSize(IntPtr textLabelRef);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncHeightForWidth")]
-            public static extern void RequestAsyncHeightForWidth(HandleRef textLabelRef, float width);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncHeightForWidth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RequestAsyncHeightForWidth(IntPtr textLabelRef, float width);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncTextRenderedSignal_Connect")]
-            public static extern void AsyncTextRenderedConnect(HandleRef textLabelRef, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncTextRenderedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AsyncTextRenderedConnect(IntPtr textLabelRef, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncTextRenderedSignal_Disconnect")]
-            public static extern void AsyncTextRenderedDisconnect(HandleRef textLabelRef, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncTextRenderedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AsyncTextRenderedDisconnect(IntPtr textLabelRef, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncNaturalSizeComputedSignal_Connect")]
-            public static extern void AsyncNaturalSizeComputedConnect(HandleRef textLabelRef, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncNaturalSizeComputedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AsyncNaturalSizeComputedConnect(IntPtr textLabelRef, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncNaturalSizeComputedSignal_Disconnect")]
-            public static extern void AsyncNaturalSizeComputedDisconnect(HandleRef textLabelRef, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncNaturalSizeComputedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AsyncNaturalSizeComputedDisconnect(IntPtr textLabelRef, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncHeightForWidthComputedSignal_Connect")]
-            public static extern void AsyncHeightForWidthComputedConnect(HandleRef textLabelRef, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncHeightForWidthComputedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AsyncHeightForWidthComputedConnect(IntPtr textLabelRef, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncHeightForWidthComputedSignal_Disconnect")]
-            public static extern void AsyncHeightForWidthComputedDisconnect(HandleRef textLabelRef, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncHeightForWidthComputedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AsyncHeightForWidthComputedDisconnect(IntPtr textLabelRef, IntPtr handler);
  
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RegisterFontVariationProperty")]
-            public static extern int RegisterFontVariationProperty(HandleRef textLabelRef, string pTag);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RegisterFontVariationProperty", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RegisterFontVariationProperty(IntPtr textLabelRef, string pTag);
  
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_SetMaskEffect")]
-            public static extern void SetMaskEffect(HandleRef textLabelRef, HandleRef control);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_SetMaskEffect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMaskEffect(IntPtr textLabelRef, IntPtr control);
  
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RemoveMaskEffect")]
-            public static extern void RemoveMaskEffect(HandleRef textLabelRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RemoveMaskEffect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemoveMaskEffect(IntPtr textLabelRef);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestUpdateManually")]
-            public static extern void RequestUpdateManually(HandleRef textLabelRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestUpdateManually", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RequestUpdateManually(IntPtr textLabelRef);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextUtils.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextUtils.cs
@@ -15,256 +15,265 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class RendererParameters
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RendererParameters_0")]
-            public static extern global::System.IntPtr NewRendererParameters();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RendererParameters_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewRendererParameters();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_text_set")]
-            public static extern void TextSet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_text_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TextSet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_text_get")]
-            public static extern string TextGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_text_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string TextGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_horizontalAlignment_set")]
-            public static extern void HorizontalAlignmentSet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_horizontalAlignment_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void HorizontalAlignmentSet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_horizontalAlignment_get")]
-            public static extern string HorizontalAlignmentGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_horizontalAlignment_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string HorizontalAlignmentGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_verticalAlignment_set")]
-            public static extern void VerticalAlignmentSet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_verticalAlignment_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void VerticalAlignmentSet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_verticalAlignment_get")]
-            public static extern string VerticalAlignmentGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_verticalAlignment_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string VerticalAlignmentGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontFamily_set")]
-            public static extern void FontFamilySet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontFamily_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FontFamilySet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontFamily_get")]
-            public static extern string FontFamilyGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontFamily_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string FontFamilyGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontWeight_set")]
-            public static extern void FontWeightSet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontWeight_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FontWeightSet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontWeight_get")]
-            public static extern string FontWeightGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontWeight_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string FontWeightGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontWidth_set")]
-            public static extern void FontWidthSet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontWidth_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FontWidthSet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontWidth_get")]
-            public static extern string FontWidthGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontWidth_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string FontWidthGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontSlant_set")]
-            public static extern void FontSlantSet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontSlant_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FontSlantSet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontSlant_get")]
-            public static extern string FontSlantGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontSlant_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string FontSlantGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_layout_set")]
-            public static extern void LayoutSet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_layout_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LayoutSet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_layout_get")]
-            public static extern string LayoutGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_layout_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string LayoutGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_circularAlignment_set")]
-            public static extern void CircularAlignmentSet(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_circularAlignment_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void CircularAlignmentSet(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_circularAlignment_get")]
-            public static extern string CircularAlignmentGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_circularAlignment_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string CircularAlignmentGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_textColor_set")]
-            public static extern void TextColorSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_textColor_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TextColorSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_textColor_get")]
-            public static extern global::System.IntPtr TextColorGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_textColor_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr TextColorGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontSize_set")]
-            public static extern void FontSizeSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontSize_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FontSizeSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontSize_get")]
-            public static extern float FontSizeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_fontSize_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float FontSizeGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_textWidth_set")]
-            public static extern void TextWidthSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_textWidth_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TextWidthSet(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_textWidth_get")]
-            public static extern uint TextWidthGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_textWidth_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint TextWidthGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_textHeight_set")]
-            public static extern void TextHeightSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_textHeight_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TextHeightSet(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_textHeight_get")]
-            public static extern uint TextHeightGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_textHeight_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint TextHeightGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_radius_set")]
-            public static extern void RadiusSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_radius_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RadiusSet(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_radius_get")]
-            public static extern uint RadiusGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_radius_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint RadiusGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_beginAngle_set")]
-            public static extern void BeginAngleSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_beginAngle_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void BeginAngleSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_beginAngle_get")]
-            public static extern float BeginAngleGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_beginAngle_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float BeginAngleGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_incrementAngle_set")]
-            public static extern void IncrementAngleSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_incrementAngle_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void IncrementAngleSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_incrementAngle_get")]
-            public static extern float IncrementAngleGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_incrementAngle_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float IncrementAngleGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_ellipsisEnabled_set")]
-            public static extern void EllipsisEnabledSet(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_ellipsisEnabled_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EllipsisEnabledSet(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_ellipsisEnabled_get")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_ellipsisEnabled_get", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool EllipsisEnabledGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool EllipsisEnabledGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_markupEnabled_set")]
-            public static extern void MarkupEnabledSet(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_markupEnabled_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void MarkupEnabledSet(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_markupEnabled_get")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_markupEnabled_get", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool MarkupEnabledGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool MarkupEnabledGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_isTextColorSet_set")]
-            public static extern void IsTextColorSetSet(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_isTextColorSet_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void IsTextColorSetSet(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_isTextColorSet_get")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_isTextColorSet_get", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsTextColorSetGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsTextColorSetGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_minLineSize_set")]
-            public static extern void MinLineSizeSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_minLineSize_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void MinLineSizeSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_minLineSize_get")]
-            public static extern float MinLineSizeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_minLineSize_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float MinLineSizeGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_padding_set")]
-            public static extern void PaddingSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_padding_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PaddingSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_padding_get")]
-            public static extern global::System.IntPtr PaddingGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RendererParameters_padding_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr PaddingGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_RendererParameters")]
-            public static extern void DeleteRendererParameters(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_RendererParameters", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteRendererParameters(IntPtr jarg1);
         }
 
         internal static partial class EmbeddedItemInfo
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_EmbeddedItemInfo_0")]
-            public static extern global::System.IntPtr NewEmbeddedItemInfo();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_EmbeddedItemInfo_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewEmbeddedItemInfo();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_EmbeddedItemInfo")]
-            public static extern void DeleteEmbeddedItemInfo(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_EmbeddedItemInfo", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteEmbeddedItemInfo(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_characterIndex_set")]
-            public static extern void CharacterIndexSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_characterIndex_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void CharacterIndexSet(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_characterIndex_get")]
-            public static extern uint CharacterIndexGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_characterIndex_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint CharacterIndexGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_glyphIndex_set")]
-            public static extern void GlyphIndexSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_glyphIndex_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GlyphIndexSet(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_glyphIndex_get")]
-            public static extern uint GlyphIndexGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_glyphIndex_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GlyphIndexGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_position_set")]
-            public static extern void PositionSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_position_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PositionSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_position_get")]
-            public static extern global::System.IntPtr PositionGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_position_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr PositionGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_size_set")]
-            public static extern void SizeSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_size_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SizeSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_size_get")]
-            public static extern global::System.IntPtr SizeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_size_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr SizeGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_rotatedSize_set")]
-            public static extern void RotatedSizeSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_rotatedSize_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RotatedSizeSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_rotatedSize_get")]
-            public static extern global::System.IntPtr RotatedSizeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_rotatedSize_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr RotatedSizeGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_angle_set")]
-            public static extern void AngleSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_angle_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AngleSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_angle_get")]
-            public static extern global::System.IntPtr AngleGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_angle_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr AngleGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_colorBlendingMode_set")]
-            public static extern void ColorBlendingModeSet(global::System.Runtime.InteropServices.HandleRef jarg1, Tizen.NUI.ColorBlendingMode jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_colorBlendingMode_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ColorBlendingModeSet(IntPtr jarg1, Tizen.NUI.ColorBlendingMode jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_colorBlendingMode_get")]
-            public static extern Tizen.NUI.ColorBlendingMode ColorBlendingModeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EmbeddedItemInfo_colorBlendingMode_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial Tizen.NUI.ColorBlendingMode ColorBlendingModeGet(IntPtr jarg1);
         }
 
         internal static partial class ShadowParameters
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ShadowParameters_0")]
-            public static extern global::System.IntPtr NewShadowParameters();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ShadowParameters_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewShadowParameters();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ShadowParameters")]
-            public static extern void DeleteShadowParameters(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ShadowParameters", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteShadowParameters(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_input_set")]
-            public static extern void InputSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_input_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void InputSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_input_get")]
-            public static extern global::System.IntPtr InputGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_input_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr InputGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_textColor_set")]
-            public static extern void TextColorSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_textColor_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TextColorSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_textColor_get")]
-            public static extern global::System.IntPtr TextColorGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_textColor_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr TextColorGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_color_set")]
-            public static extern void ColorSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_color_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ColorSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_color_get")]
-            public static extern global::System.IntPtr ColorGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_color_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ColorGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_offset_set")]
-            public static extern void OffsetSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_offset_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void OffsetSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_offset_get")]
-            public static extern global::System.IntPtr OffsetGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_offset_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr OffsetGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_blendShadow_set")]
-            public static extern void BlendShadowSet(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_blendShadow_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void BlendShadowSet(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_blendShadow_get")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ShadowParameters_blendShadow_get", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool BlendShadowGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool BlendShadowGet(IntPtr jarg1);
         }
 
         internal static partial class TextUtils
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextUtils_Render")]
-            public static extern global::System.IntPtr Render(global::System.Runtime.InteropServices.HandleRef jarg1, ref global::System.IntPtr jarg2, ref int count, ref int length);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextUtils_Render", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Render(IntPtr jarg1, ref global::System.IntPtr jarg2, ref int count, ref int length);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextUtils_CreateShadow")]
-            public static extern global::System.IntPtr CreateShadow(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextUtils_CreateShadow", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CreateShadow(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextUtils_ConvertToRgba8888")]
-            public static extern global::System.IntPtr ConvertToRgba8888(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, bool jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextUtils_ConvertToRgba8888", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ConvertToRgba8888(IntPtr jarg1, IntPtr jarg2, [MarshalAs(UnmanagedType.U1)] bool jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextUtils_UpdateBuffer")]
-            public static extern void UpdateBuffer(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, uint jarg3, uint jarg4, bool jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextUtils_UpdateBuffer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void UpdateBuffer(IntPtr jarg1, IntPtr jarg2, uint jarg3, uint jarg4, [MarshalAs(UnmanagedType.U1)] bool jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextUtils_GetLastCharacterIndex")]
-            public static extern global::System.IntPtr GetLastCharacterIndex(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextUtils_GetLastCharacterIndex", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetLastCharacterIndex(IntPtr jarg1);
 
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Texture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Texture.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,34 +26,39 @@ namespace Tizen.NUI
         internal static partial class Texture
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Texture_New__SWIG_0")]
-            public static extern global::System.IntPtr New(int jarg1, int jarg2, uint jarg3, uint jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Texture_New__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int jarg1, int jarg2, uint jarg3, uint jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Texture_New__SWIG_1")]
-            public static extern global::System.IntPtr New(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Texture_New__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Texture")]
-            public static extern void DeleteTexture(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Texture", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTexture(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Texture_Upload__SWIG_0")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Texture_Upload__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Upload(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool Upload(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Texture_Upload__SWIG_1")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Texture_Upload__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Upload(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, uint jarg3, uint jarg4, uint jarg5, uint jarg6, uint jarg7, uint jarg8);
+            public static partial bool Upload(IntPtr jarg1, IntPtr jarg2, uint jarg3, uint jarg4, uint jarg5, uint jarg6, uint jarg7, uint jarg8);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Texture_GenerateMipmaps")]
-            public static extern void GenerateMipmaps(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Texture_GenerateMipmaps", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GenerateMipmaps(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Texture_GetWidth")]
-            public static extern uint GetWidth(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Texture_GetWidth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetWidth(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Texture_GetHeight")]
-            public static extern uint GetHeight(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Texture_GetHeight", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetHeight(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Texture_TbmSurface")]
-            public static extern global::System.IntPtr NewTbmSurface(System.IntPtr jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Texture_TbmSurface", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTbmSurface(System.IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextureSet.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextureSet.cs
@@ -15,38 +15,47 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class TextureSet
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextureSet_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextureSet_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextureSet")]
-            public static extern void DeleteTextureSet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextureSet", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTextureSet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextureSet_SetTexture")]
-            public static extern void SetTexture(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextureSet_SetTexture", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTexture(IntPtr jarg1, uint jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextureSet_RemoveTexture")]
-            public static extern void RemoveTexture(global::System.Runtime.InteropServices.HandleRef textureSet, uint index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextureSet_RemoveTexture", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemoveTexture(IntPtr textureSet, uint index);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextureSet_GetTexture")]
-            public static extern global::System.IntPtr GetTexture(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextureSet_GetTexture", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetTexture(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextureSet_SetSampler")]
-            public static extern void SetSampler(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextureSet_SetSampler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetSampler(IntPtr jarg1, uint jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextureSet_RemoveSampler")]
-            public static extern void RemoveSampler(global::System.Runtime.InteropServices.HandleRef textureSet, uint index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextureSet_RemoveSampler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemoveSampler(IntPtr textureSet, uint index);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextureSet_GetSampler")]
-            public static extern global::System.IntPtr GetSampler(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextureSet_GetSampler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetSampler(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextureSet_GetTextureCount")]
-            public static extern uint GetTextureCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextureSet_GetTextureCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetTextureCount(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TimePeriod.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TimePeriod.cs
@@ -15,32 +15,41 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class TimePeriod
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TimePeriod__SWIG_0")]
-            public static extern global::System.IntPtr NewTimePeriod(float jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TimePeriod__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTimePeriod(float jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TimePeriod__SWIG_1")]
-            public static extern global::System.IntPtr NewTimePeriod(float jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TimePeriod__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTimePeriod(float jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TimePeriod")]
-            public static extern void DeleteTimePeriod(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TimePeriod", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTimePeriod(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimePeriod_delaySeconds_set")]
-            public static extern void DelaySecondsSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimePeriod_delaySeconds_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DelaySecondsSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimePeriod_delaySeconds_get")]
-            public static extern float DelaySecondsGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimePeriod_delaySeconds_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float DelaySecondsGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimePeriod_durationSeconds_set")]
-            public static extern void DurationSecondsSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimePeriod_durationSeconds_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DurationSecondsSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimePeriod_durationSeconds_get")]
-            public static extern float DurationSecondsGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimePeriod_durationSeconds_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float DurationSecondsGet(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Timer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Timer.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,56 +26,61 @@ namespace Tizen.NUI
         internal static partial class Timer
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Timer_New")]
-            public static extern global::System.IntPtr New(uint jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Timer_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(uint jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Timer__SWIG_1")]
-            public static extern global::System.IntPtr NewTimer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Timer__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTimer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Timer")]
-            public static extern void DeleteTimer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Timer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTimer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Timer_Start")]
-            public static extern void Start(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Timer_Start", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Start(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Timer_Stop")]
-            public static extern void Stop(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Timer_Stop", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Stop(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Timer_SetInterval")]
-            public static extern void SetInterval(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Timer_SetInterval", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetInterval(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Timer_GetInterval")]
-            public static extern uint GetInterval(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Timer_GetInterval", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetInterval(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Timer_IsRunning")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Timer_IsRunning", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsRunning(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsRunning(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Timer_TickSignal")]
-            public static extern global::System.IntPtr TickSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Timer_TickSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr TickSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimerSignalType_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimerSignalType_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool TimerSignalTypeEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool TimerSignalTypeEmpty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimerSignalType_GetConnectionCount")]
-            public static extern uint TimerSignalTypeGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimerSignalType_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint TimerSignalTypeGetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimerSignalType_Connect")]
-            public static extern void TimerSignalTypeConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimerSignalType_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TimerSignalTypeConnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimerSignalType_Disconnect")]
-            public static extern void TimerSignalTypeDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimerSignalType_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TimerSignalTypeDisconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimerSignalType_Emit")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimerSignalType_Emit", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool TimerSignalTypeEmit(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool TimerSignalTypeEmit(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TimerSignalType")]
-            public static extern global::System.IntPtr NewTimerSignalType();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TimerSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTimerSignalType();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TimerSignalType")]
-            public static extern void DeleteTimerSignalType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TimerSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTimerSignalType(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Touch.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Touch.cs
@@ -15,65 +15,74 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Touch
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Touch__SWIG_0")]
-            public static extern global::System.IntPtr NewTouch();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Touch__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTouch();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetMouseButton")]
-            public static extern int GetMouseButton(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetMouseButton", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetMouseButton(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetTime")]
-            public static extern uint GetTime(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetTime", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetTime(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_SetTime")]
-            public static extern void SetTime(global::System.Runtime.InteropServices.HandleRef touchEvent, uint time);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_SetTime", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTime(IntPtr touchEvent, uint time);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetPointCount")]
-            public static extern uint GetPointCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetPointCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetPointCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetDeviceId")]
-            public static extern int GetDeviceId(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetDeviceId", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetDeviceId(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetState")]
-            public static extern int GetState(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetState", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetState(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetHitActor")]
-            public static extern global::System.IntPtr GetHitActor(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetHitActor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetHitActor(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetLocalPosition")]
-            public static extern global::System.IntPtr GetLocalPosition(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetLocalPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetLocalPosition(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetScreenPosition")]
-            public static extern global::System.IntPtr GetScreenPosition(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetScreenPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetScreenPosition(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetRadius")]
-            public static extern float GetRadius(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetRadius", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetRadius(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetEllipseRadius")]
-            public static extern global::System.IntPtr GetEllipseRadius(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetEllipseRadius", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetEllipseRadius(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetPressure")]
-            public static extern float GetPressure(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetPressure", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetPressure(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetAngle")]
-            public static extern global::System.IntPtr GetAngle(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetAngle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetAngle(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetDeviceClass")]
-            public static extern int GetDeviceClass(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetDeviceClass", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetDeviceClass(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetDeviceSubclass")]
-            public static extern int GetDeviceSubClass(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetDeviceSubclass", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetDeviceSubClass(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetDeviceName")]
-            public static extern string GetDeviceName(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetDeviceName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetDeviceName(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Touch")]
-            public static extern void DeleteTouch(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Touch", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTouch(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TouchPoint.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TouchPoint.cs
@@ -15,50 +15,59 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class TouchPoint
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TouchPoint__SWIG_0")]
-            public static extern global::System.IntPtr NewTouchPoint(int jarg1, int jarg2, float jarg3, float jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TouchPoint__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTouchPoint(int jarg1, int jarg2, float jarg3, float jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TouchPoint__SWIG_1")]
-            public static extern global::System.IntPtr NewTouchPoint(int jarg1, int jarg2, float jarg3, float jarg4, float jarg5, float jarg6);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TouchPoint__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTouchPoint(int jarg1, int jarg2, float jarg3, float jarg4, float jarg5, float jarg6);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TouchPoint")]
-            public static extern void DeleteTouchPoint(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TouchPoint", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTouchPoint(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_deviceId_set")]
-            public static extern void DeviceIdSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_deviceId_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeviceIdSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_deviceId_get")]
-            public static extern int DeviceIdGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_deviceId_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DeviceIdGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_state_set")]
-            public static extern void StateSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_state_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void StateSet(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_state_get")]
-            public static extern int StateGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_state_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int StateGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_hitActor_set")]
-            public static extern void HitActorSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_hitActor_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void HitActorSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_hitActor_get")]
-            public static extern global::System.IntPtr HitActorGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_hitActor_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr HitActorGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_local_set")]
-            public static extern void LocalSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_local_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LocalSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_local_get")]
-            public static extern global::System.IntPtr LocalGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_local_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr LocalGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_screen_set")]
-            public static extern void ScreenSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_screen_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ScreenSet(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_screen_get")]
-            public static extern global::System.IntPtr ScreenGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPoint_screen_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ScreenGet(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TouchPointContainer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TouchPointContainer.cs
@@ -15,77 +15,86 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class TouchPointContainer
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_Clear")]
-            public static extern void Clear(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_Clear", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Clear(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_Add")]
-            public static extern void Add(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_Add", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Add(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_size")]
-            public static extern uint size(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_size", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint size(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_capacity")]
-            public static extern uint capacity(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_capacity", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint capacity(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_reserve")]
-            public static extern void reserve(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_reserve", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void reserve(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TouchPointContainer__SWIG_0")]
-            public static extern global::System.IntPtr NewTouchPointContainer();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TouchPointContainer__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTouchPointContainer();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TouchPointContainer__SWIG_1")]
-            public static extern global::System.IntPtr NewTouchPointContainer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TouchPointContainer__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTouchPointContainer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TouchPointContainer__SWIG_2")]
-            public static extern global::System.IntPtr NewTouchPointContainer(int jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TouchPointContainer__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTouchPointContainer(int jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_getitemcopy")]
-            public static extern global::System.IntPtr getitemcopy(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_getitemcopy", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr getitemcopy(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_getitem")]
-            public static extern global::System.IntPtr getitem(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_getitem", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr getitem(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_setitem")]
-            public static extern void setitem(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_setitem", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void setitem(IntPtr jarg1, int jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_AddRange")]
-            public static extern void AddRange(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_AddRange", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddRange(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_GetRange")]
-            public static extern global::System.IntPtr GetRange(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_GetRange", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetRange(IntPtr jarg1, int jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_Insert")]
-            public static extern void Insert(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_Insert", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Insert(IntPtr jarg1, int jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_InsertRange")]
-            public static extern void InsertRange(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_InsertRange", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void InsertRange(IntPtr jarg1, int jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_RemoveAt")]
-            public static extern void RemoveAt(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_RemoveAt", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemoveAt(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_RemoveRange")]
-            public static extern void RemoveRange(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_RemoveRange", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemoveRange(IntPtr jarg1, int jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_Repeat")]
-            public static extern global::System.IntPtr Repeat(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_Repeat", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Repeat(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_Reverse__SWIG_0")]
-            public static extern void Reverse(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_Reverse__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Reverse(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_Reverse__SWIG_1")]
-            public static extern void Reverse(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_Reverse__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Reverse(IntPtr jarg1, int jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_SetRange")]
-            public static extern void SetRange(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TouchPointContainer_SetRange", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetRange(IntPtr jarg1, int jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TouchPointContainer")]
-            public static extern void DeleteTouchPointContainer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TouchPointContainer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTouchPointContainer(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TransitionData.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TransitionData.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,23 +26,28 @@ namespace Tizen.NUI
         internal static partial class TransitionData
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TransitionData")]
-            public static extern void DeleteTransitionData(global::System.Runtime.InteropServices.HandleRef jarg1B);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TransitionData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTransitionData(IntPtr jarg1B);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionData_New__SWIG_0")]
-            public static extern global::System.IntPtr NewByMap(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionData_New__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewByMap(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionData_New__SWIG_1")]
-            public static extern global::System.IntPtr NewByArray(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionData_New__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewByArray(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TransitionData__SWIG_1")]
-            public static extern global::System.IntPtr NewTransitionData(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TransitionData__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTransitionData(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionData_Count")]
-            public static extern uint Count(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionData_Count", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint Count(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionData_GetAnimatorAt")]
-            public static extern global::System.IntPtr GetAnimatorAt(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionData_GetAnimatorAt", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetAnimatorAt(IntPtr jarg1, uint jarg2);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TransitionItem.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TransitionItem.cs
@@ -15,27 +15,31 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
-    using global::System;
-    using global::System.Runtime.InteropServices;
-
     internal static partial class Interop
     {
         internal static partial class TransitionItem
         {
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Transition_New")]
-            public static extern IntPtr New(HandleRef source, HandleRef destination, bool useDestinationTarget, HandleRef timePeriod);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Transition_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr New(IntPtr source, IntPtr destination, [MarshalAs(UnmanagedType.U1)] bool useDestinationTarget, IntPtr timePeriod);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Transition")]
-            public static extern void Delete(HandleRef transition);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Transition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Delete(IntPtr transition);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Transition_Set")]
-            public static extern IntPtr NewTransitionItem(HandleRef transition);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Transition_Set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr NewTransitionItem(IntPtr transition);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Transition_Assign")]
-            public static extern IntPtr Assign(HandleRef destination, HandleRef source);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Transition_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr Assign(IntPtr destination, IntPtr source);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TransitionItemBase.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TransitionItemBase.cs
@@ -15,45 +15,49 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
-    using global::System;
-    using global::System.Runtime.InteropServices;
-
     internal static partial class Interop
     {
         internal static partial class TransitionItemBase
         {
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_New")]
-            public static extern IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr New();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TransitionBase")]
-            public static extern void Delete(HandleRef transition);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TransitionBase", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Delete(IntPtr transition);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TransitionBase_Set")]
-            public static extern IntPtr NewTransitionItemBase(HandleRef transition);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TransitionBase_Set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr NewTransitionItemBase(IntPtr transition);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_Assign")]
-            public static extern IntPtr Assign(HandleRef destination, HandleRef source);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr Assign(IntPtr destination, IntPtr source);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_SetTimePeriod")]
-            public static extern void SetTimePeriod(HandleRef transition, HandleRef seconds);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_SetTimePeriod", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTimePeriod(IntPtr transition, IntPtr seconds);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_GetTimePeriod")]
-            public static extern IntPtr GetTimePeriod(HandleRef transition);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_GetTimePeriod", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GetTimePeriod(IntPtr transition);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_SetAlphaFunction")]
-            public static extern void SetAlphaFunction(HandleRef transition, HandleRef seconds);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_SetAlphaFunction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetAlphaFunction(IntPtr transition, IntPtr seconds);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_GetAlphaFunction")]
-            public static extern IntPtr GetAlphaFunction(HandleRef transition);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_GetAlphaFunction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GetAlphaFunction(IntPtr transition);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_TransitionWithChild")]
-            public static extern void TransitionWithChild(HandleRef transition, bool transitionWithChild);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_TransitionWithChild", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TransitionWithChild(IntPtr transition, [MarshalAs(UnmanagedType.U1)] bool transitionWithChild);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_SetAppearingTransition")]
-            public static extern void SetAppearingTransition(HandleRef transition, bool appearingTransition);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_SetAppearingTransition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetAppearingTransition(IntPtr transition, [MarshalAs(UnmanagedType.U1)] bool appearingTransition);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TransitionSet.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TransitionSet.cs
@@ -15,54 +15,59 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
-    using global::System;
-    using global::System.Runtime.InteropServices;
     internal static partial class Interop
     {
         internal static partial class TransitionSet
         {
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_New")]
-            public static extern IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr New();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TransitionSet")]
-            public static extern void Delete(HandleRef transitionSet);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TransitionSet", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Delete(IntPtr transitionSet);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TransitionSet_Set")]
-            public static extern IntPtr NewTransitionSet(HandleRef transitionSet);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TransitionSet_Set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr NewTransitionSet(IntPtr transitionSet);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_Assign")]
-            public static extern IntPtr Assign(HandleRef destination, HandleRef source);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr Assign(IntPtr destination, IntPtr source);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_AddTransition")]
-            public static extern void AddTransition(HandleRef transitionSet, HandleRef transition);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_AddTransition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddTransition(IntPtr transitionSet, IntPtr transition);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_GetTransitionAt")]
-            public static extern IntPtr GetTransitionAt(HandleRef transitionSet, uint index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_GetTransitionAt", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GetTransitionAt(IntPtr transitionSet, uint index);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_GetTransitionCount")]
-            public static extern uint GetTransitionCount(HandleRef transitionSet);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_GetTransitionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetTransitionCount(IntPtr transitionSet);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_Play")]
-            public static extern void Play(HandleRef transitionSet);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_Play", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Play(IntPtr transitionSet);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_FinishedSignal")]
-            public static extern IntPtr FinishedSignal(HandleRef nuiTransitionSet);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_FinishedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr FinishedSignal(IntPtr nuiTransitionSet);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_Signal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_Signal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool TransitionSetFinishedSignalEmpty(HandleRef transitionSet);
+            public static partial bool TransitionSetFinishedSignalEmpty(IntPtr transitionSet);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_Signal_GetConnectionCount")]
-            public static extern uint TransitionSetFinishedSignalGetConnectionCount(HandleRef transitionSet);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_Signal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint TransitionSetFinishedSignalGetConnectionCount(IntPtr transitionSet);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_Signal_Connect")]
-            public static extern void TransitionSetFinishedSignalConnect(HandleRef transitionSet, HandleRef func);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_Signal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TransitionSetFinishedSignalConnect(IntPtr transitionSet, IntPtr func);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_Signal_Disconnect")]
-            public static extern void TransitionSetFinishedSignalDisconnect(HandleRef transitionSet, HandleRef func);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionSet_Signal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TransitionSetFinishedSignalDisconnect(IntPtr transitionSet, IntPtr func);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TtsPlayer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TtsPlayer.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,38 +26,43 @@ namespace Tizen.NUI
         internal static partial class TtsPlayer
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TtsPlayer__SWIG_0")]
-            public static extern global::System.IntPtr NewTtsPlayer();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TtsPlayer__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTtsPlayer();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TtsPlayer_Get__SWIG_0")]
-            public static extern global::System.IntPtr Get(int jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TtsPlayer_Get__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Get(int jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TtsPlayer_Get__SWIG_1")]
-            public static extern global::System.IntPtr Get();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TtsPlayer_Get__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Get();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TtsPlayer__SWIG_1")]
-            public static extern global::System.IntPtr NewTtsPlayer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TtsPlayer__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTtsPlayer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TtsPlayer_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TtsPlayer_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TtsPlayer_Play")]
-            public static extern void Play(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TtsPlayer_Play", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Play(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TtsPlayer_Stop")]
-            public static extern void Stop(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TtsPlayer_Stop", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Stop(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TtsPlayer_Pause")]
-            public static extern void Pause(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TtsPlayer_Pause", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Pause(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TtsPlayer_Resume")]
-            public static extern void Resume(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TtsPlayer_Resume", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Resume(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TtsPlayer_GetState")]
-            public static extern int GetState(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TtsPlayer_GetState", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetState(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TtsPlayer_StateChangedSignal")]
-            public static extern global::System.IntPtr StateChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TtsPlayer_StateChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr StateChangedSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TypeInfo.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TypeInfo.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,29 +26,34 @@ namespace Tizen.NUI
         internal static partial class TypeInfo
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TypeInfo__SWIG_0")]
-            public static extern global::System.IntPtr NewTypeInfo();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TypeInfo__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTypeInfo();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TypeInfo")]
-            public static extern void DeleteTypeInfo(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TypeInfo", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTypeInfo(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TypeInfo__SWIG_1")]
-            public static extern global::System.IntPtr NewTypeInfo(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TypeInfo__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTypeInfo(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeInfo_GetName")]
-            public static extern string GetName(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeInfo_GetName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetName(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeInfo_GetBaseName")]
-            public static extern string GetBaseName(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeInfo_GetBaseName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetBaseName(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeInfo_CreateInstance")]
-            public static extern global::System.IntPtr CreateInstance(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeInfo_CreateInstance", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CreateInstance(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeInfo_GetPropertyCount")]
-            public static extern uint GetPropertyCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeInfo_GetPropertyCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetPropertyCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeInfo_GetPropertyName")]
-            public static extern string GetPropertyName(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeInfo_GetPropertyName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetPropertyName(IntPtr jarg1, int jarg2);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TypeRegistration.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TypeRegistration.cs
@@ -15,32 +15,41 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class TypeRegistration
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TypeRegistration__SWIG_0")]
-            public static extern global::System.IntPtr NewTypeRegistration(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TypeRegistration__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTypeRegistration(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TypeRegistration__SWIG_1")]
-            public static extern global::System.IntPtr NewTypeRegistration(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, bool jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TypeRegistration__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTypeRegistration(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, [MarshalAs(UnmanagedType.U1)] bool jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TypeRegistration__SWIG_2")]
-            public static extern global::System.IntPtr NewTypeRegistration(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TypeRegistration__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTypeRegistration(string jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeRegistration_RegisteredName")]
-            public static extern string RegisteredName(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeRegistration_RegisteredName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string RegisteredName(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeRegistration_RegisterControl")]
-            public static extern void RegisterControl(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeRegistration_RegisterControl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterControl(string jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeRegistration_RegisterProperty")]
-            public static extern void RegisterProperty(string jarg1, string jarg2, int jarg3, int jarg4, global::System.Runtime.InteropServices.HandleRef jarg5, global::System.Runtime.InteropServices.HandleRef jarg6);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeRegistration_RegisterProperty", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterProperty(string jarg1, string jarg2, int jarg3, int jarg4, IntPtr jarg5, IntPtr jarg6);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TypeRegistration")]
-            public static extern void DeleteTypeRegistration(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TypeRegistration", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTypeRegistration(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TypeRegistry.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TypeRegistry.cs
@@ -15,38 +15,47 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class TypeRegistry
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeRegistry_Get")]
-            public static extern global::System.IntPtr Get();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeRegistry_Get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Get();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TypeRegistry__SWIG_0")]
-            public static extern global::System.IntPtr NewTypeRegistry();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TypeRegistry__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTypeRegistry();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TypeRegistry")]
-            public static extern void DeleteTypeRegistry(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TypeRegistry", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteTypeRegistry(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TypeRegistry__SWIG_1")]
-            public static extern global::System.IntPtr NewTypeRegistry(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TypeRegistry__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewTypeRegistry(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeRegistry_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeRegistry_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeRegistry_GetTypeInfo__SWIG_0")]
-            public static extern global::System.IntPtr GetTypeInfo(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeRegistry_GetTypeInfo__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetTypeInfo(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeRegistry_GetTypeInfo__SWIG_1")]
-            public static extern global::System.IntPtr GetTypeInfo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeRegistry_GetTypeInfo__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetTypeInfo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeRegistry_GetTypeNameCount")]
-            public static extern uint GetTypeNameCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeRegistry_GetTypeNameCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetTypeNameCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeRegistry_GetTypeName")]
-            public static extern string GetTypeName(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TypeRegistry_GetTypeName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetTypeName(IntPtr jarg1, uint jarg2);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Uint16Pair.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Uint16Pair.cs
@@ -15,66 +15,75 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Uint16Pair
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Uint16Pair__SWIG_0")]
-            public static extern global::System.IntPtr NewUint16Pair();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Uint16Pair__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewUint16Pair();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Uint16Pair__SWIG_1")]
-            public static extern global::System.IntPtr NewUint16Pair(uint jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Uint16Pair__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewUint16Pair(uint jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Uint16Pair__SWIG_2")]
-            public static extern global::System.IntPtr NewUint16Pair(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Uint16Pair__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewUint16Pair(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_SetWidth")]
-            public static extern void SetWidth(global::System.Runtime.InteropServices.HandleRef jarg1, ushort jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_SetWidth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetWidth(IntPtr jarg1, ushort jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_GetWidth")]
-            public static extern ushort GetWidth(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_GetWidth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial ushort GetWidth(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_SetHeight")]
-            public static extern void SetHeight(global::System.Runtime.InteropServices.HandleRef jarg1, ushort jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_SetHeight", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetHeight(IntPtr jarg1, ushort jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_GetHeight")]
-            public static extern ushort GetHeight(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_GetHeight", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial ushort GetHeight(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_SetX")]
-            public static extern void SetX(global::System.Runtime.InteropServices.HandleRef jarg1, ushort jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_SetX", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetX(IntPtr jarg1, ushort jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_GetX")]
-            public static extern ushort GetX(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_GetX", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial ushort GetX(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_SetY")]
-            public static extern void SetY(global::System.Runtime.InteropServices.HandleRef jarg1, ushort jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_SetY", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetY(IntPtr jarg1, ushort jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_GetY")]
-            public static extern ushort GetY(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_GetY", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial ushort GetY(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_EqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_EqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool EqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool EqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_NotEqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_NotEqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool NotEqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool NotEqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_LessThan")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_LessThan", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool LessThan(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool LessThan(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_GreaterThan")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Uint16Pair_GreaterThan", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GreaterThan(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool GreaterThan(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Uint16Pair")]
-            public static extern void DeleteUint16Pair(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Uint16Pair", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteUint16Pair(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Vector2.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Vector2.cs
@@ -15,118 +15,127 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Vector2
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector2__SWIG_0")]
-            public static extern global::System.IntPtr NewVector2();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector2__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVector2();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector2__SWIG_1")]
-            public static extern global::System.IntPtr NewVector2(float jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector2__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVector2(float jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector2__SWIG_2")]
-            public static extern global::System.IntPtr NewVector2([global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] float[] jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector2__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVector2([global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] float[] jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector2__SWIG_3")]
-            public static extern global::System.IntPtr NewVector2WithVector3(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector2__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVector2WithVector3(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector2__SWIG_4")]
-            public static extern global::System.IntPtr NewVector2WithVector4(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector2__SWIG_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVector2WithVector4(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Add")]
-            public static extern global::System.IntPtr Add(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Add", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Add(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_AddAssign")]
-            public static extern global::System.IntPtr AddAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_AddAssign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr AddAssign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Subtract__SWIG_0")]
-            public static extern global::System.IntPtr Subtract(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Subtract__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Subtract(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_SubtractAssign")]
-            public static extern global::System.IntPtr SubtractAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_SubtractAssign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr SubtractAssign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Multiply__SWIG_0")]
-            public static extern global::System.IntPtr Multiply(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Multiply__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Multiply(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Multiply__SWIG_1")]
-            public static extern global::System.IntPtr Multiply(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Multiply__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Multiply(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_MultiplyAssign__SWIG_0")]
-            public static extern global::System.IntPtr MultiplyAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_MultiplyAssign__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr MultiplyAssign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_MultiplyAssign__SWIG_1")]
-            public static extern global::System.IntPtr MultiplyAssign(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_MultiplyAssign__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr MultiplyAssign(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Divide__SWIG_0")]
-            public static extern global::System.IntPtr Divide(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Divide__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Divide(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Divide__SWIG_1")]
-            public static extern global::System.IntPtr Divide(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Divide__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Divide(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_DivideAssign__SWIG_0")]
-            public static extern global::System.IntPtr DivideAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_DivideAssign__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DivideAssign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_DivideAssign__SWIG_1")]
-            public static extern global::System.IntPtr DivideAssign(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_DivideAssign__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DivideAssign(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Subtract__SWIG_1")]
-            public static extern global::System.IntPtr Subtract(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Subtract__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Subtract(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_EqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_EqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool EqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool EqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_NotEqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_NotEqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool NotEqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool NotEqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_ValueOfIndex__SWIG_0")]
-            public static extern float ValueOfIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_ValueOfIndex__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float ValueOfIndex(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Length")]
-            public static extern float Length(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Length", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float Length(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_LengthSquared")]
-            public static extern float LengthSquared(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_LengthSquared", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float LengthSquared(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Normalize")]
-            public static extern void Normalize(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Normalize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Normalize(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Clamp")]
-            public static extern void Clamp(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Clamp", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Clamp(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_X_set")]
-            public static extern void XSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_X_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void XSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_X_get")]
-            public static extern float XGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_X_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float XGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Width_set")]
-            public static extern void WidthSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Width_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void WidthSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Width_get")]
-            public static extern float WidthGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Width_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float WidthGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Y_set")]
-            public static extern void YSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Y_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void YSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Y_get")]
-            public static extern float YGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Y_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float YGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Height_set")]
-            public static extern void HeightSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Height_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void HeightSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Height_get")]
-            public static extern float HeightGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Height_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float HeightGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Vector2")]
-            public static extern void DeleteVector2(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Vector2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteVector2(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_set_all")]
-            public static extern void SetAll(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_set_all", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetAll(IntPtr jarg1, float jarg2, float jarg3);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Vector3.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Vector3.cs
@@ -15,163 +15,172 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Vector3
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector3__SWIG_0")]
-            public static extern global::System.IntPtr NewVector3();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector3__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVector3();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector3__SWIG_1")]
-            public static extern global::System.IntPtr NewVector3(float jarg1, float jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector3__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVector3(float jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector3__SWIG_2")]
-            public static extern global::System.IntPtr NewVector3([global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] float[] jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector3__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVector3([global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] float[] jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector3__SWIG_3")]
-            public static extern global::System.IntPtr NewVector3WithVector2(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector3__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVector3WithVector2(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector3__SWIG_4")]
-            public static extern global::System.IntPtr NewVector3WithVector4(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector3__SWIG_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVector3WithVector4(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Add")]
-            public static extern global::System.IntPtr Add(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Add", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Add(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_AddAssign")]
-            public static extern global::System.IntPtr AddAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_AddAssign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr AddAssign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Subtract__SWIG_0")]
-            public static extern global::System.IntPtr Subtract(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Subtract__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Subtract(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_SubtractAssign")]
-            public static extern global::System.IntPtr SubtractAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_SubtractAssign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr SubtractAssign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Multiply__SWIG_0")]
-            public static extern global::System.IntPtr Multiply(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Multiply__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Multiply(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Multiply__SWIG_1")]
-            public static extern global::System.IntPtr Multiply(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Multiply__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Multiply(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_MultiplyAssign__SWIG_0")]
-            public static extern global::System.IntPtr MultiplyAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_MultiplyAssign__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr MultiplyAssign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_MultiplyAssign__SWIG_1")]
-            public static extern global::System.IntPtr MultiplyAssign(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_MultiplyAssign__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr MultiplyAssign(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_MultiplyAssign__SWIG_2")]
-            public static extern global::System.IntPtr MultiplyAssignQuaternion(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_MultiplyAssign__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr MultiplyAssignQuaternion(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Divide__SWIG_0")]
-            public static extern global::System.IntPtr Divide(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Divide__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Divide(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Divide__SWIG_1")]
-            public static extern global::System.IntPtr Divide(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Divide__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Divide(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_DivideAssign__SWIG_0")]
-            public static extern global::System.IntPtr DivideAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_DivideAssign__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DivideAssign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_DivideAssign__SWIG_1")]
-            public static extern global::System.IntPtr DivideAssign(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_DivideAssign__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DivideAssign(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Subtract__SWIG_1")]
-            public static extern global::System.IntPtr Subtract(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Subtract__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Subtract(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_EqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_EqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool EqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool EqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_NotEqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_NotEqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool NotEqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool NotEqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_ValueOfIndex__SWIG_0")]
-            public static extern float ValueOfIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_ValueOfIndex__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float ValueOfIndex(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Dot")]
-            public static extern float Dot(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Dot", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float Dot(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Cross")]
-            public static extern global::System.IntPtr Cross(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Cross", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Cross(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Length")]
-            public static extern float Length(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Length", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float Length(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_LengthSquared")]
-            public static extern float LengthSquared(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_LengthSquared", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float LengthSquared(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Normalize")]
-            public static extern void Normalize(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Normalize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Normalize(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Clamp")]
-            public static extern void Clamp(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Clamp", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Clamp(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_GetVectorXY__SWIG_0")]
-            public static extern global::System.IntPtr GetVectorXY(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_GetVectorXY__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetVectorXY(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_GetVectorYZ__SWIG_0")]
-            public static extern global::System.IntPtr GetVectorYZ(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_GetVectorYZ__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetVectorYZ(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_X_set")]
-            public static extern void XSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_X_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void XSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_X_get")]
-            public static extern float XGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_X_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float XGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Width_set")]
-            public static extern void WidthSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Width_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void WidthSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Width_get")]
-            public static extern float WidthGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Width_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float WidthGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_r_set")]
-            public static extern void RSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_r_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_r_get")]
-            public static extern float RGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_r_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Y_set")]
-            public static extern void YSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Y_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void YSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Y_get")]
-            public static extern float YGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Y_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float YGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Height_set")]
-            public static extern void HeightSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Height_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void HeightSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Height_get")]
-            public static extern float HeightGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Height_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float HeightGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_g_set")]
-            public static extern void GSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_g_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_g_get")]
-            public static extern float GGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_g_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Z_set")]
-            public static extern void ZSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Z_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ZSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Z_get")]
-            public static extern float ZGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Z_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float ZGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Depth_set")]
-            public static extern void DepthSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Depth_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DepthSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Depth_get")]
-            public static extern float DepthGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_Depth_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float DepthGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_b_set")]
-            public static extern void BSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_b_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void BSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_b_get")]
-            public static extern float BGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_b_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float BGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Vector3")]
-            public static extern void DeleteVector3(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Vector3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteVector3(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_set_all")]
-            public static extern void SetAll(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_set_all", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetAll(IntPtr jarg1, float jarg2, float jarg3, float jarg4);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Vector4.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Vector4.cs
@@ -14,7 +14,10 @@
  * limitations under the License.
  *
  */
-using System.Runtime.InteropServices;
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -22,181 +25,186 @@ namespace Tizen.NUI
     {
         internal static partial class Vector4
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector4__SWIG_0")]
-            public static extern global::System.IntPtr NewVector4();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector4__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVector4();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector4__SWIG_1")]
-            public static extern global::System.IntPtr NewVector4(float jarg1, float jarg2, float jarg3, float jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector4__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVector4(float jarg1, float jarg2, float jarg3, float jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector4__SWIG_2")]
-            public static extern global::System.IntPtr NewVector4([global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] float[] jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector4__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVector4([global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] float[] jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector4__SWIG_3")]
-            public static extern global::System.IntPtr NewVector4WithVector2(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector4__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVector4WithVector2(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector4__SWIG_4")]
-            public static extern global::System.IntPtr NewVector4WithVector3(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector4__SWIG_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVector4WithVector3(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Add")]
-            public static extern global::System.IntPtr Add(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Add", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Add(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_AddAssign")]
-            public static extern global::System.IntPtr AddAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_AddAssign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr AddAssign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Subtract__SWIG_0")]
-            public static extern global::System.IntPtr Subtract(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Subtract__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Subtract(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_SubtractAssign")]
-            public static extern global::System.IntPtr SubtractAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_SubtractAssign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr SubtractAssign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Multiply__SWIG_0")]
-            public static extern global::System.IntPtr Multiply(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Multiply__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Multiply(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Multiply__SWIG_1")]
-            public static extern global::System.IntPtr Multiply(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Multiply__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Multiply(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_MultiplyAssign__SWIG_0")]
-            public static extern global::System.IntPtr MultiplyAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_MultiplyAssign__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr MultiplyAssign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_MultiplyAssign__SWIG_1")]
-            public static extern global::System.IntPtr MultiplyAssign(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_MultiplyAssign__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr MultiplyAssign(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Divide__SWIG_0")]
-            public static extern global::System.IntPtr Divide(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Divide__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Divide(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Divide__SWIG_1")]
-            public static extern global::System.IntPtr Divide(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Divide__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Divide(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_DivideAssign__SWIG_0")]
-            public static extern global::System.IntPtr DivideAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_DivideAssign__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DivideAssign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_DivideAssign__SWIG_1")]
-            public static extern global::System.IntPtr DivideAssign(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_DivideAssign__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DivideAssign(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Subtract__SWIG_1")]
-            public static extern global::System.IntPtr Subtract(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Subtract__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Subtract(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_EqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_EqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool EqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool EqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_NotEqualTo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_NotEqualTo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool NotEqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool NotEqualTo(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_ValueOfIndex__SWIG_0")]
-            public static extern float ValueOfIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_ValueOfIndex__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float ValueOfIndex(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Dot__SWIG_0")]
-            public static extern float DotWithVector3(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Dot__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float DotWithVector3(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Dot__SWIG_1")]
-            public static extern float Dot(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Dot__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float Dot(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Dot3")]
-            public static extern float Dot3(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Dot3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float Dot3(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Cross")]
-            public static extern global::System.IntPtr Cross(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Cross", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Cross(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Length")]
-            public static extern float Length(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Length", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float Length(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Length3")]
-            public static extern float Length3(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Length3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float Length3(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_LengthSquared")]
-            public static extern float LengthSquared(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_LengthSquared", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float LengthSquared(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_LengthSquared3")]
-            public static extern float LengthSquared3(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_LengthSquared3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float LengthSquared3(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Normalize")]
-            public static extern void Normalize(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Normalize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Normalize(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Normalize3")]
-            public static extern void Normalize3(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Normalize3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Normalize3(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Clamp")]
-            public static extern void Clamp(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Clamp", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Clamp(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_X_set")]
-            public static extern void XSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_X_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void XSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_X_get")]
-            public static extern float XGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_X_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float XGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_r_set")]
-            public static extern void RSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_r_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_r_get")]
-            public static extern float RGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_r_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float RGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_s_set")]
-            public static extern void SSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_s_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_s_get")]
-            public static extern float SGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_s_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float SGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Y_set")]
-            public static extern void YSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Y_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void YSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Y_get")]
-            public static extern float YGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Y_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float YGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_g_set")]
-            public static extern void GSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_g_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_g_get")]
-            public static extern float GGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_g_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_t_set")]
-            public static extern void TSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_t_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void TSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_t_get")]
-            public static extern float TGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_t_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float TGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Z_set")]
-            public static extern void ZSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Z_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ZSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Z_get")]
-            public static extern float ZGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_Z_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float ZGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_b_set")]
-            public static extern void BSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_b_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void BSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_b_get")]
-            public static extern float BGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_b_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float BGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_p_set")]
-            public static extern void PSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_p_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_p_get")]
-            public static extern float PGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_p_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float PGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_W_set")]
-            public static extern void WSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_W_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void WSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_W_get")]
-            public static extern float WGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_W_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float WGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_a_set")]
-            public static extern void ASet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_a_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ASet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_a_get")]
-            public static extern float AGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_a_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float AGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_q_set")]
-            public static extern void QSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_q_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void QSet(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_q_get")]
-            public static extern float QGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_q_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float QGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Vector4")]
-            public static extern void DeleteVector4(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Vector4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteVector4(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_set_all")]
-            public static extern void SetAll(HandleRef jarg1, float jarg2, float jarg3, float jarg4, float jarg5);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector4_set_all", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetAll(IntPtr jarg1, float jarg2, float jarg3, float jarg4, float jarg5);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VectorBase.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VectorBase.cs
@@ -15,27 +15,36 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class VectorBase
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBase_Count")]
-            public static extern uint Count(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBase_Count", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint Count(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBase_Size")]
-            public static extern uint Size(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBase_Size", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint Size(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBase_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBase_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBase_Capacity")]
-            public static extern uint Capacity(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBase_Capacity", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint Capacity(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBase_Release")]
-            public static extern void Release(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBase_Release", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Release(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VectorBlob.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VectorBlob.cs
@@ -15,41 +15,50 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class VectorBlob
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBlob_r_set")]
-            public static extern void RSet(global::System.Runtime.InteropServices.HandleRef jarg1, byte jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBlob_r_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RSet(IntPtr jarg1, byte jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBlob_r_get")]
-            public static extern byte RGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBlob_r_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial byte RGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBlob_g_set")]
-            public static extern void GSet(global::System.Runtime.InteropServices.HandleRef jarg1, byte jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBlob_g_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GSet(IntPtr jarg1, byte jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBlob_g_get")]
-            public static extern byte GGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBlob_g_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial byte GGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBlob_b_set")]
-            public static extern void BSet(global::System.Runtime.InteropServices.HandleRef jarg1, byte jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBlob_b_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void BSet(IntPtr jarg1, byte jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBlob_b_get")]
-            public static extern byte BGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBlob_b_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial byte BGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBlob_a_set")]
-            public static extern void ASet(global::System.Runtime.InteropServices.HandleRef jarg1, byte jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBlob_a_set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ASet(IntPtr jarg1, byte jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBlob_a_get")]
-            public static extern byte AGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorBlob_a_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial byte AGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VectorBlob")]
-            public static extern global::System.IntPtr NewVectorBlob();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VectorBlob", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVectorBlob();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VectorBlob")]
-            public static extern void DeleteVectorBlob(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VectorBlob", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteVectorBlob(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VectorFloat.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VectorFloat.cs
@@ -24,3 +24,5 @@ namespace Tizen.NUI
         }
     }
 }
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VectorInteger.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VectorInteger.cs
@@ -24,3 +24,5 @@ namespace Tizen.NUI
         }
     }
 }
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VectorUint16Pair.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VectorUint16Pair.cs
@@ -15,71 +15,80 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class VectorUint16Pair
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_BaseType_get")]
-            public static extern int BaseTypeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_BaseType_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BaseTypeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VectorUint16Pair__SWIG_0")]
-            public static extern global::System.IntPtr NewVectorUint16Pair();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VectorUint16Pair__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVectorUint16Pair();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VectorUint16Pair")]
-            public static extern void DeleteVectorUint16Pair(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VectorUint16Pair", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteVectorUint16Pair(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VectorUint16Pair__SWIG_1")]
-            public static extern global::System.IntPtr NewVectorUint16Pair(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VectorUint16Pair__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVectorUint16Pair(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Begin")]
-            public static extern global::System.IntPtr Begin(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Begin", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Begin(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_End")]
-            public static extern global::System.IntPtr End(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_End", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr End(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_ValueOfIndex__SWIG_0")]
-            public static extern global::System.IntPtr ValueOfIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_ValueOfIndex__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ValueOfIndex(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_PushBack")]
-            public static extern void PushBack(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_PushBack", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PushBack(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Insert__SWIG_0")]
-            public static extern void Insert(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Insert__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Insert(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Insert__SWIG_1")]
-            public static extern void Insert(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Insert__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Insert(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Reserve")]
-            public static extern void Reserve(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Reserve", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Reserve(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Resize__SWIG_0")]
-            public static extern void Resize(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Resize__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Resize(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Resize__SWIG_1")]
-            public static extern void Resize(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Resize__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Resize(IntPtr jarg1, uint jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Erase__SWIG_0")]
-            public static extern global::System.IntPtr Erase(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Erase__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Erase(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Erase__SWIG_1")]
-            public static extern global::System.IntPtr Erase(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Erase__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Erase(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Remove")]
-            public static extern void Remove(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Remove", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Remove(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Swap")]
-            public static extern void Swap(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Swap", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Swap(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Clear")]
-            public static extern void Clear(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Clear", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Clear(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Release")]
-            public static extern void Release(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUint16Pair_Release", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Release(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VectorUnsignedChar.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VectorUnsignedChar.cs
@@ -15,71 +15,80 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class VectorUnsignedChar
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_BaseType_get")]
-            public static extern int BaseTypeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_BaseType_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BaseTypeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VectorUnsignedChar__SWIG_0")]
-            public static extern global::System.IntPtr NewVectorUnsignedChar();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VectorUnsignedChar__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVectorUnsignedChar();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VectorUnsignedChar")]
-            public static extern void DeleteVectorUnsignedChar(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VectorUnsignedChar", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteVectorUnsignedChar(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VectorUnsignedChar__SWIG_1")]
-            public static extern global::System.IntPtr NewVectorUnsignedChar(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VectorUnsignedChar__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVectorUnsignedChar(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Begin")]
-            public static extern global::System.IntPtr Begin(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Begin", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Begin(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_End")]
-            public static extern global::System.IntPtr End(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_End", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr End(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_ValueOfIndex__SWIG_0")]
-            public static extern global::System.IntPtr ValueOfIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_ValueOfIndex__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ValueOfIndex(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_PushBack")]
-            public static extern void PushBack(global::System.Runtime.InteropServices.HandleRef jarg1, byte jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_PushBack", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PushBack(IntPtr jarg1, byte jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Insert__SWIG_0")]
-            public static extern void Insert(global::System.Runtime.InteropServices.HandleRef jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] byte[] jarg2, byte jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Insert__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Insert(IntPtr jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] byte[] jarg2, byte jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Insert__SWIG_1")]
-            public static extern void Insert(global::System.Runtime.InteropServices.HandleRef jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] byte[] jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Insert__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Insert(IntPtr jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] byte[] jarg2, IntPtr jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Reserve")]
-            public static extern void Reserve(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Reserve", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Reserve(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Resize__SWIG_0")]
-            public static extern void Resize(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Resize__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Resize(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Resize__SWIG_1")]
-            public static extern void Resize(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, byte jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Resize__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Resize(IntPtr jarg1, uint jarg2, byte jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Erase__SWIG_0")]
-            public static extern global::System.IntPtr Erase(global::System.Runtime.InteropServices.HandleRef jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] byte[] jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Erase__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Erase(IntPtr jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] byte[] jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Erase__SWIG_1")]
-            public static extern global::System.IntPtr Erase(global::System.Runtime.InteropServices.HandleRef jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] byte[] jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Erase__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Erase(IntPtr jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] byte[] jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Remove")]
-            public static extern void Remove(global::System.Runtime.InteropServices.HandleRef jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] byte[] jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Remove", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Remove(IntPtr jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] byte[] jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Swap")]
-            public static extern void Swap(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Swap", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Swap(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Clear")]
-            public static extern void Clear(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Clear", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Clear(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Release")]
-            public static extern void Release(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedChar_Release", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Release(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VectorVector2.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VectorVector2.cs
@@ -15,75 +15,84 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class VectorVector2
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_BaseType_get")]
-            public static extern int BaseTypeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_BaseType_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BaseTypeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VectorVector2__SWIG_0")]
-            public static extern global::System.IntPtr NewVectorVector2();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VectorVector2__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVectorVector2();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VectorVector2")]
-            public static extern void DeleteVectorVector2(global::System.Runtime.InteropServices.HandleRef daliVector);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VectorVector2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteVectorVector2(IntPtr daliVector);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VectorVector2__SWIG_1")]
-            public static extern global::System.IntPtr NewVectorVector2(global::System.Runtime.InteropServices.HandleRef daliVector);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VectorVector2__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVectorVector2(IntPtr daliVector);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef daliVectorDest, global::System.Runtime.InteropServices.HandleRef daliVectorSrc);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr daliVectorDest, IntPtr daliVectorSrc);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Begin")]
-            public static extern global::System.IntPtr Begin(global::System.Runtime.InteropServices.HandleRef daliVector);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Begin", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Begin(IntPtr daliVector);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_End")]
-            public static extern global::System.IntPtr End(global::System.Runtime.InteropServices.HandleRef daliVector);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_End", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr End(IntPtr daliVector);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_ValueOfIndex__SWIG_0")]
-            public static extern global::System.IntPtr ValueOfIndex(global::System.Runtime.InteropServices.HandleRef daliVector, uint index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_ValueOfIndex__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ValueOfIndex(IntPtr daliVector, uint index);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_PushBack")]
-            public static extern void PushBack(global::System.Runtime.InteropServices.HandleRef daliVector, global::System.Runtime.InteropServices.HandleRef item);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_PushBack", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void PushBack(IntPtr daliVector, IntPtr item);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Insert__SWIG_0")]
-            public static extern void Insert(global::System.Runtime.InteropServices.HandleRef daliVector, global::System.Runtime.InteropServices.HandleRef iterator, global::System.Runtime.InteropServices.HandleRef item);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Insert__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Insert(IntPtr daliVector, IntPtr iterator, IntPtr item);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Insert__SWIG_1")]
-            public static extern void Insert(global::System.Runtime.InteropServices.HandleRef daliVector, global::System.Runtime.InteropServices.HandleRef iterator, global::System.Runtime.InteropServices.HandleRef first, global::System.Runtime.InteropServices.HandleRef last);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Insert__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Insert(IntPtr daliVector, IntPtr iterator, IntPtr first, IntPtr last);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Reserve")]
-            public static extern void Reserve(global::System.Runtime.InteropServices.HandleRef daliVector, uint size);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Reserve", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Reserve(IntPtr daliVector, uint size);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Resize__SWIG_0")]
-            public static extern void Resize(global::System.Runtime.InteropServices.HandleRef daliVector, uint size);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Resize__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Resize(IntPtr daliVector, uint size);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Resize__SWIG_1")]
-            public static extern void Resize(global::System.Runtime.InteropServices.HandleRef daliVector, uint size, global::System.Runtime.InteropServices.HandleRef item);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Resize__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Resize(IntPtr daliVector, uint size, IntPtr item);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Erase__SWIG_0")]
-            public static extern global::System.IntPtr Erase(global::System.Runtime.InteropServices.HandleRef daliVector, global::System.Runtime.InteropServices.HandleRef iterator);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Erase__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Erase(IntPtr daliVector, IntPtr iterator);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Erase__SWIG_1")]
-            public static extern global::System.IntPtr Erase(global::System.Runtime.InteropServices.HandleRef daliVector, global::System.Runtime.InteropServices.HandleRef first, global::System.Runtime.InteropServices.HandleRef last);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Erase__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Erase(IntPtr daliVector, IntPtr first, IntPtr last);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Remove")]
-            public static extern void Remove(global::System.Runtime.InteropServices.HandleRef daliVector, global::System.Runtime.InteropServices.HandleRef item);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Remove", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Remove(IntPtr daliVector, IntPtr item);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Swap")]
-            public static extern void Swap(global::System.Runtime.InteropServices.HandleRef daliVector1, global::System.Runtime.InteropServices.HandleRef daliVector2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Swap", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Swap(IntPtr daliVector1, IntPtr daliVector2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Clear")]
-            public static extern void Clear(global::System.Runtime.InteropServices.HandleRef daliVector);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Clear", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Clear(IntPtr daliVector);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Release")]
-            public static extern void Release(global::System.Runtime.InteropServices.HandleRef daliVector);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Release", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Release(IntPtr daliVector);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Size")]
-            public static extern int Size(global::System.Runtime.InteropServices.HandleRef daliVector);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorVector2_Size", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int Size(IntPtr daliVector);
 
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VertexBuffer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VertexBuffer.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,17 +26,22 @@ namespace Tizen.NUI
         internal static partial class VertexBuffer
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VertexBuffer_New")]
-            public static extern global::System.IntPtr New(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VertexBuffer_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VertexBuffer")]
-            public static extern void DeleteVertexBuffer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VertexBuffer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteVertexBuffer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VertexBuffer_SetData")]
-            public static extern void SetData(global::System.Runtime.InteropServices.HandleRef jarg1, System.IntPtr jarg2, uint jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VertexBuffer_SetData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetData(IntPtr jarg1, System.IntPtr jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VertexBuffer_GetSize")]
-            public static extern uint GetSize(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VertexBuffer_GetSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetSize(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VideoView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VideoView.cs
@@ -15,111 +15,120 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class VideoView
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Property_VIDEO_get")]
-            public static extern int VideoGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Property_VIDEO_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int VideoGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Property_LOOPING_get")]
-            public static extern int LoopingGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Property_LOOPING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LoopingGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Property_MUTED_get")]
-            public static extern int MutedGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Property_MUTED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MutedGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Property_VOLUME_get")]
-            public static extern int VolumeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Property_VOLUME_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int VolumeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Property_UNDERLAY_get")]
-            public static extern int UnderlayGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Property_UNDERLAY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int UnderlayGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_New__SWIG_0")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_New__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_New__SWIG_1")]
-            public static extern global::System.IntPtr New(string jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_New__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(string jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_New__SWIG_2")]
-            public static extern global::System.IntPtr New(bool swCodec);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_New__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New([MarshalAs(UnmanagedType.U1)] bool swCodec);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_New__SWIG_3")]
-            public static extern global::System.IntPtr New(string jarg1, bool swCodec);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_New__SWIG_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(string jarg1, [MarshalAs(UnmanagedType.U1)] bool swCodec);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VideoView")]
-            public static extern void DeleteVideoView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VideoView", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteVideoView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Play")]
-            public static extern void Play(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Play", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Play(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Pause")]
-            public static extern void Pause(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Pause", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Pause(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Stop")]
-            public static extern void Stop(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Stop", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Stop(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Forward")]
-            public static extern void Forward(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Forward", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Forward(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Backward")]
-            public static extern void Backward(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Backward", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Backward(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_SetAutoRotationEnabled")]
-            public static extern void SetAutoRotationEnabled(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_SetAutoRotationEnabled", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetAutoRotationEnabled(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_IsAutoRotationEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_IsAutoRotationEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsAutoRotationEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsAutoRotationEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_SetLetterBoxEnabled")]
-            public static extern void SetLetterBoxEnabled(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_SetLetterBoxEnabled", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetLetterBoxEnabled(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_IsLetterBoxEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_IsLetterBoxEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsLetterBoxEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsLetterBoxEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_FinishedSignal")]
-            public static extern global::System.IntPtr FinishedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_FinishedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr FinishedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoViewSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoViewSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool VideoViewSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool VideoViewSignalEmpty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoViewSignal_GetConnectionCount")]
-            public static extern uint VideoViewSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoViewSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint VideoViewSignalGetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoViewSignal_Connect")]
-            public static extern void VideoViewSignalConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoViewSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void VideoViewSignalConnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoViewSignal_Disconnect")]
-            public static extern void VideoViewSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoViewSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void VideoViewSignalDisconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoViewSignal_Emit")]
-            public static extern void VideoViewSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoViewSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void VideoViewSignalEmit(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VideoViewSignal")]
-            public static extern global::System.IntPtr NewVideoViewSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VideoViewSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVideoViewSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VideoViewSignal")]
-            public static extern void DeleteVideoViewSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VideoViewSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteVideoViewSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_GetNativePlayerHandle")]
-            public static extern global::System.IntPtr GetNativePlayerHandle(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_GetNativePlayerHandle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetNativePlayerHandle(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_SetFrameInterpolationInterval")]
-            public static extern void SetFrameInterpolationInterval(global::System.Runtime.InteropServices.HandleRef view, float intervalSeconds);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_SetFrameInterpolationInterval", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFrameInterpolationInterval(IntPtr view, float intervalSeconds);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_GetFrameInterpolationInterval")]
-            public static extern float GetFrameInterpolationInterval(global::System.Runtime.InteropServices.HandleRef view);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_GetFrameInterpolationInterval", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetFrameInterpolationInterval(IntPtr view);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_SetVideoFrameBuffer")]
-            public static extern void SetVideoFrameBuffer(global::System.Runtime.InteropServices.HandleRef view, global::System.Runtime.InteropServices.HandleRef nativeImageSource);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_SetVideoFrameBuffer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetVideoFrameBuffer(IntPtr view, IntPtr nativeImageSource);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_EnableOffscreenFrameRendering")]
-            public static extern void EnableOffscreenFrameRendering(global::System.Runtime.InteropServices.HandleRef view, bool useOffScreenFrame);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_EnableOffscreenFrameRendering", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableOffscreenFrameRendering(IntPtr view, [MarshalAs(UnmanagedType.U1)] bool useOffScreenFrame);
 
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.View.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.View.cs
@@ -15,7 +15,9 @@
  *
  */
 
+using global::System;
 using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -23,110 +25,115 @@ namespace Tizen.NUI
     {
         internal static partial class View
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_NewWithBehaviour")]
-            public static extern global::System.IntPtr NewWithBehaviour(int behaviour);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_NewWithBehaviour", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewWithBehaviour(int behaviour);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_View")]
-            public static extern void DeleteView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_View", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_View")]
-            public static extern void DeleteControlHandleView(global::System.IntPtr jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_View", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteControlHandleView(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_DownCast")]
-            public static extern global::System.IntPtr DownCast(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_DownCast", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DownCast(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_HasKeyInputFocus")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_HasKeyInputFocus", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool HasKeyInputFocus(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool HasKeyInputFocus(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_SetStyleName")]
-            public static extern void SetStyleName(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_SetStyleName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetStyleName(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetStyleName")]
-            public static extern string GetStyleName(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetStyleName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetStyleName(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_ClearBackground")]
-            public static extern void ClearBackground(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_ClearBackground", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ClearBackground(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_SetRenderEffect")]
-            public static extern void SetRenderEffect(global::System.Runtime.InteropServices.HandleRef self, global::System.Runtime.InteropServices.HandleRef effectRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_SetRenderEffect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetRenderEffect(IntPtr self, IntPtr effectRef);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetRenderEffect")]
-            public static extern global::System.IntPtr GetRenderEffect(global::System.Runtime.InteropServices.HandleRef self);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetRenderEffect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetRenderEffect(IntPtr self);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetOffScreenRenderingOutput")]
-            public static extern global::System.IntPtr GetOffScreenRenderingOutput(global::System.Runtime.InteropServices.HandleRef self);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetOffScreenRenderingOutput", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetOffScreenRenderingOutput(IntPtr self);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_ClearRenderEffect")]
-            public static extern void ClearRenderEffect(global::System.Runtime.InteropServices.HandleRef self);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_ClearRenderEffect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ClearRenderEffect(IntPtr self);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_View__SWIG_2")]
-            public static extern global::System.IntPtr NewViewInternal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_View__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewViewInternal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetVisualResourceStatus")]
-            public static extern int GetVisualResourceStatus(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetVisualResourceStatus", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetVisualResourceStatus(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_CreateTransition")]
-            public static extern global::System.IntPtr CreateTransition(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_CreateTransition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CreateTransition(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_DoAction")]
-            public static extern void DoAction(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_DoAction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DoAction(IntPtr jarg1, int jarg2, int jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetVisualProperty")]
-            public static extern global::System.IntPtr GetVisualProperty(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetVisualProperty", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetVisualProperty(IntPtr jarg1, int jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IsResourceReady")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IsResourceReady", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsResourceReady(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsResourceReady(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ResourceReadySignal")]
-            public static extern global::System.IntPtr ResourceReadySignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ResourceReadySignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ResourceReadySignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetVisualResourceStatus")]
-            public static extern int View_GetVisualResourceStatus(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetVisualResourceStatus", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int View_GetVisualResourceStatus(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_DoActionExtension")]
-            public static extern void DoActionExtension(global::System.Runtime.InteropServices.HandleRef control, int visualIndex, int actionId, int id, string keyPath, int property, global::System.IntPtr callback);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_DoActionExtension", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DoActionExtension(IntPtr control, int visualIndex, int actionId, int id, string keyPath, int property, global::System.IntPtr callback);
 
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_DoActionWithEmptyAttributes")]
-            public static extern void DoActionWithEmptyAttributes(HandleRef control, int visualIndex, int actionId);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_DoActionWithEmptyAttributes", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DoActionWithEmptyAttributes(IntPtr control, int visualIndex, int actionId);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_DoActionWithSingleIntAttributes")]
-            public static extern void DoActionWithSingleIntAttributes(HandleRef control, int visualIndex, int actionId, int actionValue);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_DoActionWithSingleIntAttributes", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DoActionWithSingleIntAttributes(IntPtr control, int visualIndex, int actionId, int actionValue);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_InternalUpdateVisualPropertyBool")]
-            public static extern int InternalUpdateVisualPropertyBool(HandleRef control, int visualIndex, int visualPropertyIndex, bool valBool);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_InternalUpdateVisualPropertyBool", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalUpdateVisualPropertyBool(IntPtr control, int visualIndex, int visualPropertyIndex, [MarshalAs(UnmanagedType.U1)] bool valBool);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_InternalUpdateVisualPropertyFloat")]
-            public static extern int InternalUpdateVisualPropertyFloat(HandleRef control, int visualIndex, int visualPropertyIndex, float valFloat);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_InternalUpdateVisualPropertyFloat", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalUpdateVisualPropertyFloat(IntPtr control, int visualIndex, int visualPropertyIndex, float valFloat);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_InternalUpdateVisualPropertyInt")]
-            public static extern int InternalUpdateVisualPropertyInt(HandleRef control, int visualIndex, int visualPropertyIndex, int valInt);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_InternalUpdateVisualPropertyInt", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalUpdateVisualPropertyInt(IntPtr control, int visualIndex, int visualPropertyIndex, int valInt);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_InternalUpdateVisualPropertyIntPair")]
-            public static extern int InternalUpdateVisualPropertyIntPair(HandleRef control, int visualIndex, int visualPropertyIndex, int valInt1, int valInt2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_InternalUpdateVisualPropertyIntPair", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalUpdateVisualPropertyIntPair(IntPtr control, int visualIndex, int visualPropertyIndex, int valInt1, int valInt2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_InternalUpdateVisualPropertyString")]
-            public static extern int InternalUpdateVisualPropertyString(HandleRef control, int visualIndex, int visualPropertyIndex, string valString);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_InternalUpdateVisualPropertyString", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalUpdateVisualPropertyString(IntPtr control, int visualIndex, int visualPropertyIndex, string valString);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_InternalUpdateVisualPropertyStringPair")]
-            public static extern int InternalUpdateVisualPropertyStringPair(HandleRef control, int visualIndex, int visualPropertyIndex, string valString1, string valString2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_InternalUpdateVisualPropertyStringPair", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalUpdateVisualPropertyStringPair(IntPtr control, int visualIndex, int visualPropertyIndex, string valString1, string valString2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_InternalUpdateVisualPropertyVector4")]
-            public static extern int InternalUpdateVisualPropertyVector4(HandleRef control, int visualIndex, int visualPropertyIndex, HandleRef vector4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_InternalUpdateVisualPropertyVector4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalUpdateVisualPropertyVector4(IntPtr control, int visualIndex, int visualPropertyIndex, IntPtr vector4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingVisualPropertyInt")]
-            public static extern int InternalRetrievingVisualPropertyInt(HandleRef actor,  int visualIndex, int visualPropertyIndex, out int valInt);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingVisualPropertyInt", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalRetrievingVisualPropertyInt(IntPtr actor,  int visualIndex, int visualPropertyIndex, out int valInt);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingVisualPropertyString")]
-            public static extern int InternalRetrievingVisualPropertyString(HandleRef actor,  int visualIndex, int visualPropertyIndex, out string valString);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingVisualPropertyString", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalRetrievingVisualPropertyString(IntPtr actor,  int visualIndex, int visualPropertyIndex, out string valString);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingVisualPropertyVector4")]
-            public static extern int InternalRetrievingVisualPropertyVector4(HandleRef actor,  int visualIndex, int visualPropertyIndex, HandleRef retrievingVector4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingVisualPropertyVector4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalRetrievingVisualPropertyVector4(IntPtr actor,  int visualIndex, int visualPropertyIndex, IntPtr retrievingVector4);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewImpl.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewImpl.cs
@@ -15,35 +15,43 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
-
     internal static partial class Interop
     {
         internal static partial class ViewImpl
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_SetBackground")]
-            public static extern void SetBackground(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_SetBackground", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetBackground(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_EnableGestureDetection")]
-            public static extern void EnableGestureDetection(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_EnableGestureDetection", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableGestureDetection(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_DisableGestureDetection")]
-            public static extern void DisableGestureDetection(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_DisableGestureDetection", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DisableGestureDetection(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_SetKeyboardNavigationSupport")]
-            public static extern void SetKeyboardNavigationSupport(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_SetKeyboardNavigationSupport", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetKeyboardNavigationSupport(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_IsKeyboardNavigationSupported")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_IsKeyboardNavigationSupported", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsKeyboardNavigationSupported(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsKeyboardNavigationSupported(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_SetAsKeyboardFocusGroup")]
-            public static extern void SetAsKeyboardFocusGroup(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_SetAsKeyboardFocusGroup", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetAsKeyboardFocusGroup(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_IsKeyboardFocusGroup")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_IsKeyboardFocusGroup", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsKeyboardFocusGroup(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsKeyboardFocusGroup(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewInternal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewInternal.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,23 +26,28 @@ namespace Tizen.NUI
         internal static partial class ViewInternal
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_SetKeyInputFocus")]
-            public static extern void SetKeyInputFocus(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_SetKeyInputFocus", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetKeyInputFocus(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_ClearKeyInputFocus")]
-            public static extern void ClearKeyInputFocus(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_ClearKeyInputFocus", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ClearKeyInputFocus(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetPinchGestureDetector")]
-            public static extern global::System.IntPtr GetPinchGestureDetector(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetPinchGestureDetector", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetPinchGestureDetector(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetPanGestureDetector")]
-            public static extern global::System.IntPtr GetPanGestureDetector(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetPanGestureDetector", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetPanGestureDetector(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetTapGestureDetector")]
-            public static extern global::System.IntPtr GetTapGestureDetector(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetTapGestureDetector", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetTapGestureDetector(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetLongPressGestureDetector")]
-            public static extern global::System.IntPtr GetLongPressGestureDetector(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetLongPressGestureDetector", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetLongPressGestureDetector(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewProperty.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewProperty.cs
@@ -15,122 +15,131 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class ViewProperty
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_STYLE_NAME_get")]
-            public static extern int StyleNameGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_STYLE_NAME_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int StyleNameGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_KEY_INPUT_FOCUS_get")]
-            public static extern int KeyInputFocusGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_KEY_INPUT_FOCUS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int KeyInputFocusGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_BACKGROUND_get")]
-            public static extern int BackgroundGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_BACKGROUND_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BackgroundGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_MARGIN_get")]
-            public static extern int MarginGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_MARGIN_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MarginGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_PADDING_get")]
-            public static extern int PaddingGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_PADDING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PaddingGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_View_Property_TOOLTIP_get")]
-            public static extern int TooltipGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_View_Property_TOOLTIP_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TooltipGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_View_Property_STATE_get")]
-            public static extern int StateGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_View_Property_STATE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int StateGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_View_Property_SUB_STATE_get")]
-            public static extern int SubStateGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_View_Property_SUB_STATE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SubStateGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_View_Property_LEFT_FOCUSABLE_ACTOR_ID_get")]
-            public static extern int LeftFocusableActorIdGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_View_Property_LEFT_FOCUSABLE_ACTOR_ID_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LeftFocusableActorIdGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_View_Property_RIGHT_FOCUSABLE_ACTOR_ID_get")]
-            public static extern int RightFocusableActorIdGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_View_Property_RIGHT_FOCUSABLE_ACTOR_ID_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RightFocusableActorIdGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_View_Property_UP_FOCUSABLE_ACTOR_ID_get")]
-            public static extern int UpFocusableActorIdGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_View_Property_UP_FOCUSABLE_ACTOR_ID_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int UpFocusableActorIdGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_View_Property_DOWN_FOCUSABLE_ACTOR_ID_get")]
-            public static extern int DownFocusableActorIdGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_View_Property_DOWN_FOCUSABLE_ACTOR_ID_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DownFocusableActorIdGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_View_Property_CLOCKWISE_FOCUSABLE_ACTOR_ID_get")]
-            public static extern int ClockwiseFocusableActorIdGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_View_Property_CLOCKWISE_FOCUSABLE_ACTOR_ID_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ClockwiseFocusableActorIdGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_View_Property_COUNTER_CLOCKWISE_FOCUSABLE_ACTOR_ID_get")]
-            public static extern int CounterClockwiseFocusableActorIdGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_View_Property_COUNTER_CLOCKWISE_FOCUSABLE_ACTOR_ID_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CounterClockwiseFocusableActorIdGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_SHADOW_get")]
-            public static extern int ShadowGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_SHADOW_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ShadowGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_NAME_get")]
-            public static extern int AccessibilityNameGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_NAME_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AccessibilityNameGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_DESCRIPTION_get")]
-            public static extern int AccessibilityDescriptionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_DESCRIPTION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AccessibilityDescriptionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_TRANSLATION_DOMAIN_get")]
-            public static extern int AccessibilityTranslationDomainGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_TRANSLATION_DOMAIN_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AccessibilityTranslationDomainGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_ROLE_get")]
-            public static extern int AccessibilityRoleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_ROLE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AccessibilityRoleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_HIGHLIGHTABLE_get")]
-            public static extern int AccessibilityHighlightableGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_HIGHLIGHTABLE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AccessibilityHighlightableGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_ATTRIBUTES_get")]
-            public static extern int AccessibilityAttributesGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_ATTRIBUTES_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AccessibilityAttributesGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_DISPATCH_KEY_EVENTS_get")]
-            public static extern int DispatchKeyEventsGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_DISPATCH_KEY_EVENTS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DispatchKeyEventsGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_HIDDEN_get")]
-            public static extern int AccessibilityHiddenGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_HIDDEN_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AccessibilityHiddenGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_AUTOMATION_ID_get")]
-            public static extern int AutomationIdGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_AUTOMATION_ID_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AutomationIdGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_STATES_get")]
-            public static extern int AccessibilityStateGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_STATES_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AccessibilityStateGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_IS_MODAL_get")]
-            public static extern int AccessibilityIsModalGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_IS_MODAL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AccessibilityIsModalGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACESSIBILITY_VALUE_get")]
-            public static extern int AccessibilityValueGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACESSIBILITY_VALUE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AccessibilityValueGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_SCROLLABLE_get")]
-            public static extern int AccessibilityScrollableGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_SCROLLABLE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int AccessibilityScrollableGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_OFFSCREEN_RENDERING_get")]
-            public static extern int OffScreenRenderingGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_OFFSCREEN_RENDERING_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int OffScreenRenderingGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_INNER_SHADOW_get")]
-            public static extern int InnerShadowGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_INNER_SHADOW_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InnerShadowGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_BORDERLINE_get")]
-            public static extern int BorderlineGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_BORDERLINE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BorderlineGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_CORNER_RADIUS_POLICY_get")]
-            public static extern int CornerRadiusPolicyGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_CORNER_RADIUS_POLICY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CornerRadiusPolicyGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_CORNER_RADIUS_get")]
-            public static extern int CornerRadiusGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_CORNER_RADIUS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CornerRadiusGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_CORNER_SQUARENESS_get")]
-            public static extern int CornerSquarenessGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_CORNER_SQUARENESS_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CornerSquarenessGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_BORDERLINE_WIDTH_get")]
-            public static extern int BorderlineWidthGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_BORDERLINE_WIDTH_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BorderlineWidthGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_BORDERLINE_COLOR_get")]
-            public static extern int BorderlineColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_BORDERLINE_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BorderlineColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_BORDERLINE_OFFSET_get")]
-            public static extern int BorderlineOffsetGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_BORDERLINE_OFFSET_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int BorderlineOffsetGet();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewResourceReadySignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewResourceReadySignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class ViewResourceReadySignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewResourceReadySignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewResourceReadySignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewResourceReadySignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewResourceReadySignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewResourceReadySignal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewResourceReadySignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewResourceReadySignal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewResourceReadySignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewResourceReadySignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewResourceReadySignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ViewResourceReadySignal")]
-            public static extern global::System.IntPtr NewViewResourceReadySignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ViewResourceReadySignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewViewResourceReadySignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ViewResourceReadySignal")]
-            public static extern void DeleteViewResourceReadySignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ViewResourceReadySignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteViewResourceReadySignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewSignal.cs
@@ -14,7 +14,10 @@
  * limitations under the License.
  *
  */
-using System.Runtime.InteropServices;
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -22,35 +25,38 @@ namespace Tizen.NUI
     {
         internal static partial class ViewSignal
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_KeyEventSignal_Connect")]
-            public static extern void KeyEventConnect(HandleRef view, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_KeyEventSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void KeyEventConnect(IntPtr view, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_KeyEventSignal_Disconnect")]
-            public static extern void KeyEventDisconnect(HandleRef view, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_KeyEventSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void KeyEventDisconnect(IntPtr view, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_KeyInputFocusGainedSignal_Connect")]
-            public static extern void KeyInputFocusGainedConnect(HandleRef view, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_KeyInputFocusGainedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void KeyInputFocusGainedConnect(IntPtr view, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_KeyInputFocusGainedSignal_Disconnect")]
-            public static extern void KeyInputFocusGainedDisconnect(HandleRef view, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_KeyInputFocusGainedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void KeyInputFocusGainedDisconnect(IntPtr view, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_KeyInputFocusLostSignal_Connect")]
-            public static extern void KeyInputFocusLostConnect(HandleRef view, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_KeyInputFocusLostSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void KeyInputFocusLostConnect(IntPtr view, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_KeyInputFocusLostSignal_Disconnect")]
-            public static extern void KeyInputFocusLostDisconnect(HandleRef view, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_KeyInputFocusLostSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void KeyInputFocusLostDisconnect(IntPtr view, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_ResourceReadySignal_Connect")]
-            public static extern void ResourceReadyConnect(HandleRef view, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_ResourceReadySignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ResourceReadyConnect(IntPtr view, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_ResourceReadySignal_Disconnect")]
-            public static extern void ResourceReadyDisconnect(HandleRef view, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_ResourceReadySignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ResourceReadyDisconnect(IntPtr view, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_OffScreenRenderingFinishedSignal_Connect")]
-            public static extern void OffScreenRenderingFinishedConnect(HandleRef view, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_OffScreenRenderingFinishedSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void OffScreenRenderingFinishedConnect(IntPtr view, IntPtr handler);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_OffScreenRenderingFinishedSignal_Disconnect")]
-            public static extern void OffScreenRenderingFinishedDisconnect(HandleRef view, HandleRef handler);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_OffScreenRenderingFinishedSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void OffScreenRenderingFinishedDisconnect(IntPtr view, IntPtr handler);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewWrapper.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewWrapper.cs
@@ -15,17 +15,26 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class ViewWrapper
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewWrapper_New")]
-            public static extern global::System.IntPtr New(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewWrapper_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(string jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ViewWrapper")]
-            public static extern void DeleteViewWrapper(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ViewWrapper", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteViewWrapper(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewWrapperImpl.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewWrapperImpl.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,17 +26,17 @@ namespace Tizen.NUI
         internal static partial class ViewWrapperImpl
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewWrapperImpl_CONTROL_BEHAVIOUR_FLAG_COUNT_get")]
-            public static extern int ControlBehaviourFlagCountGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewWrapperImpl_CONTROL_BEHAVIOUR_FLAG_COUNT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ControlBehaviourFlagCountGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ViewWrapperImpl")]
-            public static extern global::System.IntPtr NewViewWrapperImpl(int jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ViewWrapperImpl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewViewWrapperImpl(int jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewWrapperImpl_New")]
-            public static extern global::System.IntPtr New(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewWrapperImpl_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(string jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewWrapperImpl_director_connect")]
-            public static extern void DirectorConnect(global::System.Runtime.InteropServices.HandleRef jarg1,
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewWrapperImpl_director_connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DirectorConnect(IntPtr jarg1,
                 Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_0 delegate0, Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_1 delegate1,
                 Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_2 delegate2, Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_3 delegate3,
                 Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_4 delegate4, Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_5 delegate5,
@@ -51,53 +55,58 @@ namespace Tizen.NUI
                 Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_38 delegate38, Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_39 delegate39,
                 Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_40 delegate40);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_RelayoutRequest")]
-            public static extern void RelayoutRequest(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_RelayoutRequest", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RelayoutRequest(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_GetHeightForWidthBase")]
-            public static extern float GetHeightForWidthBase(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_GetHeightForWidthBase", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetHeightForWidthBase(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_GetWidthForHeightBase")]
-            public static extern float GetWidthForHeightBase(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_GetWidthForHeightBase", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetWidthForHeightBase(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_CalculateChildSizeBase")]
-            public static extern float CalculateChildSizeBase(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_CalculateChildSizeBase", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float CalculateChildSizeBase(IntPtr jarg1, IntPtr jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_RelayoutDependentOnChildrenBase__SWIG_0")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_RelayoutDependentOnChildrenBase__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool RelayoutDependentOnChildrenBase(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            public static partial bool RelayoutDependentOnChildrenBase(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_RelayoutDependentOnChildrenBase__SWIG_1")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_RelayoutDependentOnChildrenBase__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool RelayoutDependentOnChildrenBase(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool RelayoutDependentOnChildrenBase(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_RegisterVisual__SWIG_0")]
-            public static extern void RegisterVisual(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_RegisterVisual__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterVisual(IntPtr jarg1, int jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_RegisterVisual__SWIG_1")]
-            public static extern void RegisterVisual(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, bool jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_RegisterVisual__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterVisual(IntPtr jarg1, int jarg2, IntPtr jarg3, [MarshalAs(UnmanagedType.U1)] bool jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_UnregisterVisual")]
-            public static extern void UnregisterVisual(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_UnregisterVisual", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void UnregisterVisual(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_GetVisual")]
-            public static extern global::System.IntPtr GetVisual(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_GetVisual", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetVisual(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_EnableVisual")]
-            public static extern void EnableVisual(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, bool jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_EnableVisual", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableVisual(IntPtr jarg1, int jarg2, [MarshalAs(UnmanagedType.U1)] bool jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_IsVisualEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_IsVisualEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsVisualEnabled(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            public static partial bool IsVisualEnabled(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_CreateTransition")]
-            public static extern global::System.IntPtr CreateTransition(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_CreateTransition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CreateTransition(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_EmitKeyInputFocusSignal")]
-            public static extern void EmitKeyInputFocusSignal(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ViewWrapperImpl_EmitKeyInputFocusSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EmitKeyInputFocusSignal(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewWrapperImpl_ApplyThemeStyle")]
-            public static extern void ApplyThemeStyle(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewWrapperImpl_ApplyThemeStyle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ApplyThemeStyle(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Visual.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Visual.cs
@@ -15,26 +15,35 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Visual
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Visual_Property_TRANSFORM_get")]
-            public static extern int TransformGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Visual_Property_TRANSFORM_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TransformGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Visual_Property_PREMULTIPLIED_ALPHA_get")]
-            public static extern int PremultipliedAlphaGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Visual_Property_PREMULTIPLIED_ALPHA_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PremultipliedAlphaGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Visual_Property_MIX_COLOR_get")]
-            public static extern int MixColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Visual_Property_MIX_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MixColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Image_Visual_BORDER_get")]
-            public static extern int ImageVisualBorderGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Image_Visual_BORDER_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ImageVisualBorderGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Visual_Actions_UPDATE_PROPERTY_get")]
-            public static extern int GetActionUpdateProperty();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Visual_Actions_UPDATE_PROPERTY_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetActionUpdateProperty();
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VisualBase.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VisualBase.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,41 +26,46 @@ namespace Tizen.NUI
         internal static partial class VisualBase
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VisualBase__SWIG_0")]
-            public static extern global::System.IntPtr NewVisualBase();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VisualBase__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVisualBase();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VisualBase")]
-            public static extern void DeleteVisualBase(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VisualBase", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteVisualBase(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VisualBase__SWIG_1")]
-            public static extern global::System.IntPtr NewVisualBase(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VisualBase__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVisualBase(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualBase_SetName")]
-            public static extern void SetName(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualBase_SetName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetName(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualBase_GetName")]
-            public static extern string GetName(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualBase_GetName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetName(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualBase_SetTransformAndSize")]
-            public static extern void SetTransformAndSize(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualBase_SetTransformAndSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTransformAndSize(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualBase_GetHeightForWidth")]
-            public static extern float GetHeightForWidth(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualBase_GetHeightForWidth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetHeightForWidth(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualBase_GetWidthForHeight")]
-            public static extern float GetWidthForHeight(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualBase_GetWidthForHeight", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetWidthForHeight(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualBase_GetNaturalSize")]
-            public static extern void GetNaturalSize(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualBase_GetNaturalSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GetNaturalSize(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualBase_SetDepthIndex")]
-            public static extern void SetDepthIndex(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualBase_SetDepthIndex", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetDepthIndex(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualBase_GetDepthIndex")]
-            public static extern int GetDepthIndex(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualBase_GetDepthIndex", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetDepthIndex(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualBase_CreatePropertyMap")]
-            public static extern void CreatePropertyMap(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualBase_CreatePropertyMap", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void CreatePropertyMap(IntPtr jarg1, IntPtr jarg2);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VisualEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VisualEventSignal.cs
@@ -15,8 +15,9 @@
  *
  */
 
-using System;
-using System.Runtime.InteropServices;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -24,30 +25,33 @@ namespace Tizen.NUI
     {
         internal static partial class VisualEventSignal
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualEventSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualEventSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualEventSignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualEventSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualEventSignal_Connect")]
-            public static extern void Connect(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualEventSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualEventSignal_Disconnect")]
-            public static extern void Disconnect(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualEventSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualEventSignal_Emit")]
-            public static extern void Emit(HandleRef jarg1, HandleRef jarg2, int jarg3, int jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualEventSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1, IntPtr jarg2, int jarg3, int jarg4);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VisualEventSignal")]
-            public static extern IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VisualEventSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr New();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VisualEventSignal")]
-            public static extern void Delete(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VisualEventSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Delete(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_VisualEventSignal")]
-            public static extern IntPtr NewWithView(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_VisualEventSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr NewWithView(IntPtr jarg1);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VisualFactory.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VisualFactory.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,27 +26,32 @@ namespace Tizen.NUI
         internal static partial class VisualFactory
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualFactory_Get")]
-            public static extern global::System.IntPtr Get();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualFactory_Get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Get();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VisualFactory__SWIG_0")]
-            public static extern global::System.IntPtr NewVisualFactory();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VisualFactory__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVisualFactory();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualFactory_CreateVisual__SWIG_0")]
-            public static extern global::System.IntPtr CreateVisual(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualFactory_CreateVisual__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr CreateVisual(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualFactory_SetDefaultCreationOptions")]
-            public static extern void SetDefaultCreationOptions(global::System.Runtime.InteropServices.HandleRef jarg1, int creationOptions);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualFactory_SetDefaultCreationOptions", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetDefaultCreationOptions(IntPtr jarg1, int creationOptions);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualFactory_GetDefaultCreationOptions")]
-            public static extern int GetDefaultCreationOptions(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualFactory_GetDefaultCreationOptions", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetDefaultCreationOptions(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualFactory_AddPrecompileShader")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualFactory_AddPrecompileShader", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddPrecompileShader(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool AddPrecompileShader(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualFactory_UsePreCompiledShader")]
-            public static extern void UsePreCompiledShader(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualFactory_UsePreCompiledShader", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void UsePreCompiledShader(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VisualObject.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VisualObject.cs
@@ -15,62 +15,71 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class VisualObject
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_New")]
-            public static extern global::System.IntPtr VisualObjectNew();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr VisualObjectNew();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_GetContainer")]
-            public static extern global::System.IntPtr GetContainer(global::System.Runtime.InteropServices.HandleRef visualObject);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_GetContainer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetContainer(IntPtr visualObject);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_CreateVisual")]
-            public static extern void CreateVisual(global::System.Runtime.InteropServices.HandleRef visualObject, global::System.Runtime.InteropServices.HandleRef propertyMap);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_CreateVisual", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void CreateVisual(IntPtr visualObject, IntPtr propertyMap);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_RetrieveVisualPropertyMap")]
-            public static extern void RetrieveVisualPropertyMap(global::System.Runtime.InteropServices.HandleRef visualObject, global::System.Runtime.InteropServices.HandleRef propertyMap);
-
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_DoAction_UpdatePropertyMap")]
-            public static extern void UpdateVisualPropertyMap(global::System.Runtime.InteropServices.HandleRef visualObject, global::System.Runtime.InteropServices.HandleRef propertyMap);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_DoActionWithEmptyAttributes")]
-            public static extern void DoActionWithEmptyAttributes(global::System.Runtime.InteropServices.HandleRef visualObject, int actionId);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_DoActionWithSingleIntAttributes")]
-            public static extern void DoActionWithSingleIntAttributes(global::System.Runtime.InteropServices.HandleRef visualObject, int actionId, int actionValue);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_RetrieveVisualPropertyMap", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RetrieveVisualPropertyMap(IntPtr visualObject, IntPtr propertyMap);
 
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_SetSiblingOrder")]
-            public static extern void SetSiblingOrder(global::System.Runtime.InteropServices.HandleRef visualObject, uint siblingOrder);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_DoAction_UpdatePropertyMap", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void UpdateVisualPropertyMap(IntPtr visualObject, IntPtr propertyMap);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_GetSiblingOrder")]
-            public static extern uint GetSiblingOrder(global::System.Runtime.InteropServices.HandleRef visualObject);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_DoActionWithEmptyAttributes", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DoActionWithEmptyAttributes(IntPtr visualObject, int actionId);
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_DoActionWithSingleIntAttributes", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DoActionWithSingleIntAttributes(IntPtr visualObject, int actionId, int actionValue);
 
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_DetachFromContainer")]
-            public static extern void Detach(global::System.Runtime.InteropServices.HandleRef visualObject);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_SetSiblingOrder", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetSiblingOrder(IntPtr visualObject, uint siblingOrder);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_Raise")]
-            public static extern void Raise(global::System.Runtime.InteropServices.HandleRef visualObject);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_GetSiblingOrder", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetSiblingOrder(IntPtr visualObject);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_Lower")]
-            public static extern void Lower(global::System.Runtime.InteropServices.HandleRef visualObject);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_RaiseToTop")]
-            public static extern void RaiseToTop(global::System.Runtime.InteropServices.HandleRef visualObject);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_DetachFromContainer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Detach(IntPtr visualObject);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_LowerToBottom")]
-            public static extern void LowerToBottom(global::System.Runtime.InteropServices.HandleRef visualObject);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_Raise", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Raise(IntPtr visualObject);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_RaiseAbove")]
-            public static extern void RaiseAbove(global::System.Runtime.InteropServices.HandleRef visualObject, global::System.Runtime.InteropServices.HandleRef target);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_Lower", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Lower(IntPtr visualObject);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_LowerBelow")]
-            public static extern void LowerBelow(global::System.Runtime.InteropServices.HandleRef visualObject, global::System.Runtime.InteropServices.HandleRef target);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_RaiseToTop", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RaiseToTop(IntPtr visualObject);
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_LowerToBottom", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LowerToBottom(IntPtr visualObject);
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_RaiseAbove", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RaiseAbove(IntPtr visualObject, IntPtr target);
+
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_LowerBelow", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LowerBelow(IntPtr visualObject, IntPtr target);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VisualObjectsContainer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VisualObjectsContainer.cs
@@ -15,55 +15,64 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class VisualObjectsContainer
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_ContainerRangeTypeBackgroundEffectGet")]
-            public static extern int ContainerRangeTypeBackgroundEffectGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_ContainerRangeTypeBackgroundEffectGet", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ContainerRangeTypeBackgroundEffectGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_ContainerRangeTypeBackgroundGet")]
-            public static extern int ContainerRangeTypeBackgroundGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_ContainerRangeTypeBackgroundGet", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ContainerRangeTypeBackgroundGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_ContainerRangeTypeContentGet")]
-            public static extern int ContainerRangeTypeContentGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_ContainerRangeTypeContentGet", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ContainerRangeTypeContentGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_ContainerRangeTypeDecorationGet")]
-            public static extern int ContainerRangeTypeDecorationGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_ContainerRangeTypeDecorationGet", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ContainerRangeTypeDecorationGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_ContainerRangeTypeForegroundEffectGet")]
-            public static extern int ContainerRangeTypeForegroundEffectGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_ContainerRangeTypeForegroundEffectGet", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ContainerRangeTypeForegroundEffectGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VisualObjectsContainer__SWIG_0")]
-            public static extern global::System.IntPtr NewVisualObjectsContainer();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VisualObjectsContainer__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVisualObjectsContainer();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_New")]
-            public static extern global::System.IntPtr VisualObjectsContainerNew(global::System.Runtime.InteropServices.HandleRef view, int rangeType);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr VisualObjectsContainerNew(IntPtr view, int rangeType);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_GetOwner")]
-            public static extern global::System.IntPtr GetOwner(global::System.Runtime.InteropServices.HandleRef container);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_GetOwner", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetOwner(IntPtr container);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_GetContainerRangeType")]
-            public static extern int GetContainerRangeType(global::System.Runtime.InteropServices.HandleRef container);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_GetContainerRangeType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetContainerRangeType(IntPtr container);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_GetVisualObjectsCount")]
-            public static extern uint GetVisualObjectsCount(global::System.Runtime.InteropServices.HandleRef container);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_GetVisualObjectsCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetVisualObjectsCount(IntPtr container);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_GetVisualObjectAt")]
-            public static extern global::System.IntPtr GetVisualObjectAt(global::System.Runtime.InteropServices.HandleRef container, uint index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_GetVisualObjectAt", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetVisualObjectAt(IntPtr container, uint index);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_AddVisualObject")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_AddVisualObject", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddVisualObject(global::System.Runtime.InteropServices.HandleRef container, global::System.Runtime.InteropServices.HandleRef viewObject);
+            public static partial bool AddVisualObject(IntPtr container, IntPtr viewObject);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_AddShadowVisualObject")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_AddShadowVisualObject", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddShadowVisualObject(global::System.Runtime.InteropServices.HandleRef container, global::System.Runtime.InteropServices.HandleRef viewObject, int shadowType);
+            public static partial bool AddShadowVisualObject(IntPtr container, IntPtr viewObject, int shadowType);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_RemoveVisualObject")]
-            public static extern void RemoveVisualObject(global::System.Runtime.InteropServices.HandleRef container, global::System.Runtime.InteropServices.HandleRef viewObject);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObjectsContainer_RemoveVisualObject", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemoveVisualObject(IntPtr container, IntPtr viewObject);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VoidSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VoidSignal.cs
@@ -15,36 +15,45 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class VoidSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VoidSignal")]
-            public static extern global::System.IntPtr NewVoidSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VoidSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewVoidSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VoidSignal")]
-            public static extern void DeleteVoidSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VoidSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteVoidSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VoidSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VoidSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VoidSignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VoidSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VoidSignal_Connect__SWIG_0")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VoidSignal_Connect__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VoidSignal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VoidSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VoidSignal_Connect__SWIG_4")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VoidSignal_Connect__SWIG_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VoidSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VoidSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VoidSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VoidSignalType.cs
@@ -24,3 +24,5 @@ namespace Tizen.NUI
         }
     }
 }
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Watch.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Watch.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,114 +26,119 @@ namespace Tizen.NUI
         internal static partial class Watch
         {
             //for watch
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WatchTime")]
-            public static extern global::System.IntPtr NewWatchTime();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WatchTime", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewWatchTime();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WatchTime")]
-            public static extern void DeleteWatchTime(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WatchTime", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWatchTime(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetHour")]
-            public static extern int WatchTimeGetHour(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetHour", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WatchTimeGetHour(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetHour24")]
-            public static extern int WatchTimeGetHour24(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetHour24", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WatchTimeGetHour24(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetMinute")]
-            public static extern int WatchTimeGetMinute(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetMinute", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WatchTimeGetMinute(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetSecond")]
-            public static extern int WatchTimeGetSecond(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetSecond", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WatchTimeGetSecond(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetMillisecond")]
-            public static extern int WatchTimeGetMillisecond(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetMillisecond", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WatchTimeGetMillisecond(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetYear")]
-            public static extern int WatchTimeGetYear(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetYear", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WatchTimeGetYear(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetMonth")]
-            public static extern int WatchTimeGetMonth(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetMonth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WatchTimeGetMonth(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetDay")]
-            public static extern int WatchTimeGetDay(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetDay", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WatchTimeGetDay(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetDayOfWeek")]
-            public static extern int WatchTimeGetDayOfWeek(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetDayOfWeek", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WatchTimeGetDayOfWeek(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetTimeZone")]
-            public static extern string WatchTimeGetTimeZone(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetTimeZone", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string WatchTimeGetTimeZone(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetDaylightSavingTimeStatus")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTime_GetDaylightSavingTimeStatus", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool WatchTimeGetDaylightSavingTimeStatus(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool WatchTimeGetDaylightSavingTimeStatus(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchApplication_New__SWIG_0")]
-            public static extern global::System.IntPtr WatchApplicationNew();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchApplication_New__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr WatchApplicationNew();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchApplication_New__SWIG_1")]
-            public static extern global::System.IntPtr WatchApplicationNew(int jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchApplication_New__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr WatchApplicationNew(int jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchApplication_New__SWIG_2")]
-            public static extern global::System.IntPtr WatchApplicationNew(int jarg1, string jarg2, string jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchApplication_New__SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr WatchApplicationNew(int jarg1, string jarg2, string jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WatchApplication__SWIG_1")]
-            public static extern global::System.IntPtr NewWatchApplication(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WatchApplication__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewWatchApplication(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WatchApplication")]
-            public static extern void DeleteWatchApplication(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WatchApplication", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWatchApplication(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchApplication_TimeTickSignal")]
-            public static extern global::System.IntPtr WatchApplicationTimeTickSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchApplication_TimeTickSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr WatchApplicationTimeTickSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchApplication_AmbientTickSignal")]
-            public static extern global::System.IntPtr WatchApplicationAmbientTickSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchApplication_AmbientTickSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr WatchApplicationAmbientTickSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchApplication_AmbientChangedSignal")]
-            public static extern global::System.IntPtr WatchApplicationAmbientChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchApplication_AmbientChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr WatchApplicationAmbientChangedSignal(IntPtr jarg1);
 
             //for watch signal
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTimeSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTimeSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool WatchTimeSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool WatchTimeSignalEmpty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTimeSignal_GetConnectionCount")]
-            public static extern uint WatchTimeSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTimeSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint WatchTimeSignalGetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTimeSignal_Connect")]
-            public static extern void WatchTimeSignalConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTimeSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void WatchTimeSignalConnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTimeSignal_Disconnect")]
-            public static extern void WatchTimeSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTimeSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void WatchTimeSignalDisconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTimeSignal_Emit")]
-            public static extern void WatchTimeSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTimeSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void WatchTimeSignalEmit(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WatchTimeSignal")]
-            public static extern global::System.IntPtr NewWatchTimeSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WatchTimeSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewWatchTimeSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WatchTimeSignal")]
-            public static extern void DeleteWatchTimeSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WatchTimeSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWatchTimeSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchBoolSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchBoolSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool WatchBoolSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool WatchBoolSignalEmpty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchBoolSignal_GetConnectionCount")]
-            public static extern uint WatchBoolSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchBoolSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint WatchBoolSignalGetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchBoolSignal_Connect")]
-            public static extern void WatchBoolSignalConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchBoolSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void WatchBoolSignalConnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchBoolSignal_Disconnect")]
-            public static extern void WatchBoolSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchBoolSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void WatchBoolSignalDisconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchBoolSignal_Emit")]
-            public static extern void WatchBoolSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, bool jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchBoolSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void WatchBoolSignalEmit(IntPtr jarg1, IntPtr jarg2, [MarshalAs(UnmanagedType.U1)] bool jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WatchBoolSignal")]
-            public static extern global::System.IntPtr NewWatchBoolSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WatchBoolSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewWatchBoolSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WatchBoolSignal")]
-            public static extern void DeleteWatchBoolSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WatchBoolSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWatchBoolSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WatchView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WatchView.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,34 +26,39 @@ namespace Tizen.NUI
         internal static partial class WatchView
         {
             //for widget view
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchView_New")]
-            public static extern global::System.IntPtr New(global::System.Runtime.InteropServices.HandleRef window, string nuiWatchId, string contentinfo, int width, int height);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchView_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(IntPtr window, string nuiWatchId, string contentinfo, int width, int height);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchView_DownCast")]
-            public static extern global::System.IntPtr DownCast(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchView_DownCast", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DownCast(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WatchView__SWIG_0")]
-            public static extern global::System.IntPtr NewWatchView();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WatchView__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewWatchView();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WatchView__SWIG_1")]
-            public static extern global::System.IntPtr NewWatchView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WatchView__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewWatchView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchView_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchView_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WatchView")]
-            public static extern void DeleteWatchView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WatchView", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWatchView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchView_PauseWatch")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchView_PauseWatch", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool PauseWatch(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool PauseWatch(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchView_ResumeWatch")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchView_ResumeWatch", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool ResumeWatch(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool ResumeWatch(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchView_SWIGUpcast")]
-            public static extern global::System.IntPtr Upcast(global::System.IntPtr jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchView_SWIGUpcast", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Upcast(global::System.IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebBackForwardList.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebBackForwardList.cs
@@ -15,60 +15,69 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebBackForwardListItem
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardListItem_GetUrl")]
-            public static extern string GetUrl(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardListItem_GetUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetUrl(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardListItem_GetTitle")]
-            public static extern string GetTitle(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardListItem_GetTitle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetTitle(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardListItem_GetOriginalUrl")]
-            public static extern string GetOriginalUrl(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardListItem_GetOriginalUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetOriginalUrl(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_DeleteItem")]
-            public static extern void DeleteItem(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_DeleteItem", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteItem(IntPtr jarg1);
         }
 
         internal static partial class WebBackForwardSubList
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_DeleteCopiedItems")]
-            public static extern void DeleteCopiedItems(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_DeleteCopiedItems", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteCopiedItems(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetCopiedItemsCount")]
-            public static extern uint GetItemCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetCopiedItemsCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetItemCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetItemAtIndexFromCopiedItems")]
-            public static extern global::System.IntPtr GetItemAtIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetItemAtIndexFromCopiedItems", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetItemAtIndex(IntPtr jarg1, uint jarg2);
         }
 
         internal static partial class WebBackForwardList
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetItemCount")]
-            public static extern uint GetItemCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetItemCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetItemCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetCurrentItem")]
-            public static extern global::System.IntPtr GetCurrentItem(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetCurrentItem", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetCurrentItem(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetPreviousItem")]
-            public static extern global::System.IntPtr GetPreviousItem(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetPreviousItem", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetPreviousItem(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetNextItem")]
-            public static extern global::System.IntPtr GetNextItem(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetNextItem", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetNextItem(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetItemAtIndex")]
-            public static extern global::System.IntPtr GetItemAtIndex(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetItemAtIndex", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetItemAtIndex(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetBackwardItems")]
-            public static extern global::System.IntPtr GetBackwardItems(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetBackwardItems", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetBackwardItems(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetForwardItems")]
-            public static extern global::System.IntPtr GetForwardItems(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetForwardItems", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetForwardItems(IntPtr jarg1, int jarg2);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebCertificate.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebCertificate.cs
@@ -15,36 +15,45 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebCertificate
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebCertificate")]
-            public static extern void DeleteWebCertificate(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebCertificate", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWebCertificate(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCertificate_Allow")]
-            public static extern void Allow(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCertificate_Allow", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Allow(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCertificate_IsFromMainFrame")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCertificate_IsFromMainFrame", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsFromMainFrame(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsFromMainFrame(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCertificate_GetPem")]
-            public static extern string GetPem(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCertificate_GetPem", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetPem(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCertificate_IsContextSecure")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCertificate_IsContextSecure", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsContextSecure(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsContextSecure(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCertificate_GetPolicyDecisionError")]
-            public static extern int GetPolicyDecisionError(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCertificate_GetPolicyDecisionError", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetPolicyDecisionError(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCertificate_SuspendPolicyDecision")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCertificate_SuspendPolicyDecision", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SuspendPolicyDecision(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool SuspendPolicyDecision(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebConsoleMessage.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebConsoleMessage.cs
@@ -15,27 +15,36 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebConsoleMessage
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebConsoleMessage")]
-            public static extern void DeleteWebConsoleMessage(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebConsoleMessage", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWebConsoleMessage(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebConsoleMessage_GetSource")]
-            public static extern string GetSource(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebConsoleMessage_GetSource", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetSource(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebConsoleMessage_GetLine")]
-            public static extern uint GetLine(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebConsoleMessage_GetLine", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetLine(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebConsoleMessage_GetSeverityLevel")]
-            public static extern int GetSeverityLevel(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebConsoleMessage_GetSeverityLevel", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetSeverityLevel(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebConsoleMessage_GetText")]
-            public static extern string GetText(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebConsoleMessage_GetText", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetText(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebContext.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebContext.cs
@@ -15,143 +15,152 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebContext
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_GetCacheModel")]
-            public static extern int GetCacheModel(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_GetCacheModel", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetCacheModel(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetCacheModel")]
-            public static extern void SetCacheModel(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetCacheModel", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetCacheModel(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetProxyUri")]
-            public static extern void SetProxyUri(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetProxyUri", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetProxyUri(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_GetProxyUri")]
-            public static extern string GetProxyUri(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_GetProxyUri", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetProxyUri(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetProxyBypassRule")]
-            public static extern void SetProxyBypassRule(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetProxyBypassRule", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetProxyBypassRule(IntPtr jarg1, string jarg2, string jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_GetProxyBypassRule")]
-            public static extern string GetProxyBypassRule(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_GetProxyBypassRule", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetProxyBypassRule(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetCertificateFilePath")]
-            public static extern void SetCertificateFilePath(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetCertificateFilePath", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetCertificateFilePath(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_GetCertificateFilePath")]
-            public static extern string GetCertificateFilePath(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_GetCertificateFilePath", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetCertificateFilePath(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetDefaultProxyAuth")]
-            public static extern void SetDefaultProxyAuth(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetDefaultProxyAuth", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetDefaultProxyAuth(IntPtr jarg1, string jarg2, string jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteAllWebDatabase")]
-            public static extern void DeleteAllWebDatabase(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteAllWebDatabase", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteAllWebDatabase(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_GetWebDatabaseOrigins")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_GetWebDatabaseOrigins", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetWebDatabaseOrigins(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool GetWebDatabaseOrigins(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteWebDatabase")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteWebDatabase", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool DeleteWebDatabase(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool DeleteWebDatabase(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_GetWebStorageOrigins")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_GetWebStorageOrigins", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetWebStorageOrigins(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool GetWebStorageOrigins(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_GetWebStorageUsageForOrigin")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_GetWebStorageUsageForOrigin", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetWebStorageUsageForOrigin(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            public static partial bool GetWebStorageUsageForOrigin(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteAllWebStorage")]
-            public static extern void DeleteAllWebStorage(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteAllWebStorage", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteAllWebStorage(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteWebStorage")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteWebStorage", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool DeleteWebStorage(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool DeleteWebStorage(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteLocalFileSystem")]
-            public static extern void DeleteLocalFileSystem(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteLocalFileSystem", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteLocalFileSystem(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_ClearCache")]
-            public static extern void ClearCache(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_ClearCache", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ClearCache(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteApplicationCache")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteApplicationCache", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool DeleteApplicationCache(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool DeleteApplicationCache(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_GetFormPasswordList")]
-            public static extern void GetFormPasswordList(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_GetFormPasswordList", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GetFormPasswordList(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_RegisterDownloadStartedCallback")]
-            public static extern void RegisterDownloadStartedCallback(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_RegisterDownloadStartedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterDownloadStartedCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_RegisterMimeOverriddenCallback")]
-            public static extern void RegisterMimeOverriddenCallback(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_RegisterMimeOverriddenCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterMimeOverriddenCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_RegisterRequestInterceptedCallback")]
-            public static extern void RegisterRequestInterceptedCallback(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_RegisterRequestInterceptedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterRequestInterceptedCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_EnableCache")]
-            public static extern void EnableCache(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_EnableCache", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableCache(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_IsCacheEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_IsCacheEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsCacheEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsCacheEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetAppId")]
-            public static extern void SetAppId(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetAppId", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetAppId(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetAppVersion")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetAppVersion", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SetAppVersion(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            public static partial bool SetAppVersion(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetApplicationType")]
-            public static extern void SetApplicationType(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetApplicationType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetApplicationType(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetTimeOffset")]
-            public static extern void SetTimeOffset(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetTimeOffset", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTimeOffset(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetTimeZoneOffset")]
-            public static extern void SetTimeZoneOffset(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetTimeZoneOffset", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTimeZoneOffset(IntPtr jarg1, float jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_RegisterUrlSchemesAsCorsEnabled")]
-            public static extern void RegisterUrlSchemesAsCorsEnabled(global::System.Runtime.InteropServices.HandleRef jarg1, string[] jarg2, uint jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_RegisterUrlSchemesAsCorsEnabled", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterUrlSchemesAsCorsEnabled(IntPtr jarg1, string[] jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_RegisterJsPluginMimeTypes")]
-            public static extern void RegisterJsPluginMimeTypes(global::System.Runtime.InteropServices.HandleRef jarg1, string[] jarg2, uint jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_RegisterJsPluginMimeTypes", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterJsPluginMimeTypes(IntPtr jarg1, string[] jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetDefaultZoomFactor")]
-            public static extern void SetDefaultZoomFactor(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetDefaultZoomFactor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetDefaultZoomFactor(IntPtr jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_GetDefaultZoomFactor")]
-            public static extern float GetDefaultZoomFactor(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_GetDefaultZoomFactor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetDefaultZoomFactor(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteAllApplicationCache")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteAllApplicationCache", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool DeleteAllApplicationCache(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool DeleteAllApplicationCache(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteAllWebIndexedDatabase")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteAllWebIndexedDatabase", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool DeleteAllWebIndexedDatabase(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool DeleteAllWebIndexedDatabase(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteFormPasswordDataList")]
-            public static extern void DeleteFormPasswordDataList(global::System.Runtime.InteropServices.HandleRef jarg1, string[] jarg2, uint jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteFormPasswordDataList", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteFormPasswordDataList(IntPtr jarg1, string[] jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteAllFormPasswordData")]
-            public static extern void DeleteAllFormPasswordData(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteAllFormPasswordData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteAllFormPasswordData(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteAllFormCandidateData")]
-            public static extern void DeleteAllFormCandidateData(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteAllFormCandidateData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteAllFormCandidateData(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_FreeUnusedMemory")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_FreeUnusedMemory", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool FreeUnusedMemory(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool FreeUnusedMemory(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebContextMenu.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebContextMenu.cs
@@ -15,41 +15,50 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebContextMenu
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebContextMenu")]
-            public static extern void DeleteWebContextMenu(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebContextMenu", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWebContextMenu(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenu_GetItemCount")]
-            public static extern uint GetItemCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenu_GetItemCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetItemCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenu_GetItemAt")]
-            public static extern System.IntPtr GetItemAt(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenu_GetItemAt", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial System.IntPtr GetItemAt(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenu_RemoveItem")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenu_RemoveItem", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool RemoveItem(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool RemoveItem(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenu_AppendItemAsAction")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenu_AppendItemAsAction", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AppendItemAsAction(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, string jarg3, bool jarg4);
+            public static partial bool AppendItemAsAction(IntPtr jarg1, int jarg2, string jarg3, [MarshalAs(UnmanagedType.U1)] bool jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenu_AppendItem")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenu_AppendItem", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AppendItem(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, string jarg3, string jarg4, bool jarg5);
+            public static partial bool AppendItem(IntPtr jarg1, int jarg2, string jarg3, string jarg4, [MarshalAs(UnmanagedType.U1)] bool jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenu_SelectItem")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenu_SelectItem", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SelectItem(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool SelectItem(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenu_Hide")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenu_Hide", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Hide(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Hide(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebContextMenuItem.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebContextMenuItem.cs
@@ -15,37 +15,46 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebContextMenuItem
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebContextMenuItem")]
-            public static extern void DeleteWebContextMenuItem(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebContextMenuItem", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWebContextMenuItem(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenuItem_GetTag")]
-            public static extern int GetTag(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenuItem_GetTag", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetTag(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenuItem_GetType")]
-            public static extern int GetType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenuItem_GetType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetType(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenuItem_IsEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenuItem_IsEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenuItem_GetLinkUrl")]
-            public static extern string GetLinkUrl(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenuItem_GetLinkUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetLinkUrl(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenuItem_GetImageUrl")]
-            public static extern string GetImageUrl(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenuItem_GetImageUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetImageUrl(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenuItem_GetTitle")]
-            public static extern string GetTitle(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenuItem_GetTitle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetTitle(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenuItem_GetParentMenu")]
-            public static extern System.IntPtr GetParentMenu(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContextMenuItem_GetParentMenu", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial System.IntPtr GetParentMenu(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebCookieManager.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebCookieManager.cs
@@ -15,27 +15,36 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebCookieManager
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCookieManager_GetCookieAcceptPolicy")]
-            public static extern int GetCookieAcceptPolicy(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCookieManager_GetCookieAcceptPolicy", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetCookieAcceptPolicy(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCookieManager_SetCookieAcceptPolicy")]
-            public static extern void SetCookieAcceptPolicy(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCookieManager_SetCookieAcceptPolicy", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetCookieAcceptPolicy(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCookieManager_SetPersistentStorage")]
-            public static extern void SetPersistentStorage(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCookieManager_SetPersistentStorage", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPersistentStorage(IntPtr jarg1, string jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCookieManager_ClearCookies")]
-            public static extern void ClearCookies(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCookieManager_ClearCookies", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ClearCookies(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCookieManager_ChangesWatch")]
-            public static extern void CookieChangedCallback(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCookieManager_ChangesWatch", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void CookieChangedCallback(IntPtr jarg1, IntPtr jarg2);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebDeviceList.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebDeviceList.cs
@@ -14,7 +14,10 @@
  * limitations under the License.
  *
  */
+
+using global::System;
 using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -22,17 +25,20 @@ namespace Tizen.NUI
     {
         internal static partial class WebDeviceList
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_DeviceListGet")]
-            public static extern void Delete(HandleRef obj);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_DeviceListGet", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Delete(IntPtr obj);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DeviceListGet_GetTypeAndConnect")]
-            public static extern void GetTypeAndConnect(HandleRef obj, out int type, out bool connect, int idx);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DeviceListGet_GetTypeAndConnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GetTypeAndConnect(IntPtr obj, out int type, out bool connect, int idx);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DeviceListGet_GetDeviceId")]
-            public static extern string GetDeviceId(HandleRef obj, int idx);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DeviceListGet_GetDeviceId", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetDeviceId(IntPtr obj, int idx);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DeviceListGet_GetDeviceLabel")]
-            public static extern string GetDeviceLabel(HandleRef obj, int idx);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DeviceListGet_GetDeviceLabel", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetDeviceLabel(IntPtr obj, int idx);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebFileChooser.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebFileChooser.cs
@@ -15,43 +15,52 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebFileChooser
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebFileChooserRequest")]
-            public static extern void DeleteWebFileChooserRequest(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebFileChooserRequest", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWebFileChooserRequest(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebFileChooserRequest_MultipleFilesAllowed")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebFileChooserRequest_MultipleFilesAllowed", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool MultipleFilesAllowed(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool MultipleFilesAllowed(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebFileChooserRequest_AcceptedMimetypes")]
-            public static extern System.IntPtr AcceptedMimetypes(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebFileChooserRequest_AcceptedMimetypes", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial System.IntPtr AcceptedMimetypes(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebFileChooserRequest_Cancel")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebFileChooserRequest_Cancel", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Cancel(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Cancel(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebFileChooserRequest_ChooseFiles")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebFileChooserRequest_ChooseFiles", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool ChooseFiles(global::System.Runtime.InteropServices.HandleRef jarg1, string[] files, uint count);
+            public static partial bool ChooseFiles(IntPtr jarg1, string[] files, uint count);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebFileChooserRequest_ChooseFile")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebFileChooserRequest_ChooseFile", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool ChooseFile(global::System.Runtime.InteropServices.HandleRef jarg1, string file);
+            public static partial bool ChooseFile(IntPtr jarg1, string file);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_AcceptedMimetypes")]
-            public static extern void DeleteAcceptedMimetypes(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_AcceptedMimetypes", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteAcceptedMimetypes(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AcceptedMimetypes_Count")]
-            public static extern uint AcceptedMimetypesCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AcceptedMimetypes_Count", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint AcceptedMimetypesCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AcceptedMimetypes_GetItem")]
-            public static extern string AcceptedMimetypesGetItem(global::System.Runtime.InteropServices.HandleRef jarg1, uint index);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AcceptedMimetypes_GetItem", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string AcceptedMimetypesGetItem(IntPtr jarg1, uint index);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebFormRepostPolicyDecisionMaker.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebFormRepostPolicyDecisionMaker.cs
@@ -15,18 +15,27 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebFormRepostPolicyDecisionMaker
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebFormRepostDecision")]
-            public static extern void DeleteWebFormRepostDecision(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebFormRepostDecision", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWebFormRepostDecision(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebFormRepostDecision_Reply")]
-            public static extern void Reply(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebFormRepostDecision_Reply", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Reply(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebFrame.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebFrame.cs
@@ -15,16 +15,25 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebFrame
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebFrame_IsMainFrame")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebFrame_IsMainFrame", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsMainFrame(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsMainFrame(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebHitTest.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebHitTest.cs
@@ -15,48 +15,57 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebHitTest
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebHitTest")]
-            public static extern void DeleteWebHitTest(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebHitTest", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWebHitTest(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetResultContext")]
-            public static extern int GetResultContext(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetResultContext", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetResultContext(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetLinkUri")]
-            public static extern string GetLinkUri(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetLinkUri", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetLinkUri(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetLinkTitle")]
-            public static extern string GetLinkTitle(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetLinkTitle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetLinkTitle(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetLinkLabel")]
-            public static extern string GetLinkLabel(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetLinkLabel", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetLinkLabel(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetImageUri")]
-            public static extern string GetImageUri(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetImageUri", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetImageUri(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetMediaUri")]
-            public static extern string GetMediaUri(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetMediaUri", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetMediaUri(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetTagName")]
-            public static extern string GetTagName(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetTagName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetTagName(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetNodeValue")]
-            public static extern string GetNodeValue(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetNodeValue", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetNodeValue(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetAttributes")]
-            public static extern global::System.IntPtr GetAttributes(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetAttributes", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetAttributes(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetImageFileNameExtension")]
-            public static extern string GetImageFileNameExtension(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetImageFileNameExtension", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetImageFileNameExtension(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetImageBuffer")]
-            public static extern global::System.IntPtr GetImageBuffer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHitTest_GetImageBuffer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetImageBuffer(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebHttpAuthHandler.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebHttpAuthHandler.cs
@@ -15,27 +15,36 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebHttpAuthHandler
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebHttpAuthHandler")]
-            public static extern void DeleteWebHttpAuthHandler(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebHttpAuthHandler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWebHttpAuthHandler(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHttpAuthHandler_GetRealm")]
-            public static extern string GetRealm(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHttpAuthHandler_GetRealm", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetRealm(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHttpAuthHandler_Suspend")]
-            public static extern void Suspend(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHttpAuthHandler_Suspend", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Suspend(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHttpAuthHandler_UseCredential")]
-            public static extern void UseCredential(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHttpAuthHandler_UseCredential", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void UseCredential(IntPtr jarg1, string jarg2, string jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHttpAuthHandler_CancelCredential")]
-            public static extern void CancelCredential(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHttpAuthHandler_CancelCredential", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void CancelCredential(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebHttpRequestInterceptor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebHttpRequestInterceptor.cs
@@ -15,7 +15,9 @@
  *
  */
 
-using System.Runtime.InteropServices;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -23,58 +25,63 @@ namespace Tizen.NUI
     {
         internal static partial class WebHttpRequestInterceptor
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_GetWebView")]
-            public static extern global::System.IntPtr GetWebView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_GetWebView", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetWebView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_GetUrl")]
-            public static extern string GetUrl(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_GetUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetUrl(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_GetMethod")]
-            public static extern string GetMethod(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_GetMethod", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetMethod(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_GetHeaders")]
-            public static extern global::System.IntPtr GetHeaders(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_GetHeaders", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetHeaders(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_Ignore")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_Ignore", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Ignore(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Ignore(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_SetResponseStatus")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_SetResponseStatus", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SetResponseStatus(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, string jarg3);
+            public static partial bool SetResponseStatus(IntPtr jarg1, int jarg2, string jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_AddResponseHeader")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_AddResponseHeader", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddResponseHeader(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3);
+            public static partial bool AddResponseHeader(IntPtr jarg1, string jarg2, string jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_AddResponseHeaders")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_AddResponseHeaders", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddResponseHeaders(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool AddResponseHeaders(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_AddResponseBody")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_AddResponseBody", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddResponseBody(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, uint jarg3);
+            public static partial bool AddResponseBody(IntPtr jarg1, string jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, EntryPoint = "CSharp_Dali_WebRequestInterceptor_AddResponseBody")]
+            [LibraryImport(NDalicPINVOKE.Lib, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, EntryPoint = "CSharp_Dali_WebRequestInterceptor_AddResponseBody", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddResponseBody(global::System.Runtime.InteropServices.HandleRef jarg1, [MarshalAs(UnmanagedType.LPArray)] byte[] jarg2, uint jarg3);
+            public static partial bool AddResponseBody(IntPtr jarg1, [MarshalAs(UnmanagedType.LPArray)] byte[] jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_AddResponse")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_AddResponse", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddResponse(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3, uint jarg4);
+            public static partial bool AddResponse(IntPtr jarg1, string jarg2, string jarg3, uint jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, EntryPoint = "CSharp_Dali_WebRequestInterceptor_AddResponse")]
+            [LibraryImport(NDalicPINVOKE.Lib, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, EntryPoint = "CSharp_Dali_WebRequestInterceptor_AddResponse", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddResponse(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, [MarshalAs(UnmanagedType.LPArray)] byte[] jarg3, uint jarg4);
+            public static partial bool AddResponse(IntPtr jarg1, string jarg2, [MarshalAs(UnmanagedType.LPArray)] byte[] jarg3, uint jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_WriteResponseChunk")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_WriteResponseChunk", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool WriteResponseChunk(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, uint jarg3);
+            public static partial bool WriteResponseChunk(IntPtr jarg1, string jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, EntryPoint = "CSharp_Dali_WebRequestInterceptor_WriteResponseChunk")]
+            [LibraryImport(NDalicPINVOKE.Lib, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, EntryPoint = "CSharp_Dali_WebRequestInterceptor_WriteResponseChunk", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool WriteResponseChunk(global::System.Runtime.InteropServices.HandleRef jarg1, [MarshalAs(UnmanagedType.LPArray)] byte[] jarg2, uint jarg3);
+            public static partial bool WriteResponseChunk(IntPtr jarg1, [MarshalAs(UnmanagedType.LPArray)] byte[] jarg2, uint jarg3);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebPageLoadError.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebPageLoadError.cs
@@ -15,27 +15,36 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebPageLoadError
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebLoadError")]
-            public static extern void DeleteWebPageLoadError(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebLoadError", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWebPageLoadError(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebLoadError_GetUrl")]
-            public static extern string GetUrl(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebLoadError_GetUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetUrl(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebLoadError_GetCode")]
-            public static extern int GetCode(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebLoadError_GetCode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetCode(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebLoadError_GetDescription")]
-            public static extern string GetDescription(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebLoadError_GetDescription", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetDescription(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebLoadError_GetType")]
-            public static extern int GetType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebLoadError_GetType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetType(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebPasswordData.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebPasswordData.cs
@@ -15,19 +15,28 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebPasswordData
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPasswordData_GetUrl")]
-            public static extern string GetUrl(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPasswordData_GetUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetUrl(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPasswordData_GetUseFingerprint")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPasswordData_GetUseFingerprint", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetUseFingerprint(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool GetUseFingerprint(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebPasswordDataList.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebPasswordDataList.cs
@@ -15,21 +15,30 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebPasswordDataList
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebPasswordDataList")]
-            public static extern void DeleteWebPasswordDataList(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebPasswordDataList", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWebPasswordDataList(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPasswordDataList_GetItemCount")]
-            public static extern uint GetItemCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPasswordDataList_GetItemCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetItemCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPasswordDataList_ValueOfIndex")]
-            public static extern System.IntPtr ValueOfIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPasswordDataList_ValueOfIndex", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial System.IntPtr ValueOfIndex(IntPtr jarg1, uint jarg2);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebPolicyDecisionMaker.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebPolicyDecisionMaker.cs
@@ -15,51 +15,60 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebPolicyDecisionMaker
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebPolicyDecision")]
-            public static extern void DeleteWebPolicyDecision(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebPolicyDecision", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWebPolicyDecision(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_GetUrl")]
-            public static extern string GetUrl(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_GetUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetUrl(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_GetCookie")]
-            public static extern string GetCookie(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_GetCookie", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetCookie(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_GetDecisionType")]
-            public static extern int GetDecisionType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_GetDecisionType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetDecisionType(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_GetResponseMime")]
-            public static extern string GetResponseMime(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_GetResponseMime", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetResponseMime(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_GetResponseStatusCode")]
-            public static extern int GetResponseStatusCode(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_GetResponseStatusCode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetResponseStatusCode(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_GetNavigationType")]
-            public static extern int GetNavigationType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_GetNavigationType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetNavigationType(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_GetFrame")]
-            public static extern System.IntPtr GetFrame(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_GetFrame", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial System.IntPtr GetFrame(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_GetScheme")]
-            public static extern string GetScheme(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_GetScheme", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetScheme(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_Use")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_Use", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Use(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Use(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_Ignore")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_Ignore", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Ignore(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Ignore(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_Suspend")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_Suspend", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Suspend(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Suspend(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebSecurityOrigin.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebSecurityOrigin.cs
@@ -15,18 +15,27 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebSecurityOrigin
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSecurityOrigin_GetHost")]
-            public static extern string GetHost(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSecurityOrigin_GetHost", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetHost(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSecurityOrigin_GetProtocol")]
-            public static extern string GetProtocol(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSecurityOrigin_GetProtocol", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetProtocol(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebSecurityOriginList.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebSecurityOriginList.cs
@@ -15,21 +15,30 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebSecurityOriginList
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebSecurityOriginList")]
-            public static extern void DeleteWebSecurityOriginList(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebSecurityOriginList", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWebSecurityOriginList(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSecurityOriginList_GetItemCount")]
-            public static extern uint GetItemCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSecurityOriginList_GetItemCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetItemCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSecurityOriginList_ValueOfIndex")]
-            public static extern System.IntPtr ValueOfIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSecurityOriginList_ValueOfIndex", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial System.IntPtr ValueOfIndex(IntPtr jarg1, uint jarg2);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebSettings.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebSettings.cs
@@ -15,185 +15,194 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebSettings
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_AllowMixedContents")]
-            public static extern void AllowMixedContents(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_AllowMixedContents", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AllowMixedContents(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableSpatialNavigation")]
-            public static extern void EnableSpatialNavigation(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableSpatialNavigation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableSpatialNavigation(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_GetDefaultFontSize")]
-            public static extern int GetDefaultFontSize(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_GetDefaultFontSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetDefaultFontSize(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_SetDefaultFontSize")]
-            public static extern void SetDefaultFontSize(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_SetDefaultFontSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetDefaultFontSize(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableWebSecurity")]
-            public static extern void EnableWebSecurity(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableWebSecurity", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableWebSecurity(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableCacheBuilder")]
-            public static extern void EnableCacheBuilder(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableCacheBuilder", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableCacheBuilder(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_UseScrollbarThumbFocusNotifications")]
-            public static extern void UseScrollbarThumbFocusNotifications(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_UseScrollbarThumbFocusNotifications", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void UseScrollbarThumbFocusNotifications(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableDoNotTrack")]
-            public static extern void EnableDoNotTrack(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableDoNotTrack", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableDoNotTrack(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_AllowFileAccessFromExternalUrl")]
-            public static extern void AllowFileAccessFromExternalUrl(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_AllowFileAccessFromExternalUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AllowFileAccessFromExternalUrl(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsJavaScriptEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsJavaScriptEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsJavaScriptEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsJavaScriptEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableJavaScript")]
-            public static extern void EnableJavaScript(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableJavaScript", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableJavaScript(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsAutoFittingEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsAutoFittingEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsAutoFittingEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsAutoFittingEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableAutoFitting")]
-            public static extern void EnableAutoFitting(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableAutoFitting", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableAutoFitting(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_ArePluginsEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_ArePluginsEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool ArePluginsEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool ArePluginsEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnablePlugins")]
-            public static extern void EnablePlugins(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnablePlugins", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnablePlugins(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsPrivateBrowsingEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsPrivateBrowsingEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsPrivateBrowsingEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsPrivateBrowsingEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnablePrivateBrowsing")]
-            public static extern void EnablePrivateBrowsing(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnablePrivateBrowsing", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnablePrivateBrowsing(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsLinkMagnifierEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsLinkMagnifierEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsLinkMagnifierEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsLinkMagnifierEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableLinkMagnifier")]
-            public static extern void EnableLinkMagnifier(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableLinkMagnifier", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableLinkMagnifier(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsKeypadWithoutUserActionUsed")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsKeypadWithoutUserActionUsed", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsKeypadWithoutUserActionUsed(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsKeypadWithoutUserActionUsed(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_UseKeypadWithoutUserAction")]
-            public static extern void UseKeypadWithoutUserAction(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_UseKeypadWithoutUserAction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void UseKeypadWithoutUserAction(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsAutofillPasswordFormEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsAutofillPasswordFormEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsAutofillPasswordFormEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsAutofillPasswordFormEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableAutofillPasswordForm")]
-            public static extern void EnableAutofillPasswordForm(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableAutofillPasswordForm", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableAutofillPasswordForm(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsFormCandidateDataEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsFormCandidateDataEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsFormCandidateDataEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsFormCandidateDataEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableFormCandidateData")]
-            public static extern void EnableFormCandidateData(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableFormCandidateData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableFormCandidateData(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsTextSelectionEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsTextSelectionEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsTextSelectionEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsTextSelectionEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableTextSelection")]
-            public static extern void EnableTextSelection(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableTextSelection", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableTextSelection(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsTextAutosizingEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsTextAutosizingEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsTextAutosizingEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsTextAutosizingEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableTextAutosizing")]
-            public static extern void EnableTextAutosizing(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableTextAutosizing", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableTextAutosizing(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsArrowScrollEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsArrowScrollEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsArrowScrollEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsArrowScrollEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableArrowScroll")]
-            public static extern void EnableArrowScroll(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableArrowScroll", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableArrowScroll(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsClipboardEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsClipboardEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsClipboardEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsClipboardEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableClipboard")]
-            public static extern void EnableClipboard(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableClipboard", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableClipboard(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsImePanelEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsImePanelEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsImePanelEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsImePanelEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableImePanel")]
-            public static extern void EnableImePanel(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableImePanel", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableImePanel(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_AllowScriptsOpenWindows")]
-            public static extern void AllowScriptsOpenWindows(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_AllowScriptsOpenWindows", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AllowScriptsOpenWindows(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_AreImagesLoadedAutomatically")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_AreImagesLoadedAutomatically", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AreImagesLoadedAutomatically(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool AreImagesLoadedAutomatically(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_AllowImagesLoadAutomatically")]
-            public static extern void AllowImagesLoadAutomatically(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_AllowImagesLoadAutomatically", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AllowImagesLoadAutomatically(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_GetDefaultTextEncodingName")]
-            public static extern string GetDefaultTextEncodingName(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_GetDefaultTextEncodingName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetDefaultTextEncodingName(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_SetDefaultTextEncodingName")]
-            public static extern void SetDefaultTextEncodingName(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_SetDefaultTextEncodingName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetDefaultTextEncodingName(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_SetViewportMetaTag")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_SetViewportMetaTag", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SetViewportMetaTag(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            public static partial bool SetViewportMetaTag(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_SetForceZoom")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_SetForceZoom", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SetForceZoom(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            public static partial bool SetForceZoom(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsZoomForced")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsZoomForced", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsZoomForced(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsZoomForced(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_SetTextZoomEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_SetTextZoomEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SetTextZoomEnabled(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            public static partial bool SetTextZoomEnabled(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsTextZoomEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsTextZoomEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsTextZoomEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsTextZoomEnabled(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_SetImeStyle")]
-            public static extern void SetImeStyle(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_SetImeStyle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetImeStyle(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_GetImeStyle")]
-            public static extern int GetImeStyle(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_GetImeStyle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetImeStyle(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_SetExtraFeature")]
-            public static extern void SetExtraFeature(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, bool jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_SetExtraFeature", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetExtraFeature(IntPtr jarg1, string jarg2, [MarshalAs(UnmanagedType.U1)] bool jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsExtraFeatureEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsExtraFeatureEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsExtraFeatureEnabled(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            public static partial bool IsExtraFeatureEnabled(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_SetDefaultAudioInputDevice")]
-            public static extern void SetDefaultAudioInputDevice(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_SetDefaultAudioInputDevice", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetDefaultAudioInputDevice(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableDragAndDrop")]
-            public static extern void EnableDragAndDrop(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableDragAndDrop", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableDragAndDrop(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebUserMediaPermissionRequest.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebUserMediaPermissionRequest.cs
@@ -15,22 +15,31 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebUserMediaPermissionRequest
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_UserMediaPermissionRequest")]
-            public static extern void Delete(global::System.Runtime.InteropServices.HandleRef webPermission);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_UserMediaPermissionRequest", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Delete(IntPtr webPermission);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UserMediaPermissionRequest_Set")]
-            public static extern void Set(global::System.Runtime.InteropServices.HandleRef webPermission, bool allowed);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UserMediaPermissionRequest_Set", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Set(IntPtr webPermission, [MarshalAs(UnmanagedType.U1)] bool allowed);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UserMediaPermissionRequest_Suspend")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UserMediaPermissionRequest_Suspend", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Suspend(global::System.Runtime.InteropServices.HandleRef webPermission);
+            public static partial bool Suspend(IntPtr webPermission);
         }
     }
 }
+
+
+
+
+
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebView.cs
@@ -15,8 +15,9 @@
  *
  */
 
-using global::System.Runtime.InteropServices;
 using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -24,359 +25,362 @@ namespace Tizen.NUI
     {
         internal static partial class WebView
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_New")]
-            public static extern IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr New();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_New_2")]
-            public static extern IntPtr New2(string jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_New_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr New2(string jarg1, string jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_New_3")]
-            public static extern IntPtr New3(int jarg1, string[] jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_New_3", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr New3(int jarg1, string[] jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_New_4")]
-            public static extern IntPtr New4(int argc, string[] argv, int type);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_New_4", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr New4(int argc, string[] argv, int type);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetContext")]
-            public static extern IntPtr GetWebContext();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetContext", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GetWebContext();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetCookieManager")]
-            public static extern IntPtr GetWebCookieManager();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetCookieManager", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GetWebCookieManager();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WebView__SWIG_1")]
-            public static extern IntPtr NewWebView(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WebView__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr NewWebView(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebView")]
-            public static extern void DeleteWebView(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebView", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWebView(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Assign")]
-            public static extern IntPtr Assign(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_DownCast")]
-            public static extern IntPtr DownCast(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_DownCast", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr DownCast(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_URL_get")]
-            public static extern int UrlGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_URL_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int UrlGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_USER_AGENT_get")]
-            public static extern int UserAgentGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_USER_AGENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int UserAgentGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetBackForwardList")]
-            public static extern IntPtr GetWebBackForwardList(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetBackForwardList", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GetWebBackForwardList(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetSettings")]
-            public static extern IntPtr GetWebSettings(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetSettings", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GetWebSettings(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_SCROLL_POSITION_get")]
-            public static extern int ScrollPositionGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_SCROLL_POSITION_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollPositionGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_SCROLL_SIZE_get")]
-            public static extern int ScrollSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_SCROLL_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ScrollSizeGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_CONTENT_SIZE_get")]
-            public static extern int ContentSizeGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_CONTENT_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ContentSizeGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_TITLE_get")]
-            public static extern int TitleGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_TITLE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TitleGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_VIDEO_HOLE_ENABLED_get")]
-            public static extern int VideoHoleEnabledGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_VIDEO_HOLE_ENABLED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int VideoHoleEnabledGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_MOUSE_EVENTS_ENABLED_get")]
-            public static extern int MouseEventsEnabledGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_MOUSE_EVENTS_ENABLED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int MouseEventsEnabledGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_KEY_EVENTS_ENABLED_get")]
-            public static extern int KeyEventsEnabledGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_KEY_EVENTS_ENABLED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int KeyEventsEnabledGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_DOCUMENT_BACKGROUND_COLOR_get")]
-            public static extern int DocumentBackgroundColorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_DOCUMENT_BACKGROUND_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DocumentBackgroundColorGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_TILES_CLEARED_WHEN_HIDDEN_get")]
-            public static extern int TilesClearedWhenHiddenGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_TILES_CLEARED_WHEN_HIDDEN_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TilesClearedWhenHiddenGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_TILE_COVER_AREA_MULTIPLIER_get")]
-            public static extern int TileCoverAreaMultiplierGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_TILE_COVER_AREA_MULTIPLIER_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TileCoverAreaMultiplierGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_CURSOR_ENABLED_BY_CLIENT_get")]
-            public static extern int CursorEnabledByClientGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_CURSOR_ENABLED_BY_CLIENT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int CursorEnabledByClientGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_SELECTED_TEXT_get")]
-            public static extern int SelectedTextGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_SELECTED_TEXT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SelectedTextGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_PAGE_ZOOM_FACTOR_get")]
-            public static extern int PageZoomFactorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_PAGE_ZOOM_FACTOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PageZoomFactorGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_TEXT_ZOOM_FACTOR_get")]
-            public static extern int TextZoomFactorGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_TEXT_ZOOM_FACTOR_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TextZoomFactorGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_LOAD_PROGRESS_PERCENTAGE_get")]
-            public static extern int LoadProgressPercentageGet();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_LOAD_PROGRESS_PERCENTAGE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LoadProgressPercentageGet();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetFavicon")]
-            public static extern IntPtr GetFavicon(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetFavicon", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GetFavicon(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_LoadUrl")]
-            public static extern void LoadUrl(HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_LoadUrl", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LoadUrl(IntPtr jarg1, string jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_LoadHtmlString")]
-            public static extern void LoadHtmlString(HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_LoadHtmlString", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LoadHtmlString(IntPtr jarg1, string jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_LoadHtmlStringOverrideCurrentEntry")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_LoadHtmlStringOverrideCurrentEntry", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool LoadHtmlStringOverrideCurrentEntry(HandleRef jarg1, string jarg2, string jarg3, string jarg4);
+            public static partial bool LoadHtmlStringOverrideCurrentEntry(IntPtr jarg1, string jarg2, string jarg3, string jarg4);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_LoadContents")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_LoadContents", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool LoadContents(HandleRef jarg1, string jarg2, uint jarg3, string jarg4, string jarg5, string jarg6);
+            public static partial bool LoadContents(IntPtr jarg1, string jarg2, uint jarg3, string jarg4, string jarg5, string jarg6);
 
-            [DllImport(NDalicPINVOKE.Lib, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, EntryPoint = "CSharp_Dali_WebView_LoadContents")]
+            [LibraryImport(NDalicPINVOKE.Lib, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, EntryPoint = "CSharp_Dali_WebView_LoadContents", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool LoadContents(HandleRef jarg1, [MarshalAs(UnmanagedType.LPArray)] byte[] jarg2, uint jarg3, string jarg4, string jarg5, string jarg6);
+            public static partial bool LoadContents(IntPtr jarg1, [MarshalAs(UnmanagedType.LPArray)] byte[] jarg2, uint jarg3, string jarg4, string jarg5, string jarg6);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Reload")]
-            public static extern void Reload(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Reload", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Reload(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ReloadWithoutCache")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ReloadWithoutCache", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool ReloadWithoutCache(HandleRef jarg1);
+            public static partial bool ReloadWithoutCache(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_StopLoading")]
-            public static extern void StopLoading(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_StopLoading", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void StopLoading(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Suspend")]
-            public static extern void Suspend(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Suspend", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Suspend(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Resume")]
-            public static extern void Resume(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Resume", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Resume(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_SuspendNetworkLoading")]
-            public static extern void SuspendNetworkLoading(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_SuspendNetworkLoading", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SuspendNetworkLoading(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ResumeNetworkLoading")]
-            public static extern void ResumeNetworkLoading(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ResumeNetworkLoading", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ResumeNetworkLoading(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ChangeOrientation")]
-            public static extern void ChangeOrientation(HandleRef jarg1, int orientation);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ChangeOrientation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ChangeOrientation(IntPtr jarg1, int orientation);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_AddCustomHeader")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_AddCustomHeader", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool AddCustomHeader(HandleRef jarg1, string jarg2, string jarg3);
+            public static partial bool AddCustomHeader(IntPtr jarg1, string jarg2, string jarg3);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RemoveCustomHeader")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RemoveCustomHeader", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool RemoveCustomHeader(HandleRef jarg1, string jarg2);
+            public static partial bool RemoveCustomHeader(IntPtr jarg1, string jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_StartInspectorServer")]
-            public static extern uint StartInspectorServer(HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_StartInspectorServer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint StartInspectorServer(IntPtr jarg1, uint jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_StopInspectorServer")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_StopInspectorServer", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool StopInspectorServer(HandleRef jarg1);
+            public static partial bool StopInspectorServer(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_SetImePositionAndAlignment")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_SetImePositionAndAlignment", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool SetImePositionAndAlignment(HandleRef jarg1, HandleRef jarg2, int jarg3);
+            public static partial bool SetImePositionAndAlignment(IntPtr jarg1, IntPtr jarg2, int jarg3);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_SetCursorThemeName")]
-            public static extern void SetCursorThemeName(HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_SetCursorThemeName", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetCursorThemeName(IntPtr jarg1, string jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ScrollBy")]
-            public static extern void ScrollBy(HandleRef jarg1, int jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ScrollBy", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ScrollBy(IntPtr jarg1, int jarg2, int jarg3);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ScrollEdgeBy")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ScrollEdgeBy", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool ScrollEdgeBy(HandleRef jarg1, int jarg2, int jarg3);
+            public static partial bool ScrollEdgeBy(IntPtr jarg1, int jarg2, int jarg3);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GoBack")]
-            public static extern void GoBack(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GoBack", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GoBack(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GoForward")]
-            public static extern void GoForward(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GoForward", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GoForward(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_CanGoBack")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_CanGoBack", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool CanGoBack(HandleRef jarg1);
+            public static partial bool CanGoBack(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_CanGoForward")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_CanGoForward", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool CanGoForward(HandleRef jarg1);
+            public static partial bool CanGoForward(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_EvaluateJavaScript")]
-            public static extern void EvaluateJavaScript(HandleRef jarg1, string jarg2, HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_EvaluateJavaScript", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EvaluateJavaScript(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_AddJavaScriptMessageHandler")]
-            public static extern void AddJavaScriptMessageHandler(HandleRef jarg1, string jarg2, HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_AddJavaScriptMessageHandler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddJavaScriptMessageHandler(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_AddJavaScriptEntireMessageHandler")]
-            public static extern void AddJavaScriptEntireMessageHandler(HandleRef jarg1, string jarg2, HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_AddJavaScriptEntireMessageHandler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddJavaScriptEntireMessageHandler(IntPtr jarg1, string jarg2, IntPtr jarg3);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterJavaScriptAlertCallback")]
-            public static extern void RegisterJavaScriptAlertCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterJavaScriptAlertCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterJavaScriptAlertCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_JavaScriptAlertReply")]
-            public static extern void JavaScriptAlertReply(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_JavaScriptAlertReply", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void JavaScriptAlertReply(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterJavaScriptConfirmCallback")]
-            public static extern void RegisterJavaScriptConfirmCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterJavaScriptConfirmCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterJavaScriptConfirmCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_JavaScriptConfirmReply")]
-            public static extern void JavaScriptConfirmReply(HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_JavaScriptConfirmReply", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void JavaScriptConfirmReply(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterJavaScriptPromptCallback")]
-            public static extern void RegisterJavaScriptPromptCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterJavaScriptPromptCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterJavaScriptPromptCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_JavaScriptPromptReply")]
-            public static extern void JavaScriptPromptReply(HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_JavaScriptPromptReply", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void JavaScriptPromptReply(IntPtr jarg1, string jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ClearAllTilesResources")]
-            public static extern void ClearAllTilesResources(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ClearAllTilesResources", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ClearAllTilesResources(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ClearHistory")]
-            public static extern void ClearHistory(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ClearHistory", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ClearHistory(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ExitFullscreen")]
-            public static extern void ExitFullscreen(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ExitFullscreen", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ExitFullscreen(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_SetScaleFactor")]
-            public static extern void SetScaleFactor(HandleRef jarg1, float jarg2, HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_SetScaleFactor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetScaleFactor(IntPtr jarg1, float jarg2, IntPtr jarg3);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetScaleFactor")]
-            public static extern float GetScaleFactor(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetScaleFactor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial float GetScaleFactor(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ActivateAccessibility")]
-            public static extern void ActivateAccessibility(HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ActivateAccessibility", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ActivateAccessibility(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_HighlightText")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_HighlightText", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool HighlightText(HandleRef jarg1, string jarg2, int jarg3, uint jarg4);
+            public static partial bool HighlightText(IntPtr jarg1, string jarg2, int jarg3, uint jarg4);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_AddDynamicCertificatePath")]
-            public static extern void AddDynamicCertificatePath(HandleRef jarg1, string jarg2, string jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_AddDynamicCertificatePath", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddDynamicCertificatePath(IntPtr jarg1, string jarg2, string jarg3);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetScreenshot")]
-            public static extern IntPtr GetScreenshot(HandleRef jarg1, HandleRef jarg2, float jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetScreenshot", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GetScreenshot(IntPtr jarg1, IntPtr jarg2, float jarg3);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetScreenshotAsynchronously")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetScreenshotAsynchronously", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool GetScreenshotAsynchronously(HandleRef jarg1, HandleRef jarg2, float jarg3, HandleRef jarg4);
+            public static partial bool GetScreenshotAsynchronously(IntPtr jarg1, IntPtr jarg2, float jarg3, IntPtr jarg4);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_CheckVideoPlayingAsynchronously")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_CheckVideoPlayingAsynchronously", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool CheckVideoPlayingAsynchronously(HandleRef jarg1, HandleRef jarg2);
+            public static partial bool CheckVideoPlayingAsynchronously(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterGeolocationPermissionCallback")]
-            public static extern void RegisterGeolocationPermissionCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterGeolocationPermissionCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterGeolocationPermissionCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_CreateHitTest")]
-            public static extern IntPtr CreateHitTest(HandleRef jarg1, int jarg2, int jarg3, int jarg4);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_CreateHitTest", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr CreateHitTest(IntPtr jarg1, int jarg2, int jarg3, int jarg4);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_CreateHitTestAsynchronously")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_CreateHitTestAsynchronously", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool CreateHitTestAsynchronously(HandleRef jarg1, int jarg2, int jarg3, int jarg4, HandleRef jarg5);
+            public static partial bool CreateHitTestAsynchronously(IntPtr jarg1, int jarg2, int jarg3, int jarg4, IntPtr jarg5);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_SWIGUpcast")]
-            public static extern IntPtr Upcast(IntPtr jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_SWIGUpcast", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr Upcast(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_SetTtsFocus")]
-            public static extern void SetTtsFocus(HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_SetTtsFocus", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTtsFocus(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterPageLoadStartedCallback")]
-            public static extern void RegisterPageLoadStartedCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterPageLoadStartedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterPageLoadStartedCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterPageLoadInProgressCallback")]
-            public static extern void RegisterPageLoadInProgressCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterPageLoadInProgressCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterPageLoadInProgressCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterPageLoadFinishedCallback")]
-            public static extern void RegisterPageLoadFinishedCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterPageLoadFinishedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterPageLoadFinishedCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterPageLoadErrorCallback")]
-            public static extern void RegisterPageLoadErrorCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterPageLoadErrorCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterPageLoadErrorCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterScrollEdgeReachedCallback")]
-            public static extern void RegisterScrollEdgeReachedCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterScrollEdgeReachedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterScrollEdgeReachedCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterUrlChangedCallback")]
-            public static extern void RegisterUrlChangedCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterUrlChangedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterUrlChangedCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterFormRepostDecidedCallback")]
-            public static extern void RegisterFormRepostDecidedCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterFormRepostDecidedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterFormRepostDecidedCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterFrameRenderedCallback")]
-            public static extern void RegisterFrameRenderedCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterFrameRenderedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterFrameRenderedCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterConsoleMessageReceivedCallback")]
-            public static extern void RegisterConsoleMessageReceivedCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterConsoleMessageReceivedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterConsoleMessageReceivedCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterResponsePolicyDecidedCallback")]
-            public static extern void RegisterResponsePolicyDecidedCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterResponsePolicyDecidedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterResponsePolicyDecidedCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterNavigationPolicyDecidedCallback")]
-            public static extern void RegisterNavigationPolicyDecidedCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterNavigationPolicyDecidedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterNavigationPolicyDecidedCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterOverScrolledCallback")]
-            public static extern void RegisterOverScrolledCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterOverScrolledCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterOverScrolledCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterNewWindowPolicyDecidedCallback")]
-            public static extern void RegisterNewWindowPolicyDecidedCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterNewWindowPolicyDecidedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterNewWindowPolicyDecidedCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterNewWindowCreatedCallback")]
-            public static extern void RegisterNewWindowCreatedCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterNewWindowCreatedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterNewWindowCreatedCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterCertificateConfirmedCallback")]
-            public static extern void RegisterCertificateConfirmedCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterCertificateConfirmedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterCertificateConfirmedCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterSslCertificateChangedCallback")]
-            public static extern void RegisterSslCertificateChangedCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterSslCertificateChangedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterSslCertificateChangedCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterHttpAuthHandlerCallback")]
-            public static extern void RegisterHttpAuthHandlerCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterHttpAuthHandlerCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterHttpAuthHandlerCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterContextMenuShownCallback")]
-            public static extern void RegisterContextMenuShownCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterContextMenuShownCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterContextMenuShownCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterContextMenuHiddenCallback")]
-            public static extern void RegisterContextMenuHiddenCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterContextMenuHiddenCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterContextMenuHiddenCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterFullscreenEnteredCallback")]
-            public static extern void RegisterFullscreenEnteredCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterFullscreenEnteredCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterFullscreenEnteredCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterFullscreenExitedCallback")]
-            public static extern void RegisterFullscreenExitedCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterFullscreenExitedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterFullscreenExitedCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterTextFoundCallback")]
-            public static extern void RegisterTextFoundCallback(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterTextFoundCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterTextFoundCallback(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetPlainTextAsynchronously")]
-            public static extern void GetPlainTextAsynchronously(HandleRef webViewRef, HandleRef callbackRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetPlainTextAsynchronously", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void GetPlainTextAsynchronously(IntPtr webViewRef, IntPtr callbackRef);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_WebAuthenticationCancel")]
-            public static extern void WebAuthenticationCancel(HandleRef webViewRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_WebAuthenticationCancel", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void WebAuthenticationCancel(IntPtr webViewRef);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterWebAuthDisplayQRCallback")]
-            public static extern void RegisterWebAuthDisplayQRCallback(HandleRef webViewRef, HandleRef callbackRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterWebAuthDisplayQRCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterWebAuthDisplayQRCallback(IntPtr webViewRef, IntPtr callbackRef);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterWebAuthResponseCallback")]
-            public static extern void RegisterWebAuthResponseCallback(HandleRef webViewRef, HandleRef callbackRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterWebAuthResponseCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterWebAuthResponseCallback(IntPtr webViewRef, IntPtr callbackRef);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterFileChooserRequestedCallback")]
-            public static extern void RegisterFileChooserRequestedCallback(HandleRef webViewRef, HandleRef callbackRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterFileChooserRequestedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterFileChooserRequestedCallback(IntPtr webViewRef, IntPtr callbackRef);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterWebProcessCrashedCallback")]
-            public static extern void RegisterWebProcessCrashedCallback(HandleRef webViewRef, HandleRef callbackRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterWebProcessCrashedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterWebProcessCrashedCallback(IntPtr webViewRef, IntPtr callbackRef);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterUserMediaPermissionRequestCallback")]
-            public static extern void RegisterUserMediaPermissionRequestCallback(HandleRef webViewRef, HandleRef callbackRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterUserMediaPermissionRequestCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterUserMediaPermissionRequestCallback(IntPtr webViewRef, IntPtr callbackRef);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_FeedMouseWheel")]
-            public static extern void FeedMouseWheel(HandleRef webViewRef, bool yDirection, int step, int x, int y);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_FeedMouseWheel", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FeedMouseWheel(IntPtr webViewRef, [MarshalAs(UnmanagedType.U1)] bool yDirection, int step, int x, int y);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterDeviceConnectionChangedCallback")]
-            public static extern void RegisterDeviceConnectionChangedCallback(HandleRef webViewRef, IntPtr callbackRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterDeviceConnectionChangedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterDeviceConnectionChangedCallback(IntPtr webViewRef, IntPtr callbackRef);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterDeviceListGetCallback")]
-            public static extern void RegisterDeviceListGetCallback(HandleRef webViewRef, IntPtr callbackRef);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_RegisterDeviceListGetCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterDeviceListGetCallback(IntPtr webViewRef, IntPtr callbackRef);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_SetVideoHole")]
-            public static extern void SetVideoHole(HandleRef webViewRef, bool enable, bool isWaylandWindow);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_SetVideoHole", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetVideoHole(IntPtr webViewRef, [MarshalAs(UnmanagedType.U1)] bool enable, [MarshalAs(UnmanagedType.U1)] bool isWaylandWindow);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Wheel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Wheel.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,63 +26,68 @@ namespace Tizen.NUI
         internal static partial class Wheel
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_New")]
-            public static extern global::System.IntPtr New(int jarg1, int jarg2, uint jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, int jarg5, uint jarg6);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int jarg1, int jarg2, uint jarg3, IntPtr jarg4, int jarg5, uint jarg6);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Wheel")]
-            public static extern void DeleteWheel(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Wheel", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWheel(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_IsShiftModifier")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_IsShiftModifier", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsShiftModifier(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsShiftModifier(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_IsCtrlModifier")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_IsCtrlModifier", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsCtrlModifier(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsCtrlModifier(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_IsAltModifier")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_IsAltModifier", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsAltModifier(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsAltModifier(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_type_get")]
-            public static extern int TypeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_type_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TypeGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_direction_get")]
-            public static extern int DirectionGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_direction_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DirectionGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_modifiers_get")]
-            public static extern uint ModifiersGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_modifiers_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint ModifiersGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_point_get")]
-            public static extern global::System.IntPtr PointGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_point_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr PointGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_delta_get")]
-            public static extern int DeltaGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_delta_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int DeltaGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_timeStamp_get")]
-            public static extern uint TimeStampGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_timeStamp_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint TimeStampGet(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StageWheelSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StageWheelSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool StageWheelSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool StageWheelSignalEmpty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StageWheelSignal_GetConnectionCount")]
-            public static extern uint StageWheelSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StageWheelSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint StageWheelSignalGetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StageWheelSignal_Connect")]
-            public static extern void StageWheelSignalConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StageWheelSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void StageWheelSignalConnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StageWheelSignal_Disconnect")]
-            public static extern void StageWheelSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StageWheelSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void StageWheelSignalDisconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StageWheelSignal_Emit")]
-            public static extern void StageWheelSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StageWheelSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void StageWheelSignalEmit(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StageWheelSignal")]
-            public static extern global::System.IntPtr NewStageWheelSignal();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StageWheelSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewStageWheelSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_StageWheelSignal")]
-            public static extern void DeleteStageWheelSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_StageWheelSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteStageWheelSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Widget.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Widget.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,14 +26,19 @@ namespace Tizen.NUI
         internal static partial class Widget
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Widget_New__SWIG_1")]
-            public static extern global::System.IntPtr New(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Widget_New__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Widget_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Widget_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Widget")]
-            public static extern void DeleteWidget(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Widget", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWidget(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WidgetApplication.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WidgetApplication.cs
@@ -15,26 +15,35 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WidgetApplication
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetApplication_New")]
-            public static extern global::System.IntPtr New(int jarg1, string jarg2, string jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetApplication_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int jarg1, string jarg2, string jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WidgetApplication__SWIG_1")]
-            public static extern global::System.IntPtr NewWidgetApplication(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WidgetApplication__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewWidgetApplication(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetApplication_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetApplication_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WidgetApplication")]
-            public static extern void DeleteWidgetApplication(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WidgetApplication", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWidgetApplication(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetApplication_RegisterWidgetCreatingFunction")]
-            public static extern void RegisterWidgetCreatingFunction(global::System.Runtime.InteropServices.HandleRef jarg1, ref string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetApplication_RegisterWidgetCreatingFunction", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RegisterWidgetCreatingFunction(IntPtr jarg1, ref string jarg2, IntPtr jarg3);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WidgetImpl.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WidgetImpl.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,19 +26,24 @@ namespace Tizen.NUI
         internal static partial class WidgetImpl
         {
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetImpl_New")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetImpl_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetImpl_SetContentInfo")]
-            public static extern void SetContentInfo(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetImpl_SetContentInfo", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetContentInfo(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetImpl_SetUsingKeyEvent")]
-            public static extern void SetUsingKeyEvent(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetImpl_SetUsingKeyEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetUsingKeyEvent(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetImpl_director_connect")]
-            public static extern void DirectorConnect(global::System.Runtime.InteropServices.HandleRef jarg1, Tizen.NUI.WidgetImpl.SwigDelegateWidgetImpl_0 delegate0, Tizen.NUI.WidgetImpl.SwigDelegateWidgetImpl_1 delegate1,
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetImpl_director_connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DirectorConnect(IntPtr jarg1, Tizen.NUI.WidgetImpl.SwigDelegateWidgetImpl_0 delegate0, Tizen.NUI.WidgetImpl.SwigDelegateWidgetImpl_1 delegate1,
                 Tizen.NUI.WidgetImpl.SwigDelegateWidgetImpl_2 delegate2, Tizen.NUI.WidgetImpl.SwigDelegateWidgetImpl_3 delegate3, Tizen.NUI.WidgetImpl.SwigDelegateWidgetImpl_4 delegate4, Tizen.NUI.WidgetImpl.SwigDelegateWidgetImpl_5 delegate5,
                 Tizen.NUI.WidgetImpl.SwigDelegateWidgetImpl_6 delegate6, Tizen.NUI.WidgetImpl.SwigDelegateWidgetImpl_7 delegate7);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WidgetView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WidgetView.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,139 +26,144 @@ namespace Tizen.NUI
         internal static partial class WidgetView
         {
             //for widget view
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_WIDGET_ID_get")]
-            public static extern int WidgetIdGet();
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_WIDGET_ID_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WidgetIdGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_INSTANCE_ID_get")]
-            public static extern int InstanceIdGet();
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_INSTANCE_ID_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InstanceIdGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_CONTENT_INFO_get")]
-            public static extern int ContentInfoGet();
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_CONTENT_INFO_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ContentInfoGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_TITLE_get")]
-            public static extern int TitleGet();
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_TITLE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int TitleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_UPDATE_PERIOD_get")]
-            public static extern int UpdatePeriodGet();
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_UPDATE_PERIOD_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int UpdatePeriodGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_PREVIEW_get")]
-            public static extern int PreviewGet();
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_PREVIEW_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PreviewGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_LOADING_TEXT_get")]
-            public static extern int LoadingTextGet();
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_LOADING_TEXT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int LoadingTextGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_WIDGET_STATE_FAULTED_get")]
-            public static extern int WidgetStateFaultedGet();
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_WIDGET_STATE_FAULTED_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int WidgetStateFaultedGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_PERMANENT_DELETE_get")]
-            public static extern int PermanentDeleteGet();
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_PERMANENT_DELETE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int PermanentDeleteGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_RETRY_TEXT_get")]
-            public static extern int RetryTextGet();
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_RETRY_TEXT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int RetryTextGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_EFFECT_get")]
-            public static extern int EffectGet();
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_EFFECT_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int EffectGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_KEEP_WIDGET_SIZE_get")]
-            public static extern int KeepWidgetSizeGet();
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Property_KEEP_WIDGET_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int KeepWidgetSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_New")]
-            public static extern global::System.IntPtr New(string jarg1, string jarg2, int jarg3, int jarg4, float jarg5);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(string jarg1, string jarg2, int jarg3, int jarg4, float jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_DownCast")]
-            public static extern global::System.IntPtr DownCast(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_DownCast", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DownCast(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_new_WidgetView__SWIG_1")]
-            public static extern global::System.IntPtr NewWidgetView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_new_WidgetView__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewWidgetView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_delete_WidgetView")]
-            public static extern void DeleteWidgetView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_delete_WidgetView", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWidgetView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_PauseWidget")]
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_PauseWidget", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool PauseWidget(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool PauseWidget(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_ResumeWidget")]
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_ResumeWidget", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool ResumeWidget(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool ResumeWidget(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_CancelTouchEvent")]
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_CancelTouchEvent", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool CancelTouchEvent(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool CancelTouchEvent(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_ActivateFaultedWidget")]
-            public static extern void ActivateFaultedWidget(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_ActivateFaultedWidget", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ActivateFaultedWidget(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_TerminateWidget")]
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_TerminateWidget", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool TerminateWidget(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool TerminateWidget(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_WidgetAddedSignal")]
-            public static extern global::System.IntPtr WidgetAddedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_WidgetAddedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr WidgetAddedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_WidgetDeletedSignal")]
-            public static extern global::System.IntPtr WidgetDeletedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_WidgetDeletedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr WidgetDeletedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_WidgetCreationAbortedSignal")]
-            public static extern global::System.IntPtr WidgetCreationAbortedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_WidgetCreationAbortedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr WidgetCreationAbortedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_WidgetContentUpdatedSignal")]
-            public static extern global::System.IntPtr WidgetContentUpdatedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_WidgetContentUpdatedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr WidgetContentUpdatedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_WidgetUpdatePeriodChangedSignal")]
-            public static extern global::System.IntPtr WidgetUpdatePeriodChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_WidgetUpdatePeriodChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr WidgetUpdatePeriodChangedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_WidgetFaultedSignal")]
-            public static extern global::System.IntPtr WidgetFaultedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_WidgetFaultedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr WidgetFaultedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool WidgetViewSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool WidgetViewSignalEmpty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewSignal_GetConnectionCount")]
-            public static extern uint WidgetViewSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint WidgetViewSignalGetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewSignal_Connect")]
-            public static extern void WidgetViewSignalConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void WidgetViewSignalConnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewSignal_Disconnect")]
-            public static extern void WidgetViewSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void WidgetViewSignalDisconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewSignal_Emit")]
-            public static extern void WidgetViewSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void WidgetViewSignalEmit(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_new_WidgetViewSignal")]
-            public static extern global::System.IntPtr NewWidgetViewSignal();
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_new_WidgetViewSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewWidgetViewSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_delete_WidgetViewSignal")]
-            public static extern void DeleteWidgetViewSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_delete_WidgetViewSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWidgetViewSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_PauseWidget")]
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_PauseWidget", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool WidgetView_PauseWidget(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool WidgetView_PauseWidget(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_ResumeWidget")]
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_ResumeWidget", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool WidgetView_ResumeWidget(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool WidgetView_ResumeWidget(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_TerminateWidget")]
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_TerminateWidget", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool WidgetView_TerminateWidget(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool WidgetView_TerminateWidget(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_delete_WidgetView")]
-            public static extern void delete_WidgetView(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_delete_WidgetView", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void delete_WidgetView(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_SWIGUpcast")]
-            public static extern global::System.IntPtr WidgetView_SWIGUpcast(global::System.IntPtr jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_SWIGUpcast", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr WidgetView_SWIGUpcast(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_WidgetAddedSignal")]
-            public static extern global::System.IntPtr WidgetView_WidgetAddedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_WidgetAddedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr WidgetView_WidgetAddedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_WidgetDeletedSignal")]
-            public static extern global::System.IntPtr WidgetView_WidgetDeletedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_WidgetDeletedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr WidgetView_WidgetDeletedSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WidgetViewManager.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WidgetViewManager.cs
@@ -15,6 +15,10 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -22,33 +26,38 @@ namespace Tizen.NUI
         internal static partial class WidgetViewManager
         {
             // For widget view manager
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewManager_New")]
-            public static extern global::System.IntPtr New(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewManager_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewManager_DownCast")]
-            public static extern global::System.IntPtr DownCast(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewManager_DownCast", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr DownCast(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_new_WidgetViewManager__SWIG_1")]
-            public static extern global::System.IntPtr NewWidgetViewManager(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_new_WidgetViewManager__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewWidgetViewManager(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewManager_Assign")]
-            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewManager_Assign", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Assign(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_delete_WidgetViewManager")]
-            public static extern void DeleteWidgetViewManager(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_delete_WidgetViewManager", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWidgetViewManager(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewManager_AddWidget")]
-            public static extern global::System.IntPtr AddWidget(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3, int jarg4, int jarg5, float jarg6);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewManager_AddWidget", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr AddWidget(IntPtr jarg1, string jarg2, string jarg3, int jarg4, int jarg5, float jarg6);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewManager_RemoveWidget")]
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewManager_RemoveWidget", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool RemoveWidget(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static partial bool RemoveWidget(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewManager_SWIGUpcast")]
-            public static extern global::System.IntPtr Upcast(global::System.IntPtr jarg1);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewManager_SWIGUpcast", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Upcast(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewManager_New")]
-            public static extern global::System.IntPtr WidgetViewManager_New(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewManager_New", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr WidgetViewManager_New(IntPtr jarg1, string jarg2);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
@@ -14,419 +14,429 @@
  * limitations under the License.
  *
  */
+
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Window
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_New__SWIG_0")]
-            public static extern global::System.IntPtr New(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, bool jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_New__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(IntPtr jarg1, string jarg2, [MarshalAs(UnmanagedType.U1)] bool jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_New__WithWindowData")]
-            public static extern global::System.IntPtr New(string name, string className, global::System.Runtime.InteropServices.HandleRef windowData);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_New__WithWindowData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(string name, string className, IntPtr windowData);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Window")]
-            public static extern void DeleteWindow(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Window", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWindow(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetClass")]
-            public static extern void SetClass(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetClass", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetClass(IntPtr jarg1, string jarg2, string jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Raise")]
-            public static extern void Raise(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Raise", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Raise(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Lower")]
-            public static extern void Lower(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Lower", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Lower(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Activate")]
-            public static extern void Activate(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Activate", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Activate(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_AddAvailableOrientation")]
-            public static extern void AddAvailableOrientation(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_AddAvailableOrientation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddAvailableOrientation(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_RemoveAvailableOrientation")]
-            public static extern void RemoveAvailableOrientation(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_RemoveAvailableOrientation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RemoveAvailableOrientation(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetPreferredOrientation")]
-            public static extern void SetPreferredOrientation(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetPreferredOrientation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPreferredOrientation(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetPreferredOrientation")]
-            public static extern int GetPreferredOrientation(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetPreferredOrientation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetPreferredOrientation(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetCurrentOrientation")]
-            public static extern int GetCurrentOrientation(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetCurrentOrientation", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetCurrentOrientation(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetAvailableOrientations")]
-            public static extern void SetAvailableOrientations(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetAvailableOrientations", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetAvailableOrientations(IntPtr jarg1, IntPtr jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetPositionSize")]
-            public static extern void SetPositionSize(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetPositionSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPositionSize(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusChangedSignal")]
-            public static extern global::System.IntPtr FocusChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusChangedSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr FocusChangedSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetAcceptFocus")]
-            public static extern void SetAcceptFocus(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetAcceptFocus", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetAcceptFocus(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IsFocusAcceptable")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IsFocusAcceptable", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsFocusAcceptable(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsFocusAcceptable(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Show")]
-            public static extern void Show(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Show", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Show(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hide")]
-            public static extern void Hide(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hide", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Hide(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IsVisible")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IsVisible", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsVisible(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsVisible(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetSupportedAuxiliaryHintCount")]
-            public static extern uint GetSupportedAuxiliaryHintCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetSupportedAuxiliaryHintCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetSupportedAuxiliaryHintCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetSupportedAuxiliaryHint")]
-            public static extern string GetSupportedAuxiliaryHint(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetSupportedAuxiliaryHint", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetSupportedAuxiliaryHint(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AddAuxiliaryHint")]
-            public static extern uint AddAuxiliaryHint(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AddAuxiliaryHint", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint AddAuxiliaryHint(IntPtr jarg1, string jarg2, string jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RemoveAuxiliaryHint")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RemoveAuxiliaryHint", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool RemoveAuxiliaryHint(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            public static partial bool RemoveAuxiliaryHint(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetAuxiliaryHintValue")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetAuxiliaryHintValue", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SetAuxiliaryHintValue(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, string jarg3);
+            public static partial bool SetAuxiliaryHintValue(IntPtr jarg1, uint jarg2, string jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetAuxiliaryHintValue")]
-            public static extern string GetAuxiliaryHintValue(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetAuxiliaryHintValue", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetAuxiliaryHintValue(IntPtr jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetAuxiliaryHintId")]
-            public static extern uint GetAuxiliaryHintId(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetAuxiliaryHintId", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetAuxiliaryHintId(IntPtr jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetInputRegion")]
-            public static extern void SetInputRegion(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetInputRegion", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetInputRegion(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetType")]
-            public static extern void SetType(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetType(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetType")]
-            public static extern int GetType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetType(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetNotificationLevel")]
-            public static extern int SetNotificationLevel(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetNotificationLevel", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SetNotificationLevel(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetNotificationLevel")]
-            public static extern int GetNotificationLevel(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetNotificationLevel", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetNotificationLevel(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetOpaqueState")]
-            public static extern void SetOpaqueState(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetOpaqueState", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetOpaqueState(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IsOpaqueState")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IsOpaqueState", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsOpaqueState(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool IsOpaqueState(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetScreenOffMode")]
-            public static extern int SetScreenOffMode(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetScreenOffMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SetScreenOffMode(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetScreenOffMode")]
-            public static extern int GetScreenOffMode(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetScreenOffMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetScreenOffMode(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetBrightness")]
-            public static extern int SetBrightness(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetBrightness", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int SetBrightness(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetBrightness")]
-            public static extern int GetBrightness(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetBrightness", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetBrightness(IntPtr jarg1);
 
             // For windows resized signal
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_ResizeSignal")]
-            public static extern global::System.IntPtr ResizeSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_ResizeSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr ResizeSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetSize")]
-            public static extern void SetSize(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetSize(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetSize")]
-            public static extern global::System.IntPtr GetSize(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetSize(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetPosition")]
-            public static extern void SetPosition(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPosition(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetPosition")]
-            public static extern global::System.IntPtr GetPosition(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetPosition", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetPosition(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetPartialUpdateEnabled")]
-            public static extern void SetPartialUpdateEnabled(global::System.Runtime.InteropServices.HandleRef window, bool enabled);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetPartialUpdateEnabled", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPartialUpdateEnabled(IntPtr window, [MarshalAs(UnmanagedType.U1)] bool enabled);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IsPartialUpdateEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IsPartialUpdateEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsPartialUpdateEnabled(global::System.Runtime.InteropServices.HandleRef window);
+            public static partial bool IsPartialUpdateEnabled(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetTransparency")]
-            public static extern global::System.IntPtr SetTransparency(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetTransparency", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr SetTransparency(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_FeedKey_Default_Window")]
-            public static extern void FeedKeyEvent(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_FeedKey_Default_Window", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FeedKeyEvent(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_FeedKey")]
-            public static extern void FeedKeyEvent(global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef keyEvent);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_FeedKey", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FeedKeyEvent(IntPtr window, IntPtr keyEvent);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_FeedTouch")]
-            public static extern void FeedTouchPoint(global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef touchPoint, int timeStamp);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_FeedTouch", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FeedTouchPoint(IntPtr window, IntPtr touchPoint, int timeStamp);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_FeedWheel")]
-            public static extern void FeedWheelEvent(global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef wheelEvent);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_FeedWheel", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FeedWheelEvent(IntPtr window, IntPtr wheelEvent);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_FeedHover")]
-            public static extern void FeedHoverEvent(global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef touchPoint);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_FeedHover", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void FeedHoverEvent(IntPtr window, IntPtr touchPoint);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Adaptor_RenderOnce")]
-            public static extern void RenderOnce(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Adaptor_RenderOnce", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RenderOnce(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Add")]
-            public static extern void Add(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Add", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Add(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Remove")]
-            public static extern void Remove(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Remove", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Remove(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetBackgroundColor")]
-            public static extern void SetBackgroundColor(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetBackgroundColor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetBackgroundColor(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetBackgroundColor")]
-            public static extern global::System.IntPtr GetBackgroundColor(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetBackgroundColor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetBackgroundColor(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetRootLayer")]
-            public static extern global::System.IntPtr GetRootLayer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetRootLayer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetRootLayer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetOverlayLayer")]
-            public static extern global::System.IntPtr GetOverlayLayer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetOverlayLayer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetOverlayLayer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_KeyEventSignal")]
-            public static extern global::System.IntPtr KeyEventSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_KeyEventSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr KeyEventSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InterceptKeyEventSignal")]
-            public static extern global::System.IntPtr InterceptKeyEventSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InterceptKeyEventSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr InterceptKeyEventSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GrabKeyTopmost")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GrabKeyTopmost", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GrabKeyTopmost(System.IntPtr Window, int DaliKey);
+            public static partial bool GrabKeyTopmost(System.IntPtr Window, int DaliKey);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UngrabKeyTopmost")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UngrabKeyTopmost", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool UngrabKeyTopmost(System.IntPtr Window, int DaliKey);
+            public static partial bool UngrabKeyTopmost(System.IntPtr Window, int DaliKey);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GrabKey")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GrabKey", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GrabKey(System.IntPtr Window, int DaliKey, int GrabMode);
+            public static partial bool GrabKey(System.IntPtr Window, int DaliKey, int GrabMode);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UngrabKey")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UngrabKey", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool UngrabKey(System.IntPtr Window, int DaliKey);
+            public static partial bool UngrabKey(System.IntPtr Window, int DaliKey);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Keyboard_SetRepeatInfo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Keyboard_SetRepeatInfo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SetKeyboardRepeatInfo(float rate, float delay);
+            public static partial bool SetKeyboardRepeatInfo(float rate, float delay);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Keyboard_GetRepeatInfo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Keyboard_GetRepeatInfo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetKeyboardRepeatInfo(out float rate, out float delay);
+            public static partial bool GetKeyboardRepeatInfo(out float rate, out float delay);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Keyboard_Set_Horizental_RepeatInfo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Keyboard_Set_Horizental_RepeatInfo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SetKeyboardHorizentalRepeatInfo(float rate, float delay);
+            public static partial bool SetKeyboardHorizentalRepeatInfo(float rate, float delay);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Keyboard_Get_Horizental_RepeatInfo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Keyboard_Get_Horizental_RepeatInfo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetKeyboardHorizentalRepeatInfo(out float rate, out float delay);
+            public static partial bool GetKeyboardHorizentalRepeatInfo(out float rate, out float delay);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Keyboard_Set_Vertical_RepeatInfo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Keyboard_Set_Vertical_RepeatInfo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SetKeyboardVerticalRepeatInfo(float rate, float delay);
+            public static partial bool SetKeyboardVerticalRepeatInfo(float rate, float delay);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Keyboard_Get_Vertical_RepeatInfo")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Keyboard_Get_Vertical_RepeatInfo", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetKeyboardVerticalRepeatInfo(out float rate, out float delay);
+            public static partial bool GetKeyboardVerticalRepeatInfo(out float rate, out float delay);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetNativeWindowHandler")]
-            public static extern System.IntPtr GetNativeWindowHandler(System.IntPtr Window);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetNativeWindowHandler", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial System.IntPtr GetNativeWindowHandler(System.IntPtr Window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetParent")]
-            public static extern void SetParent(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetParent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetParent(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetParent_With_Stack")]
-            public static extern void SetParentWithStack(global::System.Runtime.InteropServices.HandleRef child, global::System.Runtime.InteropServices.HandleRef parent, bool belowParent);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetParent_With_Stack", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetParentWithStack(IntPtr child, IntPtr parent, [MarshalAs(UnmanagedType.U1)] bool belowParent);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Unparent")]
-            public static extern void Unparent(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Unparent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Unparent(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetParent")]
-            public static extern global::System.IntPtr GetParent(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetParent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetParent(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetNativeId")]
-            public static extern int GetNativeId(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetNativeId", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetNativeId(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_EnableFloatingMode")]
-            public static extern void EnableFloatingMode(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_EnableFloatingMode", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void EnableFloatingMode(IntPtr jarg1, [MarshalAs(UnmanagedType.U1)] bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IsFloatingModeEnabled")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IsFloatingModeEnabled", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsFloatingModeEnabled(global::System.Runtime.InteropServices.HandleRef window);
+            public static partial bool IsFloatingModeEnabled(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_RequestMoveToServer")]
-            public static extern void RequestMoveToServer(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_RequestMoveToServer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RequestMoveToServer(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_RequestResizeToServer")]
-            public static extern void RequestResizeToServer(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_RequestResizeToServer", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void RequestResizeToServer(IntPtr jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetWindow")]
-            public static extern global::System.IntPtr Get(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetWindow", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Get(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IncludeInputRegion")]
-            public static extern void IncludeInputRegion(global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef inputRegion);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IncludeInputRegion", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void IncludeInputRegion(IntPtr window, IntPtr inputRegion);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_ExcludeInputRegion")]
-            public static extern void ExcludeInputRegion(global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef inputRegion);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_ExcludeInputRegion", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void ExcludeInputRegion(IntPtr window, IntPtr inputRegion);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Maximize")]
-            public static extern void Maximize(global::System.Runtime.InteropServices.HandleRef window, bool maximize);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Maximize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Maximize(IntPtr window, [MarshalAs(UnmanagedType.U1)] bool maximize);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IsMaximized")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IsMaximized", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsMaximized(global::System.Runtime.InteropServices.HandleRef window);
+            public static partial bool IsMaximized(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Set_Maximum_Size")]
-            public static extern void SetMaximumSize(global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef size);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Set_Maximum_Size", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMaximumSize(IntPtr window, IntPtr size);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Minimize")]
-            public static extern void Minimize(global::System.Runtime.InteropServices.HandleRef window, bool minimize);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Minimize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Minimize(IntPtr window, [MarshalAs(UnmanagedType.U1)] bool minimize);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IsMinimized")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IsMinimized", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsMinimized(global::System.Runtime.InteropServices.HandleRef window);
+            public static partial bool IsMinimized(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Set_Minimum_Size")]
-            public static extern void SetMimimumSize(global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef size);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Set_Minimum_Size", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetMimimumSize(IntPtr window, IntPtr size);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Maximize_With_RestoreSize")]
-            public static extern void MaximizeWithRestoreSize(global::System.Runtime.InteropServices.HandleRef window, bool maximize, global::System.Runtime.InteropServices.HandleRef size);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Maximize_With_RestoreSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void MaximizeWithRestoreSize(IntPtr window, [MarshalAs(UnmanagedType.U1)] bool maximize, IntPtr size);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetLayout")]
-            public static extern void SetLayout(global::System.Runtime.InteropServices.HandleRef window, uint numCols, uint numRows, uint column, uint row, uint colSpan, uint rowSpan);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetLayout", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetLayout(IntPtr window, uint numCols, uint numRows, uint column, uint row, uint colSpan, uint rowSpan);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IsWindowRotating")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IsWindowRotating", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsWindowRotating(global::System.Runtime.InteropServices.HandleRef window);
+            public static partial bool IsWindowRotating(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InternalRetrievingLastKeyEvent")]
-            public static extern void InternalRetrievingLastKeyEvent(global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef key);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InternalRetrievingLastKeyEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void InternalRetrievingLastKeyEvent(IntPtr window, IntPtr key);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InternalRetrievingLastTouchEvent")]
-            public static extern void InternalRetrievingLastTouchEvent(global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef touch);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InternalRetrievingLastTouchEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void InternalRetrievingLastTouchEvent(IntPtr window, IntPtr touch);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InternalRetrievingLastHoverEvent")]
-            public static extern void InternalRetrievingLastHoverEvent(global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef hover);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InternalRetrievingLastHoverEvent", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void InternalRetrievingLastHoverEvent(IntPtr window, IntPtr hover);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InternalRetrievingLastPanGestureState")]
-            public static extern int InternalRetrievingLastPanGestureState(global::System.Runtime.InteropServices.HandleRef window);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InternalRetrievingLastPanGestureState", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int InternalRetrievingLastPanGestureState(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetNeedsRotationCompletedAcknowledgement")]
-            public static extern void SetNeedsRotationCompletedAcknowledgement(global::System.Runtime.InteropServices.HandleRef window, bool needAcknowledgement);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetNeedsRotationCompletedAcknowledgement", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetNeedsRotationCompletedAcknowledgement(IntPtr window, [MarshalAs(UnmanagedType.U1)] bool needAcknowledgement);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SendRotationCompletedAcknowledgement")]
-            public static extern void SendRotationCompletedAcknowledgement(global::System.Runtime.InteropServices.HandleRef window);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SendRotationCompletedAcknowledgement", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SendRotationCompletedAcknowledgement(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_KeepRendering")]
-            public static extern void KeepRendering(global::System.Runtime.InteropServices.HandleRef window, float durationSeconds);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_KeepRendering", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void KeepRendering(IntPtr window, float durationSeconds);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_PointerConstraintsLock")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_PointerConstraintsLock", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool PointerConstraintsLock(global::System.Runtime.InteropServices.HandleRef window);
+            public static partial bool PointerConstraintsLock(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_PointerConstraintsUnlock")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_PointerConstraintsUnlock", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool PointerConstraintsUnlock(global::System.Runtime.InteropServices.HandleRef window);
+            public static partial bool PointerConstraintsUnlock(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_LockedPointerRegionSet")]
-            public static extern void LockedPointerRegionSet(global::System.Runtime.InteropServices.HandleRef window, int x, int y, int w, int h);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_LockedPointerRegionSet", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LockedPointerRegionSet(IntPtr window, int x, int y, int w, int h);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_LockedPointerCursorPositionHintSet")]
-            public static extern void LockedPointerCursorPositionHintSet(global::System.Runtime.InteropServices.HandleRef window, int x, int y);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_LockedPointerCursorPositionHintSet", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void LockedPointerCursorPositionHintSet(IntPtr window, int x, int y);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_PointerWarp")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_PointerWarp", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool PointerWarp(global::System.Runtime.InteropServices.HandleRef window, int x, int y);
+            public static partial bool PointerWarp(IntPtr window, int x, int y);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_CursorVisibleSet")]
-            public static extern void CursorVisibleSet(global::System.Runtime.InteropServices.HandleRef window, bool visible);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_CursorVisibleSet", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void CursorVisibleSet(IntPtr window, [MarshalAs(UnmanagedType.U1)] bool visible);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_KeyboardGrab")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_KeyboardGrab", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool KeyboardGrab(global::System.Runtime.InteropServices.HandleRef window, uint deviceSubclass);
+            public static partial bool KeyboardGrab(IntPtr window, uint deviceSubclass);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_KeyboardUnGrab")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_KeyboardUnGrab", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool KeyboardUnGrab(global::System.Runtime.InteropServices.HandleRef window);
+            public static partial bool KeyboardUnGrab(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetFullScreen")]
-            public static extern void SetFullScreen(global::System.Runtime.InteropServices.HandleRef window, bool fullscreen);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetFullScreen", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFullScreen(IntPtr window, [MarshalAs(UnmanagedType.U1)] bool fullscreen);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetFullScreen")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetFullScreen", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetFullScreen(global::System.Runtime.InteropServices.HandleRef window);
+            public static partial bool GetFullScreen(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetModal")]
-            public static extern void SetModal(global::System.Runtime.InteropServices.HandleRef window, bool modal);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetModal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetModal(IntPtr window, [MarshalAs(UnmanagedType.U1)] bool modal);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IsModal")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IsModal", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsModal(global::System.Runtime.InteropServices.HandleRef window);
+            public static partial bool IsModal(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetAlwaysOnTop")]
-            public static extern void SetAlwaysOnTop(global::System.Runtime.InteropServices.HandleRef window, bool alwaysTop);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetAlwaysOnTop", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetAlwaysOnTop(IntPtr window, [MarshalAs(UnmanagedType.U1)] bool alwaysTop);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IsAlwaysOnTop")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IsAlwaysOnTop", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsAlwaysOnTop(global::System.Runtime.InteropServices.HandleRef window);
+            public static partial bool IsAlwaysOnTop(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetBottom")]
-            public static extern void SetBottom(global::System.Runtime.InteropServices.HandleRef window, bool enable);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetBottom", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetBottom(IntPtr window, [MarshalAs(UnmanagedType.U1)] bool enable);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IsBottom")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IsBottom", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsBottom(global::System.Runtime.InteropServices.HandleRef window);
+            public static partial bool IsBottom(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_RelativeMotionGrab")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_RelativeMotionGrab", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool RelativeMotionGrab(global::System.Runtime.InteropServices.HandleRef window, uint boundary);
+            public static partial bool RelativeMotionGrab(IntPtr window, uint boundary);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_RelativeMotionUnGrab")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_RelativeMotionUnGrab", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool RelativeMotionUnGrab(global::System.Runtime.InteropServices.HandleRef window);
+            public static partial bool RelativeMotionUnGrab(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetBlur")]
-            public static extern void SetBlur(global::System.Runtime.InteropServices.HandleRef window, global::System.IntPtr blurInfo);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetBlur", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetBlur(IntPtr window, global::System.IntPtr blurInfo);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetBlur")]
-            public static extern global::System.IntPtr GetBlur(global::System.Runtime.InteropServices.HandleRef window);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetBlur", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetBlur(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetInsets__SWIG_0")]
-            public static extern global::System.IntPtr GetInsets(global::System.Runtime.InteropServices.HandleRef window);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetInsets__SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetInsets(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetInsets__SWIG_1")]
-            public static extern global::System.IntPtr GetInsets(global::System.Runtime.InteropServices.HandleRef window, int insetsFlags);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetInsets__SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetInsets(IntPtr window, int insetsFlags);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetScreen")]
-            public static extern void SetScreen(global::System.Runtime.InteropServices.HandleRef window, string name);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetScreen", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetScreen(IntPtr window, string name);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetScreen")]
-            public static extern string GetScreen(global::System.Runtime.InteropServices.HandleRef window);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetScreen", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetScreen(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetFrontBufferRendering")]
-            public static extern void SetFrontBufferRendering(global::System.Runtime.InteropServices.HandleRef window, bool enable);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetFrontBufferRendering", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFrontBufferRendering(IntPtr window, [MarshalAs(UnmanagedType.U1)] bool enable);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetFrontBufferRendering")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetFrontBufferRendering", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetFrontBufferRendering(global::System.Runtime.InteropServices.HandleRef window);
+            public static partial bool GetFrontBufferRendering(IntPtr window);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowAccessibilityHighlightSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowAccessibilityHighlightSignal.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,9 @@
  *
  */
 
-using System;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -23,24 +25,29 @@ namespace Tizen.NUI
     {
         internal static partial class WindowAccessibilityHighlightSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Accessibility_Highlight_Signal")]
-            public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef window);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Accessibility_Highlight_Signal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetSignal(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Accessibility_Highlight_Signal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Accessibility_Highlight_Signal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef signalType);
+            public static partial bool Empty(IntPtr signalType);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Accessibility_Highlight_Signal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef signalType);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Accessibility_Highlight_Signal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr signalType);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Accessibility_Highlight_Signal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef callback);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Accessibility_Highlight_Signal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr signalType, IntPtr callback);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Accessibility_Highlight_Signal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef callback);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Accessibility_Highlight_Signal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr signalType, IntPtr callback);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Accessibility_Highlight_Signal_delete")]
-            public static extern void DeleteSignal(global::System.Runtime.InteropServices.HandleRef signalType);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Accessibility_Highlight_Signal_delete", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteSignal(IntPtr signalType);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowAuxiliaryMessageSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowAuxiliaryMessageSignal.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,27 +15,36 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WindowAuxiliaryMessageSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Auxiliary_Message_Signal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Auxiliary_Message_Signal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Auxiliary_Message_Signal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Auxiliary_Message_Signal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Auxiliary_Message_Signal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Auxiliary_Message_Signal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Auxiliary_Message_Signal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Auxiliary_Message_Signal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Auxiliary_Message_Signal")]
-            public static extern global::System.IntPtr Get(global::System.Runtime.InteropServices.HandleRef window);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Auxiliary_Message_Signal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Get(IntPtr window);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowBlurInfo.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowBlurInfo.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2024 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,9 @@
  *
  */
 
-using System.Runtime.InteropServices;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -23,50 +25,53 @@ namespace Tizen.NUI
     {
         internal static partial class WindowBlurInfo
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowBlurInfo")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowBlurInfo", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowBlurInfo_SWIG_0")]
-            public static extern global::System.IntPtr New(int nuiBlurType, int nuiBlurRadius, int nuiCornerRadius);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowBlurInfo_SWIG_0", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int nuiBlurType, int nuiBlurRadius, int nuiCornerRadius);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowBlurInfo_SWIG_1")]
-            public static extern global::System.IntPtr New(int nuiBlurType, int nuiBlurRadius);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowBlurInfo_SWIG_1", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int nuiBlurType, int nuiBlurRadius);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowBlurInfo_SWIG_2")]
-            public static extern global::System.IntPtr New(int nuiBlurType, int nuiBlurRadius, int nuiCornerRadius, global::System.IntPtr nuiDimInfo);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowBlurInfo_SWIG_2", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int nuiBlurType, int nuiBlurRadius, int nuiCornerRadius, global::System.IntPtr nuiDimInfo);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowBlurInfo")]
-            public static extern void DeleteWindowBlurInfo(global::System.IntPtr nuiWindowBlurInfo);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowBlurInfo", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWindowBlurInfo(global::System.IntPtr nuiWindowBlurInfo);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowBlurInfo_GetBlurType")]
-            public static extern int GetBlurType(global::System.IntPtr nuiWindowBlurInfo);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowBlurInfo_GetBlurType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetBlurType(global::System.IntPtr nuiWindowBlurInfo);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowBlurInfo_GetBlurRadius")]
-            public static extern int GetBlurRadius(global::System.IntPtr nuiWindowBlurInfo);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowBlurInfo_GetBlurRadius", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetBlurRadius(global::System.IntPtr nuiWindowBlurInfo);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowBlurInfo_GetBackgroundCornerRadius")]
-            public static extern int GetBackgroundCornerRadius(global::System.IntPtr nuiWindowBlurInfo);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowBlurInfo_GetBackgroundCornerRadius", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetBackgroundCornerRadius(global::System.IntPtr nuiWindowBlurInfo);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowBlurInfo_SetBehindBlurDimInfo")]
-            public static extern void SetBehindBlurDimInfo(global::System.IntPtr nuiWindowBlurInfo, global::System.IntPtr nuiDimInfo);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowBlurInfo_SetBehindBlurDimInfo", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetBehindBlurDimInfo(global::System.IntPtr nuiWindowBlurInfo, global::System.IntPtr nuiDimInfo);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowBlurInfo_GetBehindBlurDimInfo")]
-            public static extern global::System.IntPtr GetBehindBlurDimInfo(global::System.IntPtr nuiWindowBlurInfo);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowBlurInfo_GetBehindBlurDimInfo", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetBehindBlurDimInfo(global::System.IntPtr nuiWindowBlurInfo);
         }
 
         internal static partial class WindowDimInfo
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowDimInfo")]
-            public static extern global::System.IntPtr New(int enable, global::System.IntPtr dimColor);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowDimInfo", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New(int enable, global::System.IntPtr dimColor);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowDimInfo")]
-            public static extern void DeleteWindowDimInfo(global::System.IntPtr nuiWindowDimInfo);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowDimInfo", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWindowDimInfo(global::System.IntPtr nuiWindowDimInfo);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowDimInfo_GetIsEnabled")]
-            public static extern int GetIsEnabled(global::System.IntPtr nuiWindowDimInfo);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowDimInfo_GetIsEnabled", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetIsEnabled(global::System.IntPtr nuiWindowDimInfo);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowDimInfo_GetDimColor")]
-            public static extern global::System.IntPtr GetDimColor(global::System.IntPtr nuiWindowDimInfo);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowDimInfo_GetDimColor", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetDimColor(global::System.IntPtr nuiWindowDimInfo);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowData.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowData.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2023 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,9 @@
  *
  */
 
-using System.Runtime.InteropServices;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -23,44 +25,47 @@ namespace Tizen.NUI
     {
         internal static partial class WindowData
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowData")]
-            public static extern global::System.IntPtr New();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr New();
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowData")]
-            public static extern void DeleteWindowData(HandleRef nuiWindowData);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowData", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWindowData(IntPtr nuiWindowData);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_SetPositionSize")]
-            public static extern void SetPositionSize(HandleRef nuiWindowData, HandleRef nuiPositionSize);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_SetPositionSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetPositionSize(IntPtr nuiWindowData, IntPtr nuiPositionSize);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_GetPositionSize")]
-            public static extern global::System.IntPtr GetPositionSize(HandleRef nuiWindowData);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_GetPositionSize", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetPositionSize(IntPtr nuiWindowData);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_SetWindowType")]
-            public static extern void SetWindowType(HandleRef nuiWindowData, int nuiWindowType);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_SetWindowType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetWindowType(IntPtr nuiWindowData, int nuiWindowType);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_GetWindowType")]
-            public static extern int GetWindowType(HandleRef nuiWindowData);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_GetWindowType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int GetWindowType(IntPtr nuiWindowData);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_SetTransparency")]
-            public static extern void SetTransparency(HandleRef nuiWindowData, bool nuiTransparency);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_SetTransparency", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetTransparency(IntPtr nuiWindowData, [MarshalAs(UnmanagedType.U1)] bool nuiTransparency);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_GetTransparency")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_GetTransparency", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool GetTransparency(HandleRef nuiWindowData);
+            public static partial bool GetTransparency(IntPtr nuiWindowData);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_SetFrontBufferRendering")]
-            public static extern void SetFrontBufferRendering(HandleRef nuiWindowData, bool enable);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_SetFrontBufferRendering", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetFrontBufferRendering(IntPtr nuiWindowData, [MarshalAs(UnmanagedType.U1)] bool enable);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_GetFrontBufferRendering")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_GetFrontBufferRendering", StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool GetFrontBufferRendering(HandleRef nuiWindowData);
+            public static partial bool GetFrontBufferRendering(IntPtr nuiWindowData);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_SetScreen")]
-            public static extern void SetScreen(HandleRef nuiWindowData, string screenName);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_SetScreen", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void SetScreen(IntPtr nuiWindowData, string screenName);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_GetScreen")]
-            public static extern string GetScreen(HandleRef nuiWindowData);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_GetScreen", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string GetScreen(IntPtr nuiWindowData);
 
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowEffectEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowEffectEventSignal.cs
@@ -15,34 +15,43 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WindowTransitionEffectSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_EventSignal")]
-            public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_EventSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_Event_Signal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_Event_Signal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_Event_Signal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_Event_Signal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_Event_Signal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_Event_Signal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_Event_Signal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_Event_Signal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_Event_Signal_Emit")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_Event_Signal_Emit", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3, int jarg4);
+            public static partial bool Emit(IntPtr jarg1, IntPtr jarg2, int jarg3, int jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_Event_Signal_delete")]
-            public static extern void DeleteSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_Event_Signal_delete", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowFocusSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowFocusSignalType.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WindowFocusSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowFocusSignalType_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowFocusSignalType_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowFocusSignalType_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowFocusSignalType_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowFocusSignalType_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowFocusSignalType_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowFocusSignalType_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowFocusSignalType_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowFocusSignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef window, bool focusIn);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowFocusSignalType_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr signalType, IntPtr window, [MarshalAs(UnmanagedType.U1)] bool focusIn);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowFocusSignalType")]
-            public static extern global::System.IntPtr NewWindowFocusSignalType();
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowFocusSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr NewWindowFocusSignalType();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowFocusSignalType")]
-            public static extern void DeleteWindowFocusSignalType(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowFocusSignalType", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWindowFocusSignalType(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowInsetsChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowInsetsChangedSignal.cs
@@ -15,7 +15,9 @@
  *
  */
 
-using System.Runtime.InteropServices;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -23,21 +25,24 @@ namespace Tizen.NUI
     {
         internal static partial class WindowInsetsChangedSignalType
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InsetsChanged_Signal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InsetsChanged_Signal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InsetsChanged_Signal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InsetsChanged_Signal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InsetsChanged_Signal_Connect")]
-            public static extern void Connect(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InsetsChanged_Signal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InsetsChanged_Signal_Disconnect")]
-            public static extern void Disconnect(HandleRef jarg1, HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InsetsChanged_Signal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InsetsChanged_Signal")]
-            public static extern global::System.IntPtr Get(HandleRef window);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InsetsChanged_Signal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Get(IntPtr window);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowInternal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowInternal.cs
@@ -15,23 +15,27 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
-    using global::System;
-    using global::System.Runtime.InteropServices;
-
     internal static partial class Interop
     {
         internal static partial class WindowInternal
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetNativeHandle")]
-            public static extern IntPtr WindowGetNativeHandle(HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetNativeHandle", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr WindowGetNativeHandle(IntPtr jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_AddFrameRenderedCallback")]
-            public static extern void AddFrameRenderedCallback(HandleRef nuiWindow, HandleRef nuiCallbakc, int nuiFrameId);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_AddFrameRenderedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddFrameRenderedCallback(IntPtr nuiWindow, IntPtr nuiCallbakc, int nuiFrameId);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_AddFramePresentedCallback")]
-            public static extern void AddFramePresentedCallback(HandleRef nuiWindow, HandleRef nuiCallbakc, int nuiFrameId);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_AddFramePresentedCallback", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void AddFramePresentedCallback(IntPtr nuiWindow, IntPtr nuiCallbakc, int nuiFrameId);
         }
     }
 }
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowMouseInOutEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowMouseInOutEventSignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WindowMouseInOutEventSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal")]
-            public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef mouseEvent);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr signalType, IntPtr window, IntPtr mouseEvent);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowMouseInOutEventSignal")]
-            public static extern void DeleteWindowMouseInOutEventSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowMouseInOutEventSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWindowMouseInOutEventSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowMouseRelativeEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowMouseRelativeEventSignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WindowMouseRelativeEventSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseRelativeEventSignal")]
-            public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseRelativeEventSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseRelativeEventSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseRelativeEventSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseRelativeEventSignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseRelativeEventSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseRelativeEventSignal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseRelativeEventSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseRelativeEventSignal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseRelativeEventSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseRelativeEventSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef mouseEvent);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseRelativeEventSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr signalType, IntPtr window, IntPtr mouseEvent);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowMouseRelativeEventSignal")]
-            public static extern void DeleteWindowMouseRelativeEventSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowMouseRelativeEventSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWindowMouseRelativeEventSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowMoveCompletedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowMoveCompletedSignal.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2023 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,34 +15,43 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WindowMoveCompletedSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Move_Completed_Signal")]
-            public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Move_Completed_Signal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Move_Completed_Signal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Move_Completed_Signal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Move_Completed_Signal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Move_Completed_Signal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Move_Completed_Signal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Move_Completed_Signal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Move_Completed_Signal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Move_Completed_Signal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Move_Completed_Signal_Emit")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Move_Completed_Signal_Emit", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            public static partial bool Emit(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Move_Completed_Signal")]
-            public static extern void DeleteSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Move_Completed_Signal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowMovedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowMovedSignal.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,34 +15,43 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WindowMovedSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Moved_Signal")]
-            public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Moved_Signal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Moved_Signal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Moved_Signal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Moved_Signal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Moved_Signal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Moved_Signal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Moved_Signal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Moved_Signal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Moved_Signal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Moved_Signal_Emit")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Moved_Signal_Emit", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            public static partial bool Emit(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Moved_Signal")]
-            public static extern void DeleteSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Moved_Signal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowOrientationChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowOrientationChangedSignal.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,34 +15,43 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WindowOrientationChangedSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Orientation_Changed_Signal")]
-            public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Orientation_Changed_Signal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Orientation_Changed_Signal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Orientation_Changed_Signal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Orientation_Changed_Signal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Orientation_Changed_Signal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Orientation_Changed_Signal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Orientation_Changed_Signal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Orientation_Changed_Signal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Orientation_Changed_Signal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Orientation_Changed_Signal_Emit")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Orientation_Changed_Signal_Emit", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3);
+            public static partial bool Emit(IntPtr jarg1, IntPtr jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Orientation_Changed_Signal")]
-            public static extern void DeleteSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Orientation_Changed_Signal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowPointerConstraintsSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowPointerConstraintsSignal.cs
@@ -15,33 +15,42 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WindowPointerConstraintsSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal")]
-            public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef mouseEvent);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr signalType, IntPtr window, IntPtr mouseEvent);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowPointerConstraintsEventSignal")]
-            public static extern void DeleteWindowPointerConstraintsSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowPointerConstraintsEventSignal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWindowPointerConstraintsSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowResizeCompletedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowResizeCompletedSignal.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2023 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,34 +15,43 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WindowResizeCompletedSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Resize_Completed_Signal")]
-            public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Resize_Completed_Signal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetSignal(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Resize_Completed_Signal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Resize_Completed_Signal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static partial bool Empty(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Resize_Completed_Signal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Resize_Completed_Signal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Resize_Completed_Signal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Resize_Completed_Signal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Resize_Completed_Signal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Resize_Completed_Signal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr jarg1, IntPtr jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Resize_Completed_Signal_Emit")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Resize_Completed_Signal_Emit", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+            public static partial bool Emit(IntPtr jarg1, IntPtr jarg2, IntPtr jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Resize_Completed_Signal")]
-            public static extern void DeleteSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Resize_Completed_Signal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteSignal(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowVisibilityChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowVisibilityChangedSignal.cs
@@ -15,7 +15,9 @@
  *
  */
 
-using System;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
 
 namespace Tizen.NUI
 {
@@ -23,27 +25,32 @@ namespace Tizen.NUI
     {
         internal static partial class WindowVisibilityChangedSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal")]
-            public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef window);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr GetSignal(IntPtr window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal_Empty")]
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal_Empty", StringMarshalling = StringMarshalling.Utf8)]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef signalType);
+            public static partial bool Empty(IntPtr signalType);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal_GetConnectionCount")]
-            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef signalType);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal_GetConnectionCount", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint GetConnectionCount(IntPtr signalType);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal_Connect")]
-            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef callback);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal_Connect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Connect(IntPtr signalType, IntPtr callback);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal_Disconnect")]
-            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef callback);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal_Disconnect", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Disconnect(IntPtr signalType, IntPtr callback);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef window, bool visibility);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal_Emit", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void Emit(IntPtr signalType, IntPtr window, [MarshalAs(UnmanagedType.U1)] bool visibility);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal_delete")]
-            public static extern void DeleteSignal(global::System.Runtime.InteropServices.HandleRef signalType);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal_delete", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteSignal(IntPtr signalType);
         }
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/ManualPINVOKE.cs
+++ b/src/Tizen.NUI/src/internal/Interop/ManualPINVOKE.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2019 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,62 +15,71 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     class NDalicManualPINVOKE
     {
-        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_HIDDENINPUT_PROPERTY_MODE_get")]
-        public static extern int HiddeninputPropertyModeGet();
+        [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_HIDDENINPUT_PROPERTY_MODE_get", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int HiddeninputPropertyModeGet();
 
-        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_HIDDENINPUT_PROPERTY_SUBSTITUTE_CHARACTER_get")]
-        public static extern int HiddeninputPropertySubstituteCharacterGet();
+        [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_HIDDENINPUT_PROPERTY_SUBSTITUTE_CHARACTER_get", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int HiddeninputPropertySubstituteCharacterGet();
 
-        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_HIDDENINPUT_PROPERTY_SUBSTITUTE_COUNT_get")]
-        public static extern int HiddeninputPropertySubstituteCountGet();
+        [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_HIDDENINPUT_PROPERTY_SUBSTITUTE_COUNT_get", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int HiddeninputPropertySubstituteCountGet();
 
-        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_HIDDENINPUT_PROPERTY_SHOW_LAST_CHARACTER_DURATION_get")]
-        public static extern int HiddeninputPropertyShowLastCharacterDurationGet();
+        [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_HIDDENINPUT_PROPERTY_SHOW_LAST_CHARACTER_DURATION_get", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int HiddeninputPropertyShowLastCharacterDurationGet();
 
-        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_POPUP_MAX_SIZE_get")]
-        public static extern int TextSelectionPopupPropertyPopupMaxSizeGet();
+        [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_POPUP_MAX_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int TextSelectionPopupPropertyPopupMaxSizeGet();
 
-        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_OPTION_DIVIDER_SIZE_get")]
-        public static extern int TextSelectionPopupPropertyOptionDividerSizeGet();
+        [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_OPTION_DIVIDER_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int TextSelectionPopupPropertyOptionDividerSizeGet();
 
-        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_OPTION_DIVIDER_PADDING_get")]
-        public static extern int TextSelectionPopupPropertyOptionDividerPaddingGet();
+        [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_OPTION_DIVIDER_PADDING_get", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int TextSelectionPopupPropertyOptionDividerPaddingGet();
 
-        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_LABEL_MINIMUM_SIZE_get")]
-        public static extern int TextSelectionPopupPropertyLabelMinimumSizeGet();
+        [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_LABEL_MINIMUM_SIZE_get", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int TextSelectionPopupPropertyLabelMinimumSizeGet();
 
-        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_LABEL_PADDING_get")]
-        public static extern int TextSelectionPopupPropertyLabelPaddingGet();
+        [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_LABEL_PADDING_get", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int TextSelectionPopupPropertyLabelPaddingGet();
 
-        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_LABEL_TEXT_VISUAL_get")]
-        public static extern int TextSelectionPopupPropertyLabelTextVisualGet();
+        [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_LABEL_TEXT_VISUAL_get", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int TextSelectionPopupPropertyLabelTextVisualGet();
 
-        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_ENABLE_SCROLL_BAR_get")]
-        public static extern int TextSelectionPopupPropertyEnableScrollBarGet();
+        [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_ENABLE_SCROLL_BAR_get", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int TextSelectionPopupPropertyEnableScrollBarGet();
 
-        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_POPUP_DIVIDER_COLOR_get")]
-        public static extern int TextSelectionPopupPropertyPopupDividerColorGet();
+        [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_POPUP_DIVIDER_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int TextSelectionPopupPropertyPopupDividerColorGet();
 
-        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_POPUP_PRESSED_COLOR_get")]
-        public static extern int TextSelectionPopupPropertyPopupPressedColorGet();
+        [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_POPUP_PRESSED_COLOR_get", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int TextSelectionPopupPropertyPopupPressedColorGet();
 
-        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_POPUP_PRESSED_CORNER_RADIUS_get")]
-        public static extern int TextSelectionPopupPropertyPopupPressedCornerRadiusGet();
+        [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_POPUP_PRESSED_CORNER_RADIUS_get", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int TextSelectionPopupPropertyPopupPressedCornerRadiusGet();
 
-        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_POPUP_FADE_IN_DURATION_get")]
-        public static extern int TextSelectionPopupPropertyPopupFadeInDurationGet();
+        [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_POPUP_FADE_IN_DURATION_get", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int TextSelectionPopupPropertyPopupFadeInDurationGet();
 
-        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_POPUP_FADE_OUT_DURATION_get")]
-        public static extern int TextSelectionPopupPropertyPopupFadeOutDurationGet();
+        [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_POPUP_FADE_OUT_DURATION_get", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int TextSelectionPopupPropertyPopupFadeOutDurationGet();
 
-        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_BACKGROUND_get")]
-        public static extern int TextSelectionPopupPropertyPopupBackgroundGet();
+        [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_BACKGROUND_get", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int TextSelectionPopupPropertyPopupBackgroundGet();
 
-        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_BACKGROUND_BORDER_get")]
-        public static extern int TextSelectionPopupPropertyPopupBackgroundBorderGet();
+        [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextSelectionPopup_Property_BACKGROUND_BORDER_get", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial int TextSelectionPopupPropertyPopupBackgroundBorderGet();
     }
 }
+
+
+
+
+

--- a/src/Tizen.NUI/src/internal/Interop/NDalicPINVOKE.cs
+++ b/src/Tizen.NUI/src/internal/Interop/NDalicPINVOKE.cs
@@ -15,9 +15,11 @@
  *
  */
 
-using System;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+using global::System.ComponentModel;
+using global::System.Runtime.CompilerServices;
 
 namespace Tizen.NUI
 {

--- a/src/Tizen.NUI/src/internal/Interop/WebHttpRequestInterceptorPtr.cs
+++ b/src/Tizen.NUI/src/internal/Interop/WebHttpRequestInterceptorPtr.cs
@@ -15,17 +15,26 @@
  *
  */
 
+using global::System;
+using global::System.Runtime.InteropServices;
+using global::System.Runtime.InteropServices.Marshalling;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class WebHttpRequestInterceptorPtr
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebRequestInterceptorPtr")]
-            public static extern void DeleteWebHttpRequestInterceptorPtr(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebRequestInterceptorPtr", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void DeleteWebHttpRequestInterceptorPtr(IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptorPtr_Get")]
-            public static extern global::System.IntPtr Get(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [LibraryImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptorPtr_Get", StringMarshalling = StringMarshalling.Utf8)]
+            public static partial global::System.IntPtr Get(IntPtr jarg1);
         }
     }
 }
+
+
+
+
+


### PR DESCRIPTION
1. Add `global::System.Runtime.InteropServices` at top of Interop files so reduce length of codes.
2. Change input parameter of native bind function input from `HandleRef` to `IntPtr`. Also change the bind function caller use IntPtr.
3. Change extern to partial for Iterop classes, and change `DllImport` to `LibraryImport`.
4. Use `StringMarshalling = StringMarshalling.Utf8` keyword for eacy library import.
5. Add `[MarshalAs(UnmanagedType.U1)]` if native bind function's input parameter is bool type.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
