### PR TITLE
[NUI](Window) Add API to request rendering forcibly.

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowInternal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowInternal.cs
@@ -32,6 +32,9 @@ namespace Tizen.NUI
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_AddFramePresentedCallback")]
             public static extern void AddFramePresentedCallback(HandleRef nuiWindow, HandleRef nuiCallbakc, int nuiFrameId);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetForceRendering")]
+            public static extern void SetForceRendering(HandleRef nuiWindow, uint frameCount);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -2547,6 +2547,18 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Request to rendering forcibly for this window
+        /// </summary>
+        /// <param name="frameCount">The number of frames to render forcibly.</param>
+        /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetForceRendering(uint frameCount)
+        {
+            Interop.WindowInternal.SetForceRendering(SwigCPtr, frameCount);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
         /// Search through this Window for a Layer with the given unique ID.
         /// </summary>
         /// <param name="id">The ID of the Layer to find.</param>


### PR DESCRIPTION
Support API to make the window render forcibly.

KeepRendering might skip render actions if their is nothing upated. And RenderOnce() API request rendering immediatly, before message flushing.

So we need to make some seperated API, sync with message flush timing.

Usually be used pairwise with `AddFrameRenderedCallback` or `AddFramePresentedCallback`.

Relative dali patches:

https://review.tizen.org/gerrit/c/platform/core/uifw/dali-core/+/341439
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-adaptor/+/341440
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/341448
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/341450

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
