### PR TITLE
Migrate DllImport to LibraryImport in low-risk core modules (Phase 1)

### DIFF
--- a/src/Tizen.Applications.Alarm/Interop/Interop.Alarm.cs
+++ b/src/Tizen.Applications.Alarm/Interop/Interop.Alarm.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Tizen.Internals;
 using Tizen.Applications;
@@ -42,80 +43,80 @@ internal static partial class Interop
             internal IntPtr tm_zone;
         };
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_after_delay")]
-        internal static extern int CreateAlarmAfterDelay(SafeAppControlHandle appControl, int delay, int period, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_after_delay")]
+        internal static partial int CreateAlarmAfterDelay(SafeAppControlHandle appControl, int delay, int period, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_once_after_delay")]
-        internal static extern int CreateAlarmOnceAfterDelay(SafeAppControlHandle appControl, int delay, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_once_after_delay")]
+        internal static partial int CreateAlarmOnceAfterDelay(SafeAppControlHandle appControl, int delay, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_once_at_date")]
-        internal static extern int CreateAlarmOnceAtDate(SafeAppControlHandle appControl, ref DateTime date, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_once_at_date")]
+        internal static partial int CreateAlarmOnceAtDate(SafeAppControlHandle appControl, ref DateTime date, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_with_recurrence_week_flag")]
-        internal static extern int CreateAlarmRecurWeek(SafeAppControlHandle appControl, ref DateTime date, int week, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_with_recurrence_week_flag")]
+        internal static partial int CreateAlarmRecurWeek(SafeAppControlHandle appControl, ref DateTime date, int week, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_service_with_recurrence_seconds")]
-        internal static extern int CreateAlarmRecurForService(SafeAppControlHandle appControl, ref DateTime date, int period, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_service_with_recurrence_seconds")]
+        internal static partial int CreateAlarmRecurForService(SafeAppControlHandle appControl, ref DateTime date, int period, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_service_once_after_delay")]
-        internal static extern int CreateAlarmOnceAfterDelayForService(SafeAppControlHandle appControl, int delay, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_service_once_after_delay")]
+        internal static partial int CreateAlarmOnceAfterDelayForService(SafeAppControlHandle appControl, int delay, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_service_once_at_date")]
-        internal static extern int CreateAlarmOnceAtDateForService(SafeAppControlHandle appControl, ref DateTime date, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_service_once_at_date")]
+        internal static partial int CreateAlarmOnceAtDateForService(SafeAppControlHandle appControl, ref DateTime date, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_get_scheduled_recurrence_week_flag")]
-        internal static extern int GetAlarmWeekFlag(int alarmId, out int weekFlag);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_get_scheduled_recurrence_week_flag")]
+        internal static partial int GetAlarmWeekFlag(int alarmId, out int weekFlag);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_cancel")]
-        internal static extern int CancelAlarm(int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_cancel")]
+        internal static partial int CancelAlarm(int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_cancel_all")]
-        internal static extern int CancelAllAlarms();
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_cancel_all")]
+        internal static partial int CancelAllAlarms();
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_get_scheduled_date")]
-        internal static extern int GetAlarmScheduledDate(int alarmId, out DateTime date);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_get_scheduled_date")]
+        internal static partial int GetAlarmScheduledDate(int alarmId, out DateTime date);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_get_current_time")]
-        internal static extern int GetCurrentTime(out DateTime date);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_get_current_time")]
+        internal static partial int GetCurrentTime(out DateTime date);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_get_app_control")]
-        internal static extern int GetAlarmAppControl(int alarmId, out SafeAppControlHandle control);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_get_app_control")]
+        internal static partial int GetAlarmAppControl(int alarmId, out SafeAppControlHandle control);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_get_scheduled_period")]
-        internal static extern int GetAlarmScheduledPeriod(int alarmId, out int period);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_get_scheduled_period")]
+        internal static partial int GetAlarmScheduledPeriod(int alarmId, out int period);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_set_global")]
-        internal static extern int SetAlarmGlobalFlag(int alarmId, bool global);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_set_global")]
+        internal static partial int SetAlarmGlobalFlag(int alarmId, [MarshalAs(UnmanagedType.U1)] bool global);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_get_global")]
-        internal static extern int GetAlarmGlobalFlag(int alarmId, out bool global);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_get_global")]
+        internal static partial int GetAlarmGlobalFlag(int alarmId, [MarshalAs(UnmanagedType.U1)] out bool global);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_foreach_registered_alarm")]
-        internal static extern int GetAllRegisteredAlarms(RegisteredAlarmCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_foreach_registered_alarm")]
+        internal static partial int GetAllRegisteredAlarms(RegisteredAlarmCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_noti_once_at_date")]
-        internal static extern AlarmError CreateAlarmNotiOnceAtDate(NotificationSafeHandle noti, ref DateTime date, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_noti_once_at_date")]
+        internal static partial AlarmError CreateAlarmNotiOnceAtDate(NotificationSafeHandle noti, ref DateTime date, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_noti_after_delay")]
-        internal static extern AlarmError CreateAlarmNotiAfterDelay(NotificationSafeHandle noti, int delay, int period, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_noti_after_delay")]
+        internal static partial AlarmError CreateAlarmNotiAfterDelay(NotificationSafeHandle noti, int delay, int period, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_noti_once_after_delay")]
-        internal static extern AlarmError CreateAlarmNotiOnceAfterDelay(NotificationSafeHandle noti, int delay, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_noti_once_after_delay")]
+        internal static partial AlarmError CreateAlarmNotiOnceAfterDelay(NotificationSafeHandle noti, int delay, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_schedule_noti_with_recurrence_week_flag")]
-        internal static extern AlarmError CreateAlarmNotiRecurWeek(NotificationSafeHandle noti, ref DateTime date, int week, out int alarmId);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_schedule_noti_with_recurrence_week_flag")]
+        internal static partial AlarmError CreateAlarmNotiRecurWeek(NotificationSafeHandle noti, ref DateTime date, int week, out int alarmId);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_update_delay")]
-        internal static extern AlarmError UpdateDelay(int alarmId, int delay);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_update_delay")]
+        internal static partial AlarmError UpdateDelay(int alarmId, int delay);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_update_date")]
-        internal static extern AlarmError UpdateDate(int alarmId, ref DateTime date);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_update_date")]
+        internal static partial AlarmError UpdateDate(int alarmId, ref DateTime date);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_update_period")]
-        internal static extern AlarmError UpdatePeriod(int alarmId, int period);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_update_period")]
+        internal static partial AlarmError UpdatePeriod(int alarmId, int period);
 
-        [DllImport(Libraries.Alarm, EntryPoint = "alarm_update_week_flag")]
-        internal static extern AlarmError UpdateWeekFlag(int alarmId, int week);
+        [LibraryImport(Libraries.Alarm, EntryPoint = "alarm_update_week_flag")]
+        internal static partial AlarmError UpdateWeekFlag(int alarmId, int week);
 
         //callback
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/src/Tizen.Applications.AttachPanel/Interop/Interop.AttachPanel.cs
+++ b/src/Tizen.Applications.AttachPanel/Interop/Interop.AttachPanel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 
 /// <summary>
@@ -30,49 +31,49 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void AttachPanelResultCallback(IntPtr attachPanel, int category, IntPtr result, int resultCode, IntPtr userData);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_create")]
-        internal static extern ErrorCode CreateAttachPanel(IntPtr conform, out IntPtr attach_panel);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_create")]
+        internal static partial ErrorCode CreateAttachPanel(IntPtr conform, out IntPtr attach_panel);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_destroy")]
-        internal static extern ErrorCode DestroyAttachPanel(IntPtr attach_panel);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_destroy")]
+        internal static partial ErrorCode DestroyAttachPanel(IntPtr attach_panel);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_add_content_category")]
-        internal static extern ErrorCode AddCategory(IntPtr attach_panel, int content_category, IntPtr extraData);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_add_content_category")]
+        internal static partial ErrorCode AddCategory(IntPtr attach_panel, int content_category, IntPtr extraData);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_remove_content_category")]
-        internal static extern ErrorCode RemoveCategory(IntPtr attach_panel, int content_category);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_remove_content_category")]
+        internal static partial ErrorCode RemoveCategory(IntPtr attach_panel, int content_category);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_set_extra_data")]
-        internal static extern ErrorCode SetExtraData(IntPtr attach_panel, int content_category, IntPtr extraData);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_set_extra_data")]
+        internal static partial ErrorCode SetExtraData(IntPtr attach_panel, int content_category, IntPtr extraData);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_set_result_cb")]
-        internal static extern ErrorCode SetResultCb(IntPtr attach_panel, AttachPanelResultCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_set_result_cb")]
+        internal static partial ErrorCode SetResultCb(IntPtr attach_panel, AttachPanelResultCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_unset_result_cb")]
-        internal static extern ErrorCode UnsetResultCb(IntPtr attach_panel);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_unset_result_cb")]
+        internal static partial ErrorCode UnsetResultCb(IntPtr attach_panel);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_set_event_cb")]
-        internal static extern ErrorCode SetEventCb(IntPtr attach_panel, AttachPanelEventCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_set_event_cb")]
+        internal static partial ErrorCode SetEventCb(IntPtr attach_panel, AttachPanelEventCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_unset_event_cb")]
-        internal static extern ErrorCode UnsetEventCb(IntPtr attach_panel);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_unset_event_cb")]
+        internal static partial ErrorCode UnsetEventCb(IntPtr attach_panel);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_show")]
-        internal static extern ErrorCode Show(IntPtr attach_panel);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_show")]
+        internal static partial ErrorCode Show(IntPtr attach_panel);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_show_without_animation")]
-        internal static extern ErrorCode ShowWithoutAnimation(IntPtr attach_panel);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_show_without_animation")]
+        internal static partial ErrorCode ShowWithoutAnimation(IntPtr attach_panel);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_hide")]
-        internal static extern ErrorCode Hide(IntPtr attach_panel);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_hide")]
+        internal static partial ErrorCode Hide(IntPtr attach_panel);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_hide_without_animation")]
-        internal static extern ErrorCode HideWithoutAnimation(IntPtr attach_panel);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_hide_without_animation")]
+        internal static partial ErrorCode HideWithoutAnimation(IntPtr attach_panel);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_get_visibility")]
-        internal static extern ErrorCode GetVisibility(IntPtr attach_panel, out int visible);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_get_visibility")]
+        internal static partial ErrorCode GetVisibility(IntPtr attach_panel, out int visible);
 
-        [DllImport(Libraries.AttachPanel, EntryPoint = "attach_panel_get_state")]
-        internal static extern ErrorCode GetState(IntPtr attach_panel, out int state);
+        [LibraryImport(Libraries.AttachPanel, EntryPoint = "attach_panel_get_state")]
+        internal static partial ErrorCode GetState(IntPtr attach_panel, out int state);
     }
 }

--- a/src/Tizen.Applications.Badge/Interop/Interop.Badge.cs
+++ b/src/Tizen.Applications.Badge/Interop/Interop.Badge.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 
 internal static partial class Interop
@@ -35,31 +36,31 @@ internal static partial class Interop
 
         internal delegate void ChangedCallback(Action action, string appId, uint count, IntPtr userData);
 
-        [DllImport(Libraries.Badge, EntryPoint = "badge_add")]
-        internal static extern BadgeError Add(string appId);
+        [LibraryImport(Libraries.Badge, EntryPoint = "badge_add", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial BadgeError Add(string appId);
 
-        [DllImport(Libraries.Badge, EntryPoint = "badge_remove")]
-        internal static extern BadgeError Remove(string appId);
+        [LibraryImport(Libraries.Badge, EntryPoint = "badge_remove", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial BadgeError Remove(string appId);
 
-        [DllImport(Libraries.Badge, EntryPoint = "badge_set_count")]
-        internal static extern BadgeError SetCount(string appId, uint count);
+        [LibraryImport(Libraries.Badge, EntryPoint = "badge_set_count", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial BadgeError SetCount(string appId, uint count);
 
-        [DllImport(Libraries.Badge, EntryPoint = "badge_get_count")]
-        internal static extern BadgeError GetCount(string appId, out uint count);
+        [LibraryImport(Libraries.Badge, EntryPoint = "badge_get_count", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial BadgeError GetCount(string appId, out uint count);
 
-        [DllImport(Libraries.Badge, EntryPoint = "badge_set_display")]
-        internal static extern BadgeError SetDisplay(string appId, uint isDisplay);
+        [LibraryImport(Libraries.Badge, EntryPoint = "badge_set_display", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial BadgeError SetDisplay(string appId, uint isDisplay);
 
-        [DllImport(Libraries.Badge, EntryPoint = "badge_get_display")]
-        internal static extern BadgeError GetDisplay(string appId, out uint isDisplay);
+        [LibraryImport(Libraries.Badge, EntryPoint = "badge_get_display", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial BadgeError GetDisplay(string appId, out uint isDisplay);
 
-        [DllImport(Libraries.Badge, EntryPoint = "badge_foreach")]
-        internal static extern BadgeError Foreach(ForeachCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Badge, EntryPoint = "badge_foreach")]
+        internal static partial BadgeError Foreach(ForeachCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Badge, EntryPoint = "badge_register_changed_cb")]
-        internal static extern BadgeError SetChangedCallback(ChangedCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Badge, EntryPoint = "badge_register_changed_cb")]
+        internal static partial BadgeError SetChangedCallback(ChangedCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Badge, EntryPoint = "badge_unregister_changed_cb")]
-        internal static extern BadgeError UnsetChangedCallback(ChangedCallback callback);
+        [LibraryImport(Libraries.Badge, EntryPoint = "badge_unregister_changed_cb")]
+        internal static partial BadgeError UnsetChangedCallback(ChangedCallback callback);
     }
 }

--- a/src/Tizen.Applications.EventManager/Interop/Interop.AppEvent.cs
+++ b/src/Tizen.Applications.EventManager/Interop/Interop.AppEvent.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Tizen.Applications;
 
@@ -36,19 +37,19 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void EventCallback(string eventName, IntPtr eventData, IntPtr userData);
 
-        [DllImport(Libraries.AppEvent, EntryPoint = "event_add_event_handler")]
-        internal static extern ErrorCode EventAddHandler(string eventName, EventCallback cb, IntPtr userData, out IntPtr handle);
+        [LibraryImport(Libraries.AppEvent, EntryPoint = "event_add_event_handler", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode EventAddHandler(string eventName, EventCallback cb, IntPtr userData, out IntPtr handle);
 
-        [DllImport(Libraries.AppEvent, EntryPoint = "event_remove_event_handler")]
-        internal static extern ErrorCode EventRemoveHandler(IntPtr handle);
+        [LibraryImport(Libraries.AppEvent, EntryPoint = "event_remove_event_handler")]
+        internal static partial ErrorCode EventRemoveHandler(IntPtr handle);
 
-        [DllImport(Libraries.AppEvent, EntryPoint = "event_publish_app_event")]
-        internal static extern ErrorCode EventPublishAppEvent(string eventName, SafeBundleHandle eventData);
+        [LibraryImport(Libraries.AppEvent, EntryPoint = "event_publish_app_event", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode EventPublishAppEvent(string eventName, SafeBundleHandle eventData);
 
-        [DllImport(Libraries.AppEvent, EntryPoint = "event_publish_trusted_app_event")]
-        internal static extern ErrorCode EventPublishTrustedAppEvent(string eventName, SafeBundleHandle eventData);
+        [LibraryImport(Libraries.AppEvent, EntryPoint = "event_publish_trusted_app_event", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode EventPublishTrustedAppEvent(string eventName, SafeBundleHandle eventData);
 
-        [DllImport(Libraries.AppEvent, EntryPoint = "event_keep_last_event_data")]
-        internal static extern ErrorCode EventKeepLastEventData(string eventName);
+        [LibraryImport(Libraries.AppEvent, EntryPoint = "event_keep_last_event_data", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode EventKeepLastEventData(string eventName);
     }
 }

--- a/src/Tizen.Applications.MessagePort/Interop/Interop.MessagePort.cs
+++ b/src/Tizen.Applications.MessagePort/Interop/Interop.MessagePort.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Tizen.Applications;
 
@@ -23,38 +24,38 @@ internal static partial class Interop
 {
     internal static partial class MessagePort
     {
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_register_local_port", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int RegisterPort(string local_port, message_port_message_cb callback, IntPtr userData);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_register_local_port", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RegisterPort(string local_port, message_port_message_cb callback, IntPtr userData);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_register_trusted_local_port", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int RegisterTrustedPort(string trusted_local_port, message_port_message_cb callback, IntPtr userData);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_register_trusted_local_port", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int RegisterTrustedPort(string trusted_local_port, message_port_message_cb callback, IntPtr userData);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_unregister_local_port", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int UnregisterPort(int local_port_id);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_unregister_local_port")]
+        internal static partial int UnregisterPort(int local_port_id);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_unregister_trusted_local_port", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int UnregisterTrustedPort(int trusted_local_port_id);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_unregister_trusted_local_port")]
+        internal static partial int UnregisterTrustedPort(int trusted_local_port_id);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_send_message_with_local_port", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int SendMessageWithLocalPort(string remote_app_id, string remote_port, SafeBundleHandle message, int local_port_id);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_send_message_with_local_port", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SendMessageWithLocalPort(string remote_app_id, string remote_port, SafeBundleHandle message, int local_port_id);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_send_trusted_message_with_local_port", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int SendTrustedMessageWithLocalPort(string remote_app_id, string remote_port, SafeBundleHandle message, int local_port_id);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_send_trusted_message_with_local_port", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SendTrustedMessageWithLocalPort(string remote_app_id, string remote_port, SafeBundleHandle message, int local_port_id);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_check_remote_port", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int CheckRemotePort(string remote_app_id, string remote_port, out bool exist);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_check_remote_port", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CheckRemotePort(string remote_app_id, string remote_port, [MarshalAs(UnmanagedType.U1)] out bool exist);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_check_trusted_remote_port", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int CheckTrustedRemotePort(string remote_app_id, string remote_port, out bool exist);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_check_trusted_remote_port", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int CheckTrustedRemotePort(string remote_app_id, string remote_port, [MarshalAs(UnmanagedType.U1)] out bool exist);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_add_registered_cb", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int AddRegisteredCallback(string remote_app_id, string remote_port, bool trusted_remote_port, message_port_registration_event_cb callback, IntPtr userData, out int watcher_id);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_add_registered_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int AddRegisteredCallback(string remote_app_id, string remote_port, [MarshalAs(UnmanagedType.U1)] bool trusted_remote_port, message_port_registration_event_cb callback, IntPtr userData, out int watcher_id);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_add_unregistered_cb", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int AddUnregisteredCallback(string remote_app_id, string remote_port, bool trusted_remote_port, message_port_registration_event_cb callback, IntPtr userData, out int watcher_id);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_add_unregistered_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int AddUnregisteredCallback(string remote_app_id, string remote_port, [MarshalAs(UnmanagedType.U1)] bool trusted_remote_port, message_port_registration_event_cb callback, IntPtr userData, out int watcher_id);
 
-        [DllImport(Libraries.MessagePort, EntryPoint = "message_port_remove_registration_event_cb", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int RemoveRegistrationCallback(int watcher_id);
+        [LibraryImport(Libraries.MessagePort, EntryPoint = "message_port_remove_registration_event_cb")]
+        internal static partial int RemoveRegistrationCallback(int watcher_id);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void message_port_message_cb(int local_port_id, string remote_app_id, string remote_port, bool trusted_remote_port, IntPtr message, IntPtr userData);

--- a/src/Tizen.Applications.Preference/Interop/Interop.Preference.cs
+++ b/src/Tizen.Applications.Preference/Interop/Interop.Preference.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 
 /// <summary>
@@ -32,46 +33,46 @@ internal static partial class Interop
 
         internal delegate bool ItemCallback(string key, IntPtr userData);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_set_int")]
-        internal static extern int SetInt(string key, int value);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_set_int", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetInt(string key, int value);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_get_int")]
-        internal static extern int GetInt(string key, out int value);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_get_int", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetInt(string key, out int value);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_set_double")]
-        internal static extern int SetDouble(string key, double value);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_set_double", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetDouble(string key, double value);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_get_double")]
-        internal static extern int GetDouble(string key, out double value);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_get_double", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetDouble(string key, out double value);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_set_string")]
-        internal static extern int SetString(string key, string value);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_set_string", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetString(string key, string value);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_get_string")]
-        internal static extern int GetString(string key, out string value);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_get_string", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetString(string key, out string value);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_set_boolean")]
-        internal static extern int SetBoolean(string key, bool value);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_set_boolean", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetBoolean(string key, [MarshalAs(UnmanagedType.U1)] bool value);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_get_boolean")]
-        internal static extern int GetBoolean(string key, out bool value);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_get_boolean", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetBoolean(string key, [MarshalAs(UnmanagedType.U1)] out bool value);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_remove")]
-        internal static extern int Remove(string key);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_remove", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Remove(string key);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_is_existing")]
-        internal static extern int IsExisting(string key, out bool existing);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_is_existing", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int IsExisting(string key, [MarshalAs(UnmanagedType.U1)] out bool existing);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_remove_all")]
-        internal static extern int RemoveAll();
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_remove_all")]
+        internal static partial int RemoveAll();
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_set_changed_cb")]
-        internal static extern int SetChangedCb(string key, ChangedCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_set_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int SetChangedCb(string key, ChangedCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_unset_changed_cb")]
-        internal static extern int UnsetChangedCb(string key);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_unset_changed_cb", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int UnsetChangedCb(string key);
 
-        [DllImport(Libraries.Preference, EntryPoint = "preference_foreach_item")]
-        internal static extern int ForeachItem(ItemCallback callback, IntPtr userData);
+        [LibraryImport(Libraries.Preference, EntryPoint = "preference_foreach_item")]
+        internal static partial int ForeachItem(ItemCallback callback, IntPtr userData);
     }
 }

--- a/src/Tizen.Applications.ThemeManager/Interop/Interop.ThemeManager.cs
+++ b/src/Tizen.Applications.ThemeManager/Interop/Interop.ThemeManager.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen;
 using Tizen.Applications;
 
@@ -63,79 +64,79 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate int ThemeLoaderChangedCallback(IntPtr handle, IntPtr userData);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_id")]
-        internal static extern ErrorCode GetId(IntPtr handle, out string id);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_id", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetId(IntPtr handle, out string id);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_version")]
-        internal static extern ErrorCode GetVersion(IntPtr handle, out string version);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_version", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetVersion(IntPtr handle, out string version);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_tool_version")]
-        internal static extern ErrorCode GetToolVersion(IntPtr handle, out string version);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_tool_version", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetToolVersion(IntPtr handle, out string version);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_title")]
-        internal static extern ErrorCode GetTitle(IntPtr handle, out string title);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_title", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetTitle(IntPtr handle, out string title);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_resolution")]
-        internal static extern ErrorCode GetResolution(IntPtr handle, out string resolution);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_resolution", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetResolution(IntPtr handle, out string resolution);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_preview")]
-        internal static extern ErrorCode GetPreview(IntPtr handle, out string preview);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_preview", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetPreview(IntPtr handle, out string preview);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_description")]
-        internal static extern ErrorCode GetDescription(IntPtr handle, out string description);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_description", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetDescription(IntPtr handle, out string description);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_string")]
-        internal static extern ErrorCode GetString(IntPtr handle, string key, out string val);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_string", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetString(IntPtr handle, string key, out string val);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_string_array")]
-        internal static extern ErrorCode GetStringArray(IntPtr handle, string key, out IntPtr val, out int count);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_string_array", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetStringArray(IntPtr handle, string key, out IntPtr val, out int count);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_path")]
-        internal static extern ErrorCode GetPath(IntPtr handle, string key, out string val);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_path", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetPath(IntPtr handle, string key, out string val);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_path_array")]
-        internal static extern ErrorCode GetPathArray(IntPtr handle, string key, out IntPtr val, out int count);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_path_array", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetPathArray(IntPtr handle, string key, out IntPtr val, out int count);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_int")]
-        internal static extern ErrorCode GetInt(IntPtr handle, string key, out int val);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_int", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetInt(IntPtr handle, string key, out int val);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_float")]
-        internal static extern ErrorCode GetFloat(IntPtr handle, string key, out float val);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_float", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetFloat(IntPtr handle, string key, out float val);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_bool")]
-        internal static extern ErrorCode GetBool(IntPtr handle, string key, out bool val);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_get_bool", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode GetBool(IntPtr handle, string key, [MarshalAs(UnmanagedType.U1)] out bool val);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_is_key_exist")]
-        internal static extern ErrorCode IsKeyExist(IntPtr handle, string key, out bool val);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_is_key_exist", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode IsKeyExist(IntPtr handle, string key, [MarshalAs(UnmanagedType.U1)] out bool val);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_clone")]
-        internal static extern ErrorCode ThemeClone(IntPtr handle, out IntPtr cloned);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_clone")]
+        internal static partial ErrorCode ThemeClone(IntPtr handle, out IntPtr cloned);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_destroy")]
-        internal static extern ErrorCode ThemeDestroy(IntPtr handle);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_destroy")]
+        internal static partial ErrorCode ThemeDestroy(IntPtr handle);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_loader_create")]
-        internal static extern ErrorCode LoaderCreate(out IntPtr loaderHandle);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_loader_create")]
+        internal static partial ErrorCode LoaderCreate(out IntPtr loaderHandle);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_loader_destroy")]
-        internal static extern ErrorCode LoaderDestroy(IntPtr loaderHandle);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_loader_destroy")]
+        internal static partial ErrorCode LoaderDestroy(IntPtr loaderHandle);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_loader_add_event")]
-        internal static extern ErrorCode LoaderAddEvent(IntPtr loaderHandle, ThemeLoaderChangedCallback callback, IntPtr userData, out string eventId);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_loader_add_event", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode LoaderAddEvent(IntPtr loaderHandle, ThemeLoaderChangedCallback callback, IntPtr userData, out string eventId);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_loader_remove_event")]
-        internal static extern ErrorCode LoaderRemoveEvent(IntPtr loaderHandle, string eventId);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_loader_remove_event", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode LoaderRemoveEvent(IntPtr loaderHandle, string eventId);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_loader_load_current")]
-        internal static extern ErrorCode LoaderLoadCurrentTheme(IntPtr loaderHandle, out IntPtr handle);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_loader_load_current")]
+        internal static partial ErrorCode LoaderLoadCurrentTheme(IntPtr loaderHandle, out IntPtr handle);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_loader_load")]
-        internal static extern ErrorCode LoaderLoadTheme(IntPtr loaderHandle, string id, out IntPtr handle);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_loader_load", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode LoaderLoadTheme(IntPtr loaderHandle, string id, out IntPtr handle);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_loader_query_id")]
-        internal static extern ErrorCode LoaderQueryId(IntPtr loaderHandle, out IntPtr ids, out int count);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_loader_query_id")]
+        internal static partial ErrorCode LoaderQueryId(IntPtr loaderHandle, out IntPtr ids, out int count);
 
-        [DllImport(Libraries.ThemeManager, EntryPoint = "theme_loader_set_current")]
-        internal static extern ErrorCode LoaderSetCurrentTheme(IntPtr loaderHandle, string id);
+        [LibraryImport(Libraries.ThemeManager, EntryPoint = "theme_loader_set_current", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial ErrorCode LoaderSetCurrentTheme(IntPtr loaderHandle, string id);
     }
 }

--- a/src/Tizen.Applications.ToastMessage/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.ToastMessage/Interop/Interop.Libraries.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);

--- a/src/Tizen.Applications.ToastMessage/Interop/Interop.ToastMessage.cs
+++ b/src/Tizen.Applications.ToastMessage/Interop/Interop.ToastMessage.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -16,13 +16,14 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 
 internal static partial class Interop
 {
-    internal static class ToastMessage
+    internal static partial class ToastMessage
     {
-        [DllImport(Libraries.ToastMessage, EntryPoint = "notification_status_message_post")]
-        internal static extern int ToastMessagePost(string message);
+        [LibraryImport(Libraries.ToastMessage, EntryPoint = "notification_status_message_post", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int ToastMessagePost(string message);
     }
 }

--- a/src/Tizen.Applications.UI/Interop/Interop.Application.cs
+++ b/src/Tizen.Applications.UI/Interop/Interop.Application.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Applications;
 using Tizen.Applications.CoreBackend;
 using Tizen.Internals;
@@ -38,23 +39,23 @@ internal static partial class Interop
         internal delegate void AppControlCallback(IntPtr appControl, IntPtr userData);
 
 
-        [DllImport(Libraries.Application, EntryPoint = "app_get_device_orientation")]
-        internal static extern DeviceOrientation AppGetDeviceOrientation();
+        [LibraryImport(Libraries.Application, EntryPoint = "app_get_device_orientation")]
+        internal static partial DeviceOrientation AppGetDeviceOrientation();
 
-        [DllImport(Libraries.Application, EntryPoint = "ui_app_main")]
+        [DllImport(Libraries.Application, EntryPoint = "ui_app_main", CallingConvention = CallingConvention.Cdecl)]
         internal static extern ErrorCode Main(int argc, string[] argv, ref UIAppLifecycleCallbacks callback, IntPtr userData);
 
-        [DllImport(Libraries.Application, EntryPoint = "ui_app_exit")]
-        internal static extern void Exit();
+        [LibraryImport(Libraries.Application, EntryPoint = "ui_app_exit")]
+        internal static partial void Exit();
 
-        [DllImport(Libraries.Application, EntryPoint = "ui_app_add_event_handler")]
-        internal static extern ErrorCode AddEventHandler(out IntPtr handle, DefaultCoreBackend.AppEventType eventType, AppEventCallback callback, IntPtr data);
+        [LibraryImport(Libraries.Application, EntryPoint = "ui_app_add_event_handler")]
+        internal static partial ErrorCode AddEventHandler(out IntPtr handle, DefaultCoreBackend.AppEventType eventType, AppEventCallback callback, IntPtr data);
 
-        [DllImport(Libraries.Application, EntryPoint = "ui_app_remove_event_handler")]
-        internal static extern ErrorCode RemoveEventHandler(IntPtr handle);
+        [LibraryImport(Libraries.Application, EntryPoint = "ui_app_remove_event_handler")]
+        internal static partial ErrorCode RemoveEventHandler(IntPtr handle);
 
-        [DllImport(Libraries.Application, EntryPoint = "ui_app_get_window_position")]
-        internal static extern ErrorCode GetWindowPosition(out int x, out int y, out int w, out int h);
+        [LibraryImport(Libraries.Application, EntryPoint = "ui_app_get_window_position")]
+        internal static partial ErrorCode GetWindowPosition(out int x, out int y, out int w, out int h);
 
         [NativeStruct("ui_app_lifecycle_callback_s", Include="app.h", PkgConfig="capi-appfw-application")]
         [StructLayout(LayoutKind.Sequential)]
@@ -68,4 +69,3 @@ internal static partial class Interop
         }
     }
 }
-

--- a/src/Tizen.Content.MimeType/Interop/Interop.Glib.cs
+++ b/src/Tizen.Content.MimeType/Interop/Interop.Glib.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
@@ -24,7 +25,7 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate bool GSourceFunc(IntPtr userData);
 
-        [DllImport(Libraries.Glib, EntryPoint = "g_idle_add", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern uint IdleAdd(GSourceFunc d, IntPtr data);
+        [LibraryImport(Libraries.Glib, EntryPoint = "g_idle_add")]
+        internal static partial uint IdleAdd(GSourceFunc d, IntPtr data);
     }
 }

--- a/src/Tizen.System.Information/Interop/Interop.RuntimeInfo.cs
+++ b/src/Tizen.System.Information/Interop/Interop.RuntimeInfo.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
 *
 * Licensed under the Apache License, Version 2.0 (the License);
@@ -17,6 +17,7 @@
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Tizen.Internals;
 using Tizen.System;
 
@@ -116,46 +117,46 @@ internal static partial class Interop
             GemRss = 1000
         }
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_value_int")]
-        public static extern InformationError GetValue(RuntimeInfoKey key, out int status);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_value_int")]
+        public static partial InformationError GetValue(RuntimeInfoKey key, out int status);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_value_bool")]
-        public static extern InformationError GetValue(RuntimeInfoKey key, out bool status);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_value_bool")]
+        public static partial InformationError GetValue(RuntimeInfoKey key, [MarshalAs(UnmanagedType.U1)] out bool status);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_value_double")]
-        public static extern InformationError GetValue(RuntimeInfoKey key, out double status);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_value_double")]
+        public static partial InformationError GetValue(RuntimeInfoKey key, out double status);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_value_string")]
-        public static extern InformationError GetValue(RuntimeInfoKey key, out string status);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_value_string", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial InformationError GetValue(RuntimeInfoKey key, out string status);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_system_memory_info")]
-        public static extern InformationError GetSystemMemoryInfo(out MemoryInfo memoryInfo);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_system_memory_info")]
+        public static partial InformationError GetSystemMemoryInfo(out MemoryInfo memoryInfo);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_process_memory_info")]
-        public static extern InformationError GetProcessMemoryInfo(int[] pid, int size, ref IntPtr array);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_process_memory_info")]
+        public static partial InformationError GetProcessMemoryInfo(int[] pid, int size, ref IntPtr array);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_cpu_usage")]
-        public static extern InformationError GetCpuUsage(out CpuUsage cpuUsage);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_cpu_usage")]
+        public static partial InformationError GetCpuUsage(out CpuUsage cpuUsage);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_process_cpu_usage")]
-        public static extern InformationError GetProcessCpuUsage(int[] pid, int size, ref IntPtr array);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_process_cpu_usage")]
+        public static partial InformationError GetProcessCpuUsage(int[] pid, int size, ref IntPtr array);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_processor_count")]
-        public static extern InformationError GetProcessorCount(out int processorCount);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_processor_count")]
+        public static partial InformationError GetProcessorCount(out int processorCount);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_processor_current_frequency")]
-        public static extern InformationError GetProcessorCurrentFrequency(int coreId, out int cpuFreq);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_processor_current_frequency")]
+        public static partial InformationError GetProcessorCurrentFrequency(int coreId, out int cpuFreq);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_processor_max_frequency")]
-        public static extern InformationError GetProcessorMaxFrequency(int coreId, out int cpuFreq);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_processor_max_frequency")]
+        public static partial InformationError GetProcessorMaxFrequency(int coreId, out int cpuFreq);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_set_changed_cb")]
-        public static extern InformationError SetRuntimeInfoChangedCallback(RuntimeInfoKey runtimeInfoKey, RuntimeInformationChangedCallback cb, IntPtr userData);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_set_changed_cb")]
+        public static partial InformationError SetRuntimeInfoChangedCallback(RuntimeInfoKey runtimeInfoKey, RuntimeInformationChangedCallback cb, IntPtr userData);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_unset_changed_cb")]
-        public static extern InformationError UnsetRuntimeInfoChangedCallback(RuntimeInfoKey runtimeInfoKey);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_unset_changed_cb")]
+        public static partial InformationError UnsetRuntimeInfoChangedCallback(RuntimeInfoKey runtimeInfoKey);
 
-        [DllImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_process_memory_value_int")]
-        public static extern InformationError GetProcessMemoryValueInt(int[] pid, int size, ProcessMemoryInfoKey memoryInfoKey, out IntPtr array);
+        [LibraryImport(Libraries.RuntimeInfo, EntryPoint = "runtime_info_get_process_memory_value_int")]
+        public static partial InformationError GetProcessMemoryValueInt(int[] pid, int size, ProcessMemoryInfoKey memoryInfoKey, out IntPtr array);
     }
 }

--- a/src/Tizen.System.Information/Interop/Interop.SystemInfo.cs
+++ b/src/Tizen.System.Information/Interop/Interop.SystemInfo.cs
@@ -16,6 +16,7 @@
 
 using Tizen.System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
@@ -36,34 +37,34 @@ internal static partial class Interop
             None,
         }
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_type")]
-        internal static extern InformationError SystemInfoGetPlatformType(string key, out SystemInfoValueType type);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetPlatformType(string key, out SystemInfoValueType type);
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_type")]
-        internal static extern InformationError SystemInfoGetCustomType(string key, out SystemInfoValueType type);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_type", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetCustomType(string key, out SystemInfoValueType type);
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_bool")]
-        internal static extern InformationError SystemInfoGetPlatformBool(string key, out bool value);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_bool", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetPlatformBool(string key, [MarshalAs(UnmanagedType.U1)] out bool value);
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_int")]
-        internal static extern InformationError SystemInfoGetPlatformInt(string key, out int value);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_int", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetPlatformInt(string key, out int value);
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_double")]
-        internal static extern InformationError SystemInfoGetPlatformDouble(string key, out double value);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_double", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetPlatformDouble(string key, out double value);
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_string")]
-        internal static extern InformationError SystemInfoGetPlatformString(string key, out string value);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_platform_string", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetPlatformString(string key, out string value);
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_bool")]
-        internal static extern InformationError SystemInfoGetCustomBool(string key, out bool value);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_bool", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetCustomBool(string key, [MarshalAs(UnmanagedType.U1)] out bool value);
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_int")]
-        internal static extern InformationError SystemInfoGetCustomInt(string key, out int value);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_int", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetCustomInt(string key, out int value);
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_double")]
-        internal static extern InformationError SystemInfoGetCustomDouble(string key, out double value);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_double", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetCustomDouble(string key, out double value);
 
-        [DllImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_string")]
-        internal static extern InformationError SystemInfoGetCustomString(string key, out string value);
+        [LibraryImport(Libraries.SystemInfo, EntryPoint = "system_info_get_custom_string", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial InformationError SystemInfoGetCustomString(string key, out string value);
     }
 }

--- a/src/Tizen/Interop/Interop.CommonError.cs
+++ b/src/Tizen/Interop/Interop.CommonError.cs
@@ -21,10 +21,10 @@ internal static partial class Interop
 {
     internal static partial class CommonError
     {
-        [DllImport(Libraries.Base, EntryPoint = "get_last_result")]
-        internal static extern int GetLastResult();
+        [LibraryImport(Libraries.Base, EntryPoint = "get_last_result")]
+        internal static partial int GetLastResult();
 
-        [DllImport(Libraries.Base, EntryPoint = "get_error_message")]
-        internal static extern IntPtr GetErrorMessage(int errorCode);
+        [LibraryImport(Libraries.Base, EntryPoint = "get_error_message")]
+        internal static partial IntPtr GetErrorMessage(int errorCode);
     }
 }

--- a/src/Tizen/Interop/Interop.Dlog.cs
+++ b/src/Tizen/Interop/Interop.Dlog.cs
@@ -15,6 +15,7 @@
  */
 
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
@@ -38,11 +39,10 @@ internal static partial class Interop
             DLOG_SILENT,
             DLOG_PRIO_MAX,
         }
-        [DllImportAttribute(Libraries.Dlog, EntryPoint = "dlog_print_dotnet", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int Print(LogPriority prio, string tag, string fmt, string msg);
+        [LibraryImport(Libraries.Dlog, EntryPoint = "dlog_print_dotnet", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Print(LogPriority prio, string tag, string fmt, string msg);
 
-        [DllImportAttribute(Libraries.Dlog, EntryPoint = "dlog_print_dotnet", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int Print(LogPriority prio, string tag, string fmt, string file, string func, int line, string msg);
+        [LibraryImport(Libraries.Dlog, EntryPoint = "dlog_print_dotnet", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int Print(LogPriority prio, string tag, string fmt, string file, string func, int line, string msg);
     }
 }
-

--- a/src/Tizen/Interop/Interop.DotnetUtil.cs
+++ b/src/Tizen/Interop/Interop.DotnetUtil.cs
@@ -16,12 +16,13 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 internal static partial class Interop
 {
     internal static partial class DotnetUtil
     {
-        [DllImport(Libraries.Vconf, EntryPoint = "vconf_get_int")]
-        internal static extern int GetVconfInt(string key, out int value);
+        [LibraryImport(Libraries.Vconf, EntryPoint = "vconf_get_int", StringMarshalling = StringMarshalling.Utf8)]
+        internal static partial int GetVconfInt(string key, out int value);
     }
 }


### PR DESCRIPTION
### Description of Change ###
This is **Phase 1 of 4** in a staged LibraryImport migration. Low-risk modules with simple parameter types are converted first to minimize regression risk.

## Modules Changed (16 files)

| Module | Key Interop |
|--------|-------------|
| **Tizen** (core) | Dlog, CommonError, DotnetUtil |
| **Tizen.System.Information** | RuntimeInfo, SystemInfo |
| **Tizen.Applications.Alarm** | Alarm scheduling APIs |
| **Tizen.Applications.Badge** | Badge APIs |
| **Tizen.Applications.Preference** | Preference APIs |
| **Tizen.Applications.MessagePort** | MessagePort APIs |
| **Tizen.Applications.EventManager** | AppEvent APIs |
| **Tizen.Applications.AttachPanel** | AttachPanel APIs |
| **Tizen.Applications.ToastMessage** | Toast APIs |
| **Tizen.Applications.ThemeManager** | Theme APIs |
| **Tizen.Applications.UI** | UI Application lifecycle |
| **Tizen.Content.MimeType** | Glib idle_add |

## Changes

- Replace `[DllImport]` with `[LibraryImport]` and `static extern` with `static partial`
- Add `StringMarshalling = StringMarshalling.Utf8` only where string parameters are present
- Add `[MarshalAs(UnmanagedType.U1)]` for `bool` parameters/out in LibraryImport declarations
- Remove `CallingConvention.Cdecl` (default for LibraryImport)

## What is NOT included

- **Delegate `bool` MarshalAs improvements** — separated for independent review
- **Modules not fully converted** (Service, Mime with complex marshaling) — excluded
- **Deprecated modules** (RemoteView) — excluded


### TCT Results ###

SuiteSort | Total | Passed | Failed | Blocked | Not Executed | Ratio
-- | -- | -- | -- | -- | -- | --
Tizen.Alarm.Tests | 9 | 9 | 0 | 0 | 0 | 100.00%
Tizen.Alarm.UI.Tests | 22 | 22 | 0 | 0 | 0 | 100.00%
Tizen.Applications.EventManager.Tests | 126 | 126 | 0 | 0 | 0 | 100.00%
Tizen.Applications.MessagePort.Tests | 24 | 24 | 0 | 0 | 0 | 100.00%
Tizen.Applications.Preference.Tests | 24 | 24 | 0 | 0 | 0 | 100.00%
Tizen.Applications.Service.Tests | 3 | 3 | 0 | 0 | 0 | 100.00%
Tizen.Applications.Tests | 205 | 205 | 0 | 0 | 0 | 100.00%
Tizen.Applications.UI.Tests | 4 | 4 | 0 | 0 | 0 | 100.00%
Tizen.Badge.Tests | 29 | 29 | 0 | 0 | 0 | 100.00%
Tizen.Common.Tests | 39 | 39 | 0 | 0 | 0 | 100.00%
Tizen.Information.Tests | 62 | 62 | 0 | 0 | 0 | 100.00%
Tizen.Mime.Tests | 4 | 4 | 0 | 0 | 0 | 100.00%
Tizen.ToastMessage.Tests | 3 | 3 | 0 | 0 | 0 | 100.00%


### API Changes ###
- None
