### PR TITLE
[Tizen.Applications.Common] Replace manual null checks with ArgumentNullException.ThrowIfNull()

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/Application.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/Application.cs
@@ -118,10 +118,7 @@ namespace Tizen.Applications
         /// <since_tizen> 3 </since_tizen>
         public virtual void Run(string[] args)
         {
-            if (args == null)
-            {
-                throw new ArgumentNullException(nameof(args));
-            }
+            ArgumentNullException.ThrowIfNull(args);
             s_CurrentApplication = this;
         }
 

--- a/src/Tizen.Applications.Common/Tizen.Applications/ApplicationManager.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/ApplicationManager.cs
@@ -879,10 +879,7 @@ namespace Tizen.Applications
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static IEnumerable<string> GetRuaStatTags(string caller)
         {
-            if (caller == null)
-            {
-                throw new ArgumentNullException(nameof(caller));
-            }
+            ArgumentNullException.ThrowIfNull(caller);
 
             List<string> tags = new List<string>();
             Interop.ApplicationManager.RuaStatTagIterCallback callback = (string ruaStatTag, IntPtr userData) =>

--- a/src/Tizen.Applications.Common/Tizen.Applications/Bundle.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/Bundle.cs
@@ -68,10 +68,7 @@ namespace Tizen.Applications
         /// <since_tizen> 3 </since_tizen>
         public Bundle(SafeBundleHandle handle)
         {
-            if (handle == null)
-            {
-                throw new ArgumentNullException(nameof(handle));
-            }
+            ArgumentNullException.ThrowIfNull(handle);
 
             if (handle.IsInvalid)
             {
@@ -230,10 +227,7 @@ namespace Tizen.Applications
         /// <since_tizen> 3 </since_tizen>
         public void AddItem(string key, byte[] value)
         {
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
+            ArgumentNullException.ThrowIfNull(value);
             AddItem(key, value, 0, value.Length);
         }
 
@@ -260,10 +254,7 @@ namespace Tizen.Applications
         {
             if (!_keys.Contains(key))
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
+                ArgumentNullException.ThrowIfNull(value);
                 if (offset < 0)
                 {
                     throw new ArgumentOutOfRangeException(nameof(offset), offset, "Cannot be less than 0");
@@ -773,10 +764,7 @@ namespace Tizen.Applications
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static Bundle ImportFromArgv(string[] argv)
         {
-            if (argv == null)
-            {
-                throw new ArgumentNullException(nameof(argv));
-            }
+            ArgumentNullException.ThrowIfNull(argv);
 
             return new Bundle(Interop.Bundle.ImportFromArgv(argv.Length, argv));
         }

--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -349,10 +349,7 @@ namespace Tizen.Applications
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Post(Action runner)
         {
-            if (runner == null)
-            {
-                throw new ArgumentNullException(nameof(runner));
-            }
+            ArgumentNullException.ThrowIfNull(runner);
 
             GSourceManager.Post(runner, true);
         }
@@ -372,10 +369,7 @@ namespace Tizen.Applications
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static async Task<T> Post<T>(Func<T> runner)
         {
-            if (runner == null)
-            {
-                throw new ArgumentNullException(nameof(runner));
-            }
+            ArgumentNullException.ThrowIfNull(runner);
 
             var task = new TaskCompletionSource<T>();
             GSourceManager.Post(() => { task.SetResult(runner()); }, true);

--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreTask.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreTask.cs
@@ -125,10 +125,7 @@ namespace Tizen.Applications
         /// <since_tizen> 10 </since_tizen>
         public static void Post(Action runner)
         {
-            if (runner == null)
-            {
-                throw new ArgumentNullException(nameof(runner));
-            }
+            ArgumentNullException.ThrowIfNull(runner);
 
             GSourceManager.Post(runner);
         }
@@ -147,10 +144,7 @@ namespace Tizen.Applications
 
         public static async Task<T> Post<T>(Func<T> runner)
         {
-            if (runner == null)
-            {
-                throw new ArgumentNullException(nameof(runner));
-            }
+            ArgumentNullException.ThrowIfNull(runner);
 
             var task = new TaskCompletionSource<T>();
             GSourceManager.Post(() => { task.SetResult(runner()); });

--- a/src/Tizen.Applications.Common/Tizen.Applications/ReceivedAppControl.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/ReceivedAppControl.cs
@@ -140,10 +140,7 @@ namespace Tizen.Applications
         /// <since_tizen> 3 </since_tizen>
         public void ReplyToLaunchRequest(AppControl replyRequest, AppControlReplyResult result)
         {
-            if (replyRequest == null)
-            {
-                throw new ArgumentNullException(nameof(replyRequest));
-            }
+            ArgumentNullException.ThrowIfNull(replyRequest);
             Interop.AppControl.ErrorCode err = Interop.AppControl.ReplyToLaunchRequest(replyRequest.SafeAppControlHandle, this.SafeAppControlHandle, (int)result);
             if (err != Interop.AppControl.ErrorCode.None)
                 throw new InvalidOperationException("Failed to reply. Err = " + err);


### PR DESCRIPTION
Closes #7548

## Summary

Converts 11 manual 4-line null-check patterns in `Tizen.Applications.Common` to `ArgumentNullException.ThrowIfNull()` (.NET 6+ API).

**Before** (repeated pattern):
```csharp
if (value == null)
{
    throw new ArgumentNullException(nameof(value));
}
```

**After**:
```csharp
ArgumentNullException.ThrowIfNull(value);
```

## Files Changed

| File | Occurrences |
|------|-------------|
| `Application.cs` | 1 (`args`) |
| `ApplicationManager.cs` | 1 (`caller`) |
| `ReceivedAppControl.cs` | 1 (`replyRequest`) |
| `CoreApplication.cs` | 2 (`runner`) |
| `CoreTask.cs` | 2 (`runner`) |
| `Bundle.cs` | 4 (`handle`, `value` ×2, `argv`) |

**Excluded** (non-conforming patterns — extra constructor arguments or non-null conditions):
- `Bundle.cs` line 75: `ArgumentNullException(nameof(handle), "handle is invalid")` — extra message
- `Bundle.cs` line 86: `ArgumentNullException(nameof(handle), e.Message)` — extra message
- `AppControl.cs`: extra constructor arguments

## Impact
- 6 files changed: -44 lines / +11 lines (net -33)
- No public API changes; behavior preserved (`ThrowIfNull` is functionally equivalent)
- Build: 0 errors, 4 pre-existing warnings (unchanged)

## Benchmark
Device benchmark skipped — no `sdb` target available in build environment.