### PR TITLE
[NUI](Application) Implement NUIApplicationInitializer

### DIFF
--- a/src/Tizen.NUI/src/internal/Application/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application/Application.cs
@@ -731,18 +731,7 @@ namespace Tizen.NUI
         // Callback for Application InitSignal
         private void OnApplicationInit(IntPtr data)
         {
-            Log.Info("NUI", $"[NUI] Preload : {NUIApplication.IsPreload} Support preload time view creation : {NUIApplication.SupportPreInitializedCreation}\n");
-
-            Log.Info("NUI", "[NUI] OnApplicationInit: ProcessorController Initialize");
-            Tizen.Tracer.Begin("[NUI] OnApplicationInit: ProcessorController Initialize");
-            ProcessorController.Instance.Initialize();
-            Tizen.Tracer.End();
-
-            // Initialize DisposeQueue Singleton class. This is also required to create DisposeQueue on main thread.
-            Log.Info("NUI", "[NUI] OnApplicationInit: DisposeQueue Initialize");
-            Tizen.Tracer.Begin("[NUI] OnApplicationInit: DisposeQueue Initialize");
-            DisposeQueue.Instance.Initialize();
-            Tizen.Tracer.End();
+            NUIApplicationInitializer.Initialize();
 
             // Note : Preload window might not be changed after application created. GetWindow again.
             Log.Info("NUI", "[NUI] OnApplicationInit: GetWindow");

--- a/src/Tizen.NUI/src/internal/Application/NUIApplicationInitializer.cs
+++ b/src/Tizen.NUI/src/internal/Application/NUIApplicationInitializer.cs
@@ -1,0 +1,68 @@
+/*
+ * Copyright(c) 2024 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.Threading;
+
+namespace Tizen.NUI
+{
+    internal static class NUIApplicationInitializer
+    {
+        internal static bool IsStaticInitialized {get; set;}
+        internal static bool IsInitialized {get; set;}
+
+        /// <summary>
+        /// Initialize call at very early time of project. (Should only called once)
+        /// </summary>
+        public static void StaticInitialize()
+        {
+            Tizen.Log.Info("NUI", $"[NUI] IsStaticInitialized : {IsStaticInitialized}\n");
+            if (!IsStaticInitialized)
+            {
+                Tizen.Log.Info("NUI", "[NUI] NUIApplicationInitializer: StaticInitialize");
+                Registry.Instance.SavedApplicationThread = Thread.CurrentThread;
+                PropertyBridge.RegisterStringGetter();
+
+                IsStaticInitialized = true;
+                Tizen.Log.Info("NUI", "[NUI] NUIApplicationInitializer: StaticInitialize done");
+            }
+        }
+
+        /// <summary>
+        /// Initialize call at Application::OnInitialize(), or Preload() when SupportPreInitializedCreation == true.
+        /// </summary>
+        public static void Initialize()
+        {
+            Tizen.Log.Info("NUI", $"[NUI] Preload : {NUIApplication.IsPreload} Support preload time view creation : {NUIApplication.SupportPreInitializedCreation} IsStaticInitialized : {IsStaticInitialized} IsInitialized : {IsInitialized}\n");
+
+            if (!IsInitialized)
+            {
+                Tizen.Log.Info("NUI", "[NUI] NUIApplicationInitializer: ProcessorController Initialize");
+                Tizen.Tracer.Begin("[NUI] NUIApplicationInitializer: ProcessorController Initialize");
+                ProcessorController.Instance.Initialize();
+                Tizen.Tracer.End();
+
+                // Initialize DisposeQueue Singleton class. This is also required to create DisposeQueue on main thread.
+                Tizen.Log.Info("NUI", "[NUI] NUIApplicationInitializer: DisposeQueue Initialize");
+                Tizen.Tracer.Begin("[NUI] NUIApplicationInitializer: DisposeQueue Initialize");
+                DisposeQueue.Instance.Initialize();
+                Tizen.Tracer.End();
+
+                IsInitialized = true;
+            }
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Common/Registry.cs
+++ b/src/Tizen.NUI/src/internal/Common/Registry.cs
@@ -215,7 +215,11 @@ namespace Tizen.NUI
 
         private static void RegistryCurrentThreadCheck()
         {
-
+            if (!NUIApplicationInitializer.IsStaticInitialized || !NUIApplicationInitializer.IsInitialized)
+            {
+                Tizen.Log.Fatal("NUI", $"Error! NUIApplicationInitializer.Initialize() not called! You cannot use NUI framework\n");
+                return;
+            }
             if (savedApplicationThread == null)
             {
                 Tizen.Log.Fatal("NUI", $"Error! maybe main thread is created by other process\n");

--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -103,8 +103,7 @@ namespace Tizen.NUI
 
         static NUIApplication()
         {
-            Registry.Instance.SavedApplicationThread = Thread.CurrentThread;
-            PropertyBridge.RegisterStringGetter();
+            NUIApplicationInitializer.StaticInitialize();
         }
 
         /// <summary>
@@ -879,6 +878,8 @@ namespace Tizen.NUI
                 Log.Error("NUI", "[NUI] Preload() Should be called before application created. Ignore\n");
                 return;
             }
+            IsPreload = true;
+
             Interop.Application.PreInitialize();
             SupportPreInitializedCreation = Interop.Application.IsSupportPreInitializedCreation();
 
@@ -890,6 +891,8 @@ namespace Tizen.NUI
             // Get default window only if pre initialize creation supported.
             if (SupportPreInitializedCreation)
             {
+                NUIApplicationInitializer.Initialize();
+
                 Log.Info("NUI", "[NUI] Preload: GetWindow");
                 Tizen.Tracer.Begin("[NUI] Preload: GetWindow");
                 var nativeWindow = Interop.Application.GetPreInitializeWindow();
@@ -911,8 +914,6 @@ namespace Tizen.NUI
 
             // Initialize exception tasks. It must be called end of Preload()
             NDalicPINVOKE.Preload();
-
-            IsPreload = true;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Application/NUIComponentApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIComponentApplication.cs
@@ -41,7 +41,6 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIComponentApplication(IDictionary<Type, string> typeInfo) : base(new NUIComponentCoreBackend())
         {
-            Registry.Instance.SavedApplicationThread = Thread.CurrentThread;
             if (typeInfo != null)
             {
                 foreach (var component in typeInfo)
@@ -82,6 +81,11 @@ namespace Tizen.NUI
             {
                 throw new ArgumentException("compType must be sub type of FrameComponent or ServiceComponent", nameof(compType));
             }
+        }
+
+        static NUIComponentApplication()
+        {
+            NUIApplicationInitializer.StaticInitialize();
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Application/NUIWidgetApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIWidgetApplication.cs
@@ -36,7 +36,6 @@ namespace Tizen.NUI
         /// <param name="widgetType">Derived widget class type.</param>
         public NUIWidgetApplication(System.Type widgetType) : base(new NUIWidgetCoreBackend())
         {
-            Registry.Instance.SavedApplicationThread = Thread.CurrentThread;
             NUIWidgetCoreBackend core = Backend as NUIWidgetCoreBackend;
             core?.RegisterWidgetInfo(new Dictionary<System.Type, string> { { widgetType, ApplicationInfo.ApplicationId } });
         }
@@ -53,7 +52,6 @@ namespace Tizen.NUI
             }
             else
             {
-                Registry.Instance.SavedApplicationThread = Thread.CurrentThread;
                 NUIWidgetCoreBackend core = Backend as NUIWidgetCoreBackend;
                 core?.RegisterWidgetInfo(widgetTypes);
             }
@@ -68,7 +66,6 @@ namespace Tizen.NUI
         /// <since_tizen> 4 </since_tizen>
         public NUIWidgetApplication(System.Type widgetType, string styleSheet) : base(new NUIWidgetCoreBackend(styleSheet))
         {
-            Registry.Instance.SavedApplicationThread = Thread.CurrentThread;
             NUIWidgetCoreBackend core = Backend as NUIWidgetCoreBackend;
             core?.RegisterWidgetInfo(new Dictionary<System.Type, string> { { widgetType, ApplicationInfo.ApplicationId } });
         }
@@ -120,6 +117,11 @@ namespace Tizen.NUI
                     _isUsingXaml = value;
                 }
             }
+        }
+
+        static NUIWidgetApplication()
+        {
+            NUIApplicationInitializer.StaticInitialize();
         }
 
         internal WidgetApplication ApplicationHandle


### PR DESCRIPTION
Let we make some API to support non-NUIApplication could use NUI features.

TODO : For now, we don't support to get defautl window for this case. We'd better make some unified logic to support it.

For example, bind ApplicationController + UiContext at native, and make current NUIApplication use it.

It is quite complex job. So need to seperate PR.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
