### PR TITLE
[MediaVision] Prevent GC of object in GenerateImage (#7325)

### DIFF
--- a/src/Tizen.Multimedia.Vision/MediaVision/BarcodeGenerator.cs
+++ b/src/Tizen.Multimedia.Vision/MediaVision/BarcodeGenerator.cs
@@ -237,6 +237,7 @@ namespace Tizen.Multimedia.Vision
                 imageConfig.Width, imageConfig.Height, type, qrMode, qrEcc, qrVersion,
                 imageConfig.Path, imageConfig.Format).
                 Validate("Failed to generate image");
+            GC.KeepAlive(config);
         }
 
         /// <summary>
@@ -308,6 +309,8 @@ namespace Tizen.Multimedia.Vision
         public static void GenerateImage(string message, QrConfiguration qrConfig,
             BarcodeImageConfiguration imageConfig, BarcodeGenerationConfiguration config)
         {
+            BarcodeGenerationConfiguration config_ = null;
+
             if (qrConfig == null)
             {
                 throw new ArgumentNullException(nameof(qrConfig));
@@ -325,14 +328,16 @@ namespace Tizen.Multimedia.Vision
                 if (qrConfig.DataShape != QrShape.Rectangular || qrConfig.FinderShape != QrShape.Rectangular ||
                     qrConfig.EmbedImagePath != null)
                 {
-                    config = new BarcodeGenerationConfiguration();
+                    // Design QR case. The config_ for legacy QR will be null.
+                    config_ = new BarcodeGenerationConfiguration();
                 }
             }
 
-            SetDesignQrOptions(qrConfig, config);
+            SetDesignQrOptions(qrConfig, config ?? config_);
 
-            GenerateImage(config, message, BarcodeType.QR, imageConfig, (int)qrConfig.Mode,
+            GenerateImage(config ?? config_, message, BarcodeType.QR, imageConfig, (int)qrConfig.Mode,
                 (int)qrConfig.ErrorCorrectionLevel, qrConfig.Version);
+            config_?.Dispose();
         }
 
         /// <summary>


### PR DESCRIPTION
* [MediaVision] Prevent GC of object in GenerateImage



* Fix typo and build error



* Remove unnecessary try-catch



---------

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
