### PR TITLE
[Tizen.Applications] Fix wrong library version deps

### DIFF
--- a/src/Tizen.Applications.Team/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.Team/Interop/Interop.Libraries.cs
@@ -22,7 +22,7 @@ internal static partial class Interop
         public const string Glib = "libglib-2.0.so.0";
         public const string Libc = "libc.so.6";
         public const string BaseUtilsi18n = "libbase-utils-i18n.so.0";
-        public const string IniParser = "libiniparser.so.1";
+        public const string IniParser = "libiniparser.so.4";
         public const string AppManager = "libcapi-appfw-app-manager.so.0";
     }
 }


### PR DESCRIPTION
[Tizen.Applications.Team]

API13_MR target currently use libiniparser.so.4, not libiniparser.so.1