### PR TITLE
[Tizen.Applications] Remove TeamLoop CreateLib Op & Create Launcher

### DIFF
--- a/src/Tizen.Applications.Team/Interop/Interop.TeamLoop.cs
+++ b/src/Tizen.Applications.Team/Interop/Interop.TeamLoop.cs
@@ -28,8 +28,6 @@ internal static partial class Interop
 
         internal delegate IntPtr TeamLoopOpsCreateArgs(IntPtr loadObj);
 
-        internal delegate void TeamLoopOpsCreateLibPath([MarshalAs(UnmanagedType.LPStr)] string path, ref IntPtr output);
-
         internal delegate void TeamLoopOpsOnLoopCreate();
 
         internal delegate void TeamLoopOpsOnLoopTerminate();
@@ -49,9 +47,6 @@ internal static partial class Interop
 
             [MarshalAs(UnmanagedType.FunctionPtr)]
             public TeamLoopOpsCreateArgs CreateArgs;
-
-            [MarshalAs(UnmanagedType.FunctionPtr)]
-            public TeamLoopOpsCreateLibPath CreateLibPath;
 
             [MarshalAs(UnmanagedType.FunctionPtr)]
             public TeamLoopOpsOnLoopCreate OnLoopCreate;

--- a/src/Tizen.Applications.Team/TeamLoop.cs
+++ b/src/Tizen.Applications.Team/TeamLoop.cs
@@ -44,7 +44,6 @@ namespace Tizen.Applications
             _ops.Load = new Interop.TeamLoop.TeamLoopOpsLoad(DoLoad);
             _ops.Unload = new Interop.TeamLoop.TeamLoopOpsUnload(DoUnload);
             _ops.CreateArgs = new Interop.TeamLoop.TeamLoopOpsCreateArgs(DoCreateArgs);
-            _ops.CreateLibPath = new Interop.TeamLoop.TeamLoopOpsCreateLibPath(DoCreateLibPath);
             _ops.OnLoopCreate = new Interop.TeamLoop.TeamLoopOpsOnLoopCreate(DoOnLoopCreate);
             _ops.OnLoopTerminate = new Interop.TeamLoop.TeamLoopOpsOnLoopTerminate(DoOnLoopTerminate);
         }
@@ -203,41 +202,6 @@ namespace Tizen.Applications
             {
                 Log.Error(LogTag, $"Failed to invoke Main method - ID: {loadObj}, Error: {e.Message}");
                 return IntPtr.Zero;
-            }
-        }
-
-        internal static void DoCreateLibPath(string path, ref IntPtr output)
-        {
-            if (string.IsNullOrEmpty(path))
-            {
-                Log.Error(LogTag, "Invalid path: null or empty");
-                output = IntPtr.Zero;
-                return;
-            }
-
-            int lastDotIndex = path.LastIndexOf('.');
-            if (lastDotIndex < 0)
-            {
-                Log.Error(LogTag, $"Invalid path format: {path}. Expected format: org.appfw.csteam.{{member_id}}");
-                output = IntPtr.Zero;
-                return;
-            }
-
-            string memberId = path.Substring(lastDotIndex + 1);
-            if (string.IsNullOrEmpty(memberId))
-            {
-                Log.Error(LogTag, $"Empty member_id extracted from: {path}");
-                output = IntPtr.Zero;
-                return;
-            }
-
-            string libPath = $"/usr/share/csteam/dll/{memberId}.dll";
-            Log.Info(LogTag, $"Created lib path: {libPath} from {path}");
-
-            output = Marshal.StringToHGlobalAnsi(libPath);
-
-            if (output == IntPtr.Zero) {
-                Log.Error(LogTag, "Failed to allocate memory for lib path");
             }
         }
 

--- a/src/Tizen.Applications.Team/Tizen.Applications.CoreBackend/TeamServiceCoreBackend.cs
+++ b/src/Tizen.Applications.Team/Tizen.Applications.CoreBackend/TeamServiceCoreBackend.cs
@@ -81,15 +81,7 @@ namespace Tizen.Applications.CoreBackend
             // base.Run() is not required.
             if (!TeamManager.IsInit())
             {
-              string[] argsClone = new string[args == null ? 1 : args.Length + 1];
-              if (args != null && args.Length > 1)
-              {
-                  args.CopyTo(argsClone, 1);
-              }
-              argsClone[0] = "Tizen.Applications.Team.dll";
-
-              TeamManager.Init(argsClone);
-              Log.Info("DN_TAM", $"Launching Team Loop.");
+              Log.Error("DN_TAM", $"Team Loop is not running!. Launch app via launcher.");
               return;
             }
 

--- a/src/Tizen.Applications.Team/Tizen.Applications.CoreBackend/TeamUICoreBackend.cs
+++ b/src/Tizen.Applications.Team/Tizen.Applications.CoreBackend/TeamUICoreBackend.cs
@@ -108,15 +108,7 @@ namespace Tizen.Applications.CoreBackend
             // base.Run() is not required.
             if (!TeamManager.IsInit())
             {
-              string[] argsClone = new string[args == null ? 1 : args.Length + 1];
-              if (args != null && args.Length > 1)
-              {
-                  args.CopyTo(argsClone, 1);
-              }
-              argsClone[0] = "Tizen.Applications.Team.dll";
-
-              TeamManager.Init(argsClone);
-              Log.Info("DN_TAM", $"Launching Team Loop.");
+              Log.Error("DN_TAM", $"Team Loop is not running!. Launch app via launcher.");
               return;
             }
 

--- a/src/Tizen.Applications.Team/Tizen.Applications.CoreBackend/TeamViewCoreBackend.cs
+++ b/src/Tizen.Applications.Team/Tizen.Applications.CoreBackend/TeamViewCoreBackend.cs
@@ -108,15 +108,7 @@ namespace Tizen.Applications.CoreBackend
             // base.Run() is not required.
             if (!TeamManager.IsInit())
             {
-              string[] argsClone = new string[args == null ? 1 : args.Length + 1];
-              if (args != null && args.Length > 1)
-              {
-                  args.CopyTo(argsClone, 1);
-              }
-              argsClone[0] = "Tizen.Applications.Team.dll";
-
-              TeamManager.Init(argsClone);
-              Log.Info("DN_TAM", $"Launching Team Loop.");
+              Log.Error("DN_TAM", $"Team Loop is not running!. Launch app via launcher.");
               return;
             }
 

--- a/src/Tizen.Applications.TeamLauncher/TeamLauncher.cs
+++ b/src/Tizen.Applications.TeamLauncher/TeamLauncher.cs
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Reflection;
+using System.Runtime.Loader;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.Applications
+{
+  internal static class TeamLauncher{
+    static void Main(string[] args)
+    {
+      if(!TeamManager.IsInit())
+      {
+        Log.Info("TeamLauncher", $"Loop Start");
+        string[] argsClone = new string[args == null ? 1 : args.Length + 1];
+        if (args != null && args.Length > 1)
+        {
+            args.CopyTo(argsClone, 1);
+        }
+        argsClone[0] = "Tizen.Applications.TeamLauncher.dll";
+        TeamManager.Init(argsClone);
+      }
+      else
+      {
+        Log.Info("TeamLauncher", $"Loop is already running");
+      }
+    }
+  }
+}

--- a/src/Tizen.Applications.TeamLauncher/Tizen.Applications.TeamLauncher.csproj
+++ b/src/Tizen.Applications.TeamLauncher/Tizen.Applications.TeamLauncher.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Tizen.Applications.Team\Tizen.Applications.Team.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
[Tizen.Applications] Remove TeamLoop CreateLib Op & Create Launcher
- TeamLoop now use app exec path as dynlib
- The operation is not required
- Team Launcher dll will be used as team application launcher