### PR TITLE
[NUI][API13_MR] Remove `NUIInitializer.IsInitialized` check at Registry + Mark `IsPreload = true` at begin of `Preload()`

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/DisposeQueue.cs
+++ b/src/Tizen.NUI/src/internal/Common/DisposeQueue.cs
@@ -117,6 +117,14 @@ namespace Tizen.NUI
 
                 // 2023-12-18 Block this logic since some APP call some thread-dependency objects before application start.
                 // ProcessDisposables();
+
+                int disposablesCount = 0;
+                lock (listLock)
+                {
+                    disposablesCount = (int)disposables.Count;
+                }
+                Tizen.Log.Error("NUI", $" Type [{disposable?.GetType()?.FullName ?? "Unknown"}] disposed before NUI initialized! / Total disposed items : {disposablesCount}");
+                Tizen.Log.Error("NUI", "Must call NUIApplicationInitializer.Initialize() at least once if you want to use NUI framework");
             }
         }
 

--- a/src/Tizen.NUI/src/internal/Common/Registry.cs
+++ b/src/Tizen.NUI/src/internal/Common/Registry.cs
@@ -215,9 +215,9 @@ namespace Tizen.NUI
 
         private static void RegistryCurrentThreadCheck()
         {
-            if (!NUIApplicationInitializer.IsStaticInitialized || !NUIApplicationInitializer.IsInitialized)
+            if (!NUIApplicationInitializer.IsStaticInitialized)
             {
-                Tizen.Log.Fatal("NUI", $"Error! NUIApplicationInitializer.Initialize() not called! You cannot use NUI framework\n");
+                Tizen.Log.Fatal("NUI", $"Error! NUIApplicationInitializer.StaticInitialize() not called! You cannot use NUI framework\n");
                 return;
             }
             if (savedApplicationThread == null)

--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -879,6 +879,8 @@ namespace Tizen.NUI
                 return;
             }
 
+            IsPreload = true;
+
             Interop.Application.PreInitialize();
             SupportPreInitializedCreation = Interop.Application.IsSupportPreInitializedCreation();
 
@@ -911,8 +913,6 @@ namespace Tizen.NUI
 
             // Initialize exception tasks. It must be called end of Preload()
             NDalicPINVOKE.Preload();
-
-            IsPreload = true;
         }
 
         /// <summary>


### PR DESCRIPTION
Apply gemini review points - Do not ignore registry at preload time. Instead, just print error log if some IDispose item disposed without NUIInitializer.Initialize()

Also, we'd better mark `IsPreload` at the begin of `Preload()` API, so we can ensure to block re-execute of `Preload()` twice ensurely.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
