### PR TITLE
Remove net8 Microsoft.NETCore.Platforms dependency from API14

### DIFF
--- a/pkg/Tizen.NET/Tizen.NET.nuspec
+++ b/pkg/Tizen.NET/Tizen.NET.nuspec
@@ -58,15 +58,12 @@
       </group>
       <group targetFramework="net8.0-tizen10.0">
         <dependency id="Tizen.NET.API13" version="13.0.0.19198" />
-        <dependency id="Microsoft.NETCore.Platforms" version="8.0.0-preview.7.23375.6" />
       </group>
       <group targetFramework="net8.0-tizen10.1">
         <dependency id="Tizen.NET.API14" version="$fxversion$" />
-        <dependency id="Microsoft.NETCore.Platforms" version="8.0.0-preview.7.23375.6" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="Tizen.NET.API14" version="$fxversion$" />
-        <dependency id="Microsoft.NETCore.Platforms" version="8.0.0-preview.7.23375.6" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
## Summary
- Remove the missing `Microsoft.NETCore.Platforms 8.0.0-preview.7.23375.6` dependency from the `net8.0*` Tizen.NET package groups.
- Keep the existing legacy and net6.0 `Microsoft.NETCore.Platforms` dependencies unchanged.

## Verification
- Parsed `pkg/Tizen.NET/Tizen.NET.nuspec` as XML.
- Ran `git diff --check`.

Related to #7634.