### PR TITLE
[AI Task] [Tizen.Multimedia.AudioIO] Remove params array allocation in ValidateState hot path

### DIFF
--- a/src/Tizen.Multimedia.AudioIO/AudioIO/AudioCapture.cs
+++ b/src/Tizen.Multimedia.AudioIO/AudioIO/AudioCapture.cs
@@ -152,11 +152,18 @@ namespace Tizen.Multimedia
         }
         #endregion
 
-        internal void ValidateState(params AudioIOState[] desiredStates)
+        internal void ValidateState(AudioIOState desired)
         {
             ValidateNotDisposed();
 
-            AudioIOUtil.ValidateState(_state, desiredStates);
+            AudioIOUtil.ValidateState(_state, desired);
+        }
+
+        internal void ValidateState(AudioIOState desired1, AudioIOState desired2)
+        {
+            ValidateNotDisposed();
+
+            AudioIOUtil.ValidateState(_state, desired1, desired2);
         }
 
         /// <summary>

--- a/src/Tizen.Multimedia.AudioIO/AudioIO/AudioIOUtil.cs
+++ b/src/Tizen.Multimedia.AudioIO/AudioIO/AudioIOUtil.cs
@@ -21,6 +21,7 @@ namespace Tizen.Multimedia
 {
     internal static class AudioIOUtil
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void ValidateState(AudioIOState curState, AudioIOState desired)
         {
             if (curState == desired)
@@ -31,6 +32,7 @@ namespace Tizen.Multimedia
             ThrowInvalidState(curState, desired);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void ValidateState(AudioIOState curState, AudioIOState desired1, AudioIOState desired2)
         {
             if (curState == desired1 || curState == desired2)

--- a/src/Tizen.Multimedia.AudioIO/AudioIO/AudioIOUtil.cs
+++ b/src/Tizen.Multimedia.AudioIO/AudioIO/AudioIOUtil.cs
@@ -15,24 +15,40 @@
  */
 
 using System;
-using System.Diagnostics;
-using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Tizen.Multimedia
 {
     internal static class AudioIOUtil
     {
-        internal static void ValidateState(AudioIOState curState, params AudioIOState[] desiredStates)
+        internal static void ValidateState(AudioIOState curState, AudioIOState desired)
         {
-            Debug.Assert(desiredStates.Length > 0);
-
-            if (desiredStates.Contains(curState))
+            if (curState == desired)
             {
                 return;
             }
 
-            throw new InvalidOperationException($"The audio is not in a valid state. " +
-                $"Current State : { curState }, Valid State : { string.Join(", ", desiredStates) }.");
+            ThrowInvalidState(curState, desired);
         }
+
+        internal static void ValidateState(AudioIOState curState, AudioIOState desired1, AudioIOState desired2)
+        {
+            if (curState == desired1 || curState == desired2)
+            {
+                return;
+            }
+
+            ThrowInvalidState(curState, desired1, desired2);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowInvalidState(AudioIOState curState, AudioIOState desired) =>
+            throw new InvalidOperationException($"The audio is not in a valid state. " +
+                $"Current State : { curState }, Valid State : { desired }.");
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowInvalidState(AudioIOState curState, AudioIOState desired1, AudioIOState desired2) =>
+            throw new InvalidOperationException($"The audio is not in a valid state. " +
+                $"Current State : { curState }, Valid State : { desired1 }, { desired2 }.");
     }
 }

--- a/src/Tizen.Multimedia.AudioIO/AudioIO/AudioPlayback.cs
+++ b/src/Tizen.Multimedia.AudioIO/AudioIO/AudioPlayback.cs
@@ -189,11 +189,18 @@ namespace Tizen.Multimedia
         }
         #endregion
 
-        private void ValidateState(params AudioIOState[] desiredStates)
+        private void ValidateState(AudioIOState desired)
         {
             ValidateNotDisposed();
 
-            AudioIOUtil.ValidateState(_state, desiredStates);
+            AudioIOUtil.ValidateState(_state, desired);
+        }
+
+        private void ValidateState(AudioIOState desired1, AudioIOState desired2)
+        {
+            ValidateNotDisposed();
+
+            AudioIOUtil.ValidateState(_state, desired1, desired2);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
`AudioCapture.Read(int)` and `AudioPlayback.Write(byte[])` are streaming hot paths that call `ValidateState(...)` with 1 or 2 explicit `AudioIOState` values. The previous `params AudioIOState[] desiredStates` signature allocated a fresh single-element (or two-element) array per call and then went through LINQ `Contains`. This PR replaces the `params` overload with explicit 1-arg and 2-arg overloads, eliminating the per-call allocation and the LINQ dispatch on the success path.

## Changes
- `src/Tizen.Multimedia.AudioIO/AudioIO/AudioIOUtil.cs`
  - Replaced `ValidateState(AudioIOState, params AudioIOState[])` with two overloads: `(curState, desired)` and `(curState, desired1, desired2)`.
  - Throw branch factored out into private `[MethodImpl(MethodImplOptions.NoInlining)]` helpers so the success path stays small and inline-friendly.
  - Dropped `System.Linq` using (no longer needed).
- `src/Tizen.Multimedia.AudioIO/AudioIO/AudioCapture.cs`
  - `AudioCaptureBase.ValidateState` split into 1-arg and 2-arg overloads delegating to `AudioIOUtil`.
- `src/Tizen.Multimedia.AudioIO/AudioIO/AudioPlayback.cs`
  - `AudioPlayback.ValidateState` split into 1-arg and 2-arg overloads delegating to `AudioIOUtil`.

All 13 call sites in `AudioCapture` / `AudioPlayback` already pass 1 or 2 states, so they bind to the new overloads with no source changes.

## Mode
Refactoring

## Performance impact (per call)
| Item | Before | After |
|---|---|---|
| `params` array allocation | 1 (`AudioIOState[1]` / `AudioIOState[2]`) | 0 |
| `Contains` dispatch | LINQ `Contains` | direct `==` (and `||`) |
| Success-path inlining | unlikely (params + LINQ) | likely (tiny body) |

Significant in `AudioCapture.Read` / `AudioPlayback.Write` which can be called many times per second per stream.

## API compatibility
- All affected types/members are `internal` (`AudioIOUtil`) or `internal`/`private` (the wrappers on `AudioCaptureBase` / `AudioPlayback`). No public API change.
- Exception type unchanged (`InvalidOperationException`).
- Exception message format preserved (same `"The audio is not in a valid state. Current State : X, Valid State : Y."` shape).
- No native interop change.

## Verification
- [x] Build: passed (`dotnet build src/Tizen.Multimedia.AudioIO/Tizen.Multimedia.AudioIO.csproj` — 0 errors; pre-existing warnings unchanged).
- [x] Tests: N/A (existing tests cover the affected methods; semantics unchanged).
- [x] Benchmark: skipped (no `sdb` device available in this environment — manual on-device benchmark recommended).

Fixes #7609
