### PR TITLE
Fix NullReferenceException in NUIGadgetManager

### DIFF
--- a/src/Tizen.Applications.UIGadget/Tizen.Applications/UIGadgetInfo.cs
+++ b/src/Tizen.Applications.UIGadget/Tizen.Applications/UIGadgetInfo.cs
@@ -222,9 +222,10 @@ namespace Tizen.Applications
 
         internal static UIGadgetInfo CreateUIGadgetInfo(string packageId)
         {
+            IntPtr handle = IntPtr.Zero;
             try
             {
-                Interop.PackageManagerInfo.ErrorCode errorCode = Interop.PackageManagerInfo.PackageInfoGet(packageId, out IntPtr handle);
+                Interop.PackageManagerInfo.ErrorCode errorCode = Interop.PackageManagerInfo.PackageInfoGet(packageId, out handle);
                 if (errorCode != Interop.PackageManagerInfo.ErrorCode.None)
                 {
                     Log.Error("Failed to get package info. packageId: " + packageId + ", error = " + errorCode);
@@ -232,21 +233,10 @@ namespace Tizen.Applications
                 }
 
                 UIGadgetInfo info = new UIGadgetInfo(packageId);
-                if (info == null)
-                {
-                    Log.Error("Failed to create UIGadgetInfo. packageId: " + packageId);
-                    return null;
-                }
 
                 SetResourceType(info, handle);
                 SetResourceVersion(info, handle);
                 SetMetadata(info, handle);
-
-                errorCode = Interop.PackageManagerInfo.PackageInfoDestroy(handle);
-                if (errorCode != Interop.PackageManagerInfo.ErrorCode.None)
-                {
-                    Log.Warn("Failed to destroy package info. error = " + errorCode);
-                }
 
                 SetExecutableFile(info);
                 SetResourceFile(info);
@@ -259,6 +249,17 @@ namespace Tizen.Applications
             {
                 Log.Error("Exception occurred while creating UIGadgetInfo. packageId: " + packageId + ", exception: " + e);
                 return null;
+            }
+            finally
+            {
+                if (handle != IntPtr.Zero)
+                {
+                    Interop.PackageManagerInfo.ErrorCode errorCode = Interop.PackageManagerInfo.PackageInfoDestroy(handle);
+                    if (errorCode != Interop.PackageManagerInfo.ErrorCode.None)
+                    {
+                        Log.Warn("Failed to destroy package info. error = " + errorCode);
+                    }
+                }
             }
         }
     }

--- a/src/Tizen.Applications.UIGadget/Tizen.Applications/UIGadgetInfo.cs
+++ b/src/Tizen.Applications.UIGadget/Tizen.Applications/UIGadgetInfo.cs
@@ -245,11 +245,6 @@ namespace Tizen.Applications
                 SetUIGadgetResourcePath(info);
                 return info;
             }
-            catch (Exception e)
-            {
-                Log.Error("Exception occurred while creating UIGadgetInfo. packageId: " + packageId + ", exception: " + e);
-                return null;
-            }
             finally
             {
                 if (handle != IntPtr.Zero)

--- a/src/Tizen.Applications.UIGadget/Tizen.Applications/UIGadgetInfo.cs
+++ b/src/Tizen.Applications.UIGadget/Tizen.Applications/UIGadgetInfo.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2025 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -222,31 +222,44 @@ namespace Tizen.Applications
 
         internal static UIGadgetInfo CreateUIGadgetInfo(string packageId)
         {
-            Interop.PackageManagerInfo.ErrorCode errorCode = Interop.PackageManagerInfo.PackageInfoGet(packageId, out IntPtr handle);
-            if (errorCode != Interop.PackageManagerInfo.ErrorCode.None)
+            try
             {
-                Log.Error("Failed to get package info. error = " + errorCode);
+                Interop.PackageManagerInfo.ErrorCode errorCode = Interop.PackageManagerInfo.PackageInfoGet(packageId, out IntPtr handle);
+                if (errorCode != Interop.PackageManagerInfo.ErrorCode.None)
+                {
+                    Log.Error("Failed to get package info. packageId: " + packageId + ", error = " + errorCode);
+                    return null;
+                }
+
+                UIGadgetInfo info = new UIGadgetInfo(packageId);
+                if (info == null)
+                {
+                    Log.Error("Failed to create UIGadgetInfo. packageId: " + packageId);
+                    return null;
+                }
+
+                SetResourceType(info, handle);
+                SetResourceVersion(info, handle);
+                SetMetadata(info, handle);
+
+                errorCode = Interop.PackageManagerInfo.PackageInfoDestroy(handle);
+                if (errorCode != Interop.PackageManagerInfo.ErrorCode.None)
+                {
+                    Log.Warn("Failed to destroy package info. error = " + errorCode);
+                }
+
+                SetExecutableFile(info);
+                SetResourceFile(info);
+                SetResourceClassName(info);
+                SetResourcePath(info);
+                SetUIGadgetResourcePath(info);
+                return info;
+            }
+            catch (Exception e)
+            {
+                Log.Error("Exception occurred while creating UIGadgetInfo. packageId: " + packageId + ", exception: " + e);
                 return null;
             }
-
-            UIGadgetInfo info = new UIGadgetInfo(packageId);
-
-            SetResourceType(info, handle);
-            SetResourceVersion(info, handle);
-            SetMetadata(info, handle);
-
-            errorCode = Interop.PackageManagerInfo.PackageInfoDestroy(handle);
-            if (errorCode != Interop.PackageManagerInfo.ErrorCode.None)
-            {
-                Log.Warn("Failed to destroy package info. error = " + errorCode);
-            }
-
-            SetExecutableFile(info);
-            SetResourceFile(info);
-            SetResourceClassName(info);
-            SetResourcePath(info);
-            SetUIGadgetResourcePath(info);
-            return info;
         }
     }
 }

--- a/src/Tizen.Applications.UIGadget/Tizen.Applications/UIGadgetManager.cs
+++ b/src/Tizen.Applications.UIGadget/Tizen.Applications/UIGadgetManager.cs
@@ -39,53 +39,43 @@ namespace Tizen.Applications
 
         static UIGadgetManager()
         {
-            try
+            var ptr = Interop.Libc.GetEnvironmentVariable("GADGET_PKGIDS");
+            if (ptr != IntPtr.Zero)
             {
-                var ptr = Interop.Libc.GetEnvironmentVariable("GADGET_PKGIDS");
-                if (ptr != IntPtr.Zero)
+                var packages = Marshal.PtrToStringAnsi(ptr);
+                if (!string.IsNullOrWhiteSpace(packages))
                 {
-                    var packages = Marshal.PtrToStringAnsi(ptr);
-                    if (!string.IsNullOrWhiteSpace(packages))
+                    foreach (var pkg in packages.Split(':'))
                     {
-                        foreach (var pkg in packages.Split(':'))
+                        try
                         {
                             var info = UIGadgetInfo.CreateUIGadgetInfo(pkg);
                             if (info != null)
                             {
-                                try
-                                {
-                                    _gadgetInfos.TryAdd(info.ResourceType, info);
-                                }
-                                catch (Exception e) when (e is ArgumentNullException || e is OverflowException)
-                                {
-                                    Log.Error("Exception occurs while adding gadget info. packageId: " + pkg + ", " + e.Message);
-                                }
+                                _gadgetInfos.TryAdd(info.ResourceType, info);
                             }
+                        }
+                        catch (Exception e)
+                        {
+                            Log.Error("Exception occurs while creating gadget info. packageId: " + pkg + ", " + e);
                         }
                     }
                 }
-                else
-                {
-                    Log.Warn("Failed to get environment variable");
-                }
-
-                var app = CoreApplication.Current as CoreApplication;
-                if (app != null)
-                {
-                    app.AppControlReceived += (s, e) => HandleAppControl(e);
-                    app.LowMemory += (s, e) => HandleLowMemoryEvent(e);
-                    app.LowBattery += (s, e) => HandleLowBatteryEvent(e);
-                    app.LocaleChanged += (s, e) => HandleLocaleChangedEvent(e);
-                    app.RegionFormatChanged += (s, e) => HandleRegionFormatChangedEvent(e);
-                    app.DeviceOrientationChanged += (s, e) => HandleDeviceOrientationChangedEvent(e);
-                }
-
-                UIGadgetLifecycleEventBroker.LifecycleChanged += OnUIGadgetLifecycleChanged;
             }
-            catch (Exception e)
+            else
             {
-                Log.Error("Exception occurs in UIGadgetManager static constructor. " + e);
+                Log.Warn("Failed to get environment variable");
             }
+
+            var app = (CoreApplication)CoreApplication.Current;
+            app.AppControlReceived += (s, e) => HandleAppControl(e);
+            app.LowMemory += (s, e) => HandleLowMemoryEvent(e);
+            app.LowBattery += (s, e) => HandleLowBatteryEvent(e);
+            app.LocaleChanged += (s, e) => HandleLocaleChangedEvent(e);
+            app.RegionFormatChanged += (s, e) => HandleRegionFormatChangedEvent(e);
+            app.DeviceOrientationChanged += (s, e) => HandleDeviceOrientationChangedEvent(e);
+
+            UIGadgetLifecycleEventBroker.LifecycleChanged += OnUIGadgetLifecycleChanged;
         }
 
         /// <summary>
@@ -658,17 +648,17 @@ namespace Tizen.Applications
             {
                 foreach (var pkg in pkgList.Split(':'))
                 {
-                    var info = UIGadgetInfo.CreateUIGadgetInfo(pkg);
-                    if (info != null)
+                    try
                     {
-                        try
+                        var info = UIGadgetInfo.CreateUIGadgetInfo(pkg);
+                        if (info != null)
                         {
                             _gadgetInfos.TryAdd(info.ResourceType, info);
                         }
-                        catch (Exception e) when (e is ArgumentNullException || e is OverflowException)
-                        {
-                            Log.Error("Exception occurs while adding gadget info. packageId: " + pkg + ", " + e.Message);
-                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Error("Exception occurs while creating gadget info. packageId: " + pkg + ", " + e);
                     }
                 }
             }

--- a/src/Tizen.Applications.UIGadget/Tizen.Applications/UIGadgetManager.cs
+++ b/src/Tizen.Applications.UIGadget/Tizen.Applications/UIGadgetManager.cs
@@ -39,43 +39,57 @@ namespace Tizen.Applications
 
         static UIGadgetManager()
         {
-            var ptr = Interop.Libc.GetEnvironmentVariable("GADGET_PKGIDS");
-            if (ptr != IntPtr.Zero)
+            try
             {
-                var packages = Marshal.PtrToStringAnsi(ptr);
-                if (!string.IsNullOrWhiteSpace(packages))
+                var ptr = Interop.Libc.GetEnvironmentVariable("GADGET_PKGIDS");
+                if (ptr != IntPtr.Zero)
                 {
-                    foreach (var pkg in packages.Split(':'))
+                    var packages = Marshal.PtrToStringAnsi(ptr);
+                    if (!string.IsNullOrWhiteSpace(packages))
                     {
-                        var info = UIGadgetInfo.CreateUIGadgetInfo(pkg);
-                        if (info != null)
+                        foreach (var pkg in packages.Split(':'))
                         {
                             try
                             {
-                                _gadgetInfos.TryAdd(info.ResourceType, info);
+                                var info = UIGadgetInfo.CreateUIGadgetInfo(pkg);
+                                if (info != null)
+                                {
+                                    try
+                                    {
+                                        _gadgetInfos.TryAdd(info.ResourceType, info);
+                                    }
+                                    catch (Exception e) when (e is ArgumentNullException || e is OverflowException)
+                                    {
+                                        Log.Error("Exception occurs while adding gadget info. packageId: " + pkg + ", " + e.Message);
+                                    }
+                                }
                             }
-                            catch (Exception e) when (e is ArgumentNullException || e is OverflowException)
+                            catch (Exception e)
                             {
-                                Log.Error("Exception occurs. " + e.Message);
+                                Log.Error("Exception occurs while creating gadget info. packageId: " + pkg + ", " + e);
                             }
                         }
                     }
                 }
+                else
+                {
+                    Log.Warn("Failed to get environment variable");
+                }
+
+                var app = (CoreApplication)CoreApplication.Current;
+                app.AppControlReceived += (s, e) => HandleAppControl(e);
+                app.LowMemory += (s, e) => HandleLowMemoryEvent(e);
+                app.LowBattery += (s, e) => HandleLowBatteryEvent(e);
+                app.LocaleChanged += (s, e) => HandleLocaleChangedEvent(e);
+                app.RegionFormatChanged += (s, e) => HandleRegionFormatChangedEvent(e);
+                app.DeviceOrientationChanged += (s, e) => HandleDeviceOrientationChangedEvent(e);
+
+                UIGadgetLifecycleEventBroker.LifecycleChanged += OnUIGadgetLifecycleChanged;
             }
-            else
+            catch (Exception e)
             {
-                Log.Warn("Failed to get environment variable");
+                Log.Error("Exception occurs in UIGadgetManager static constructor. " + e);
             }
-
-            var app = (CoreApplication)CoreApplication.Current;
-            app.AppControlReceived += (s, e) => HandleAppControl(e);
-            app.LowMemory += (s, e) => HandleLowMemoryEvent(e);
-            app.LowBattery += (s, e) => HandleLowBatteryEvent(e);
-            app.LocaleChanged += (s, e) => HandleLocaleChangedEvent(e);
-            app.RegionFormatChanged += (s, e) => HandleRegionFormatChangedEvent(e);
-            app.DeviceOrientationChanged += (s, e) => HandleDeviceOrientationChangedEvent(e);
-
-            UIGadgetLifecycleEventBroker.LifecycleChanged += OnUIGadgetLifecycleChanged;
         }
 
         /// <summary>
@@ -648,17 +662,24 @@ namespace Tizen.Applications
             {
                 foreach (var pkg in pkgList.Split(':'))
                 {
-                    var info = UIGadgetInfo.CreateUIGadgetInfo(pkg);
-                    if (info != null)
+                    try
                     {
-                        try
+                        var info = UIGadgetInfo.CreateUIGadgetInfo(pkg);
+                        if (info != null)
                         {
-                            _gadgetInfos.TryAdd(info.ResourceType, info);
+                            try
+                            {
+                                _gadgetInfos.TryAdd(info.ResourceType, info);
+                            }
+                            catch (Exception e) when (e is ArgumentNullException || e is OverflowException)
+                            {
+                                Log.Error("Exception occurs while adding gadget info. packageId: " + pkg + ", " + e.Message);
+                            }
                         }
-                        catch (Exception e) when (e is ArgumentNullException || e is OverflowException)
-                        {
-                            Log.Error("Exception occurs. " + e.Message);
-                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Error("Exception occurs while creating gadget info. packageId: " + pkg + ", " + e);
                     }
                 }
             }

--- a/src/Tizen.Applications.UIGadget/Tizen.Applications/UIGadgetManager.cs
+++ b/src/Tizen.Applications.UIGadget/Tizen.Applications/UIGadgetManager.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2025 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -49,24 +49,17 @@ namespace Tizen.Applications
                     {
                         foreach (var pkg in packages.Split(':'))
                         {
-                            try
+                            var info = UIGadgetInfo.CreateUIGadgetInfo(pkg);
+                            if (info != null)
                             {
-                                var info = UIGadgetInfo.CreateUIGadgetInfo(pkg);
-                                if (info != null)
+                                try
                                 {
-                                    try
-                                    {
-                                        _gadgetInfos.TryAdd(info.ResourceType, info);
-                                    }
-                                    catch (Exception e) when (e is ArgumentNullException || e is OverflowException)
-                                    {
-                                        Log.Error("Exception occurs while adding gadget info. packageId: " + pkg + ", " + e.Message);
-                                    }
+                                    _gadgetInfos.TryAdd(info.ResourceType, info);
                                 }
-                            }
-                            catch (Exception e)
-                            {
-                                Log.Error("Exception occurs while creating gadget info. packageId: " + pkg + ", " + e);
+                                catch (Exception e) when (e is ArgumentNullException || e is OverflowException)
+                                {
+                                    Log.Error("Exception occurs while adding gadget info. packageId: " + pkg + ", " + e.Message);
+                                }
                             }
                         }
                     }
@@ -76,13 +69,16 @@ namespace Tizen.Applications
                     Log.Warn("Failed to get environment variable");
                 }
 
-                var app = (CoreApplication)CoreApplication.Current;
-                app.AppControlReceived += (s, e) => HandleAppControl(e);
-                app.LowMemory += (s, e) => HandleLowMemoryEvent(e);
-                app.LowBattery += (s, e) => HandleLowBatteryEvent(e);
-                app.LocaleChanged += (s, e) => HandleLocaleChangedEvent(e);
-                app.RegionFormatChanged += (s, e) => HandleRegionFormatChangedEvent(e);
-                app.DeviceOrientationChanged += (s, e) => HandleDeviceOrientationChangedEvent(e);
+                var app = CoreApplication.Current as CoreApplication;
+                if (app != null)
+                {
+                    app.AppControlReceived += (s, e) => HandleAppControl(e);
+                    app.LowMemory += (s, e) => HandleLowMemoryEvent(e);
+                    app.LowBattery += (s, e) => HandleLowBatteryEvent(e);
+                    app.LocaleChanged += (s, e) => HandleLocaleChangedEvent(e);
+                    app.RegionFormatChanged += (s, e) => HandleRegionFormatChangedEvent(e);
+                    app.DeviceOrientationChanged += (s, e) => HandleDeviceOrientationChangedEvent(e);
+                }
 
                 UIGadgetLifecycleEventBroker.LifecycleChanged += OnUIGadgetLifecycleChanged;
             }
@@ -662,24 +658,17 @@ namespace Tizen.Applications
             {
                 foreach (var pkg in pkgList.Split(':'))
                 {
-                    try
+                    var info = UIGadgetInfo.CreateUIGadgetInfo(pkg);
+                    if (info != null)
                     {
-                        var info = UIGadgetInfo.CreateUIGadgetInfo(pkg);
-                        if (info != null)
+                        try
                         {
-                            try
-                            {
-                                _gadgetInfos.TryAdd(info.ResourceType, info);
-                            }
-                            catch (Exception e) when (e is ArgumentNullException || e is OverflowException)
-                            {
-                                Log.Error("Exception occurs while adding gadget info. packageId: " + pkg + ", " + e.Message);
-                            }
+                            _gadgetInfos.TryAdd(info.ResourceType, info);
                         }
-                    }
-                    catch (Exception e)
-                    {
-                        Log.Error("Exception occurs while creating gadget info. packageId: " + pkg + ", " + e);
+                        catch (Exception e) when (e is ArgumentNullException || e is OverflowException)
+                        {
+                            Log.Error("Exception occurs while adding gadget info. packageId: " + pkg + ", " + e.Message);
+                        }
                     }
                 }
             }

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
@@ -36,37 +36,23 @@ namespace Tizen.NUI
 
         static NUIGadgetManager()
         {
-            try
-            {
-                LoadGadgetInfos();
-                UIGadgetLifecycleEventBroker.LifecycleChanged += OnUIGadgetLifecycleChanged;
-            }
-            catch (Exception e)
-            {
-                Log.Error("Exception occurs in NUIGadgetManager static constructor. " + e);
-            }
+            LoadGadgetInfos();
+            UIGadgetLifecycleEventBroker.LifecycleChanged += OnUIGadgetLifecycleChanged;
         }
 
         private static void LoadGadgetInfos()
         {
-            try
+            foreach (var info in UIGadgetManager.GetUIGadgetInfos())
             {
-                foreach (var info in UIGadgetManager.GetUIGadgetInfos())
+                try
                 {
-                    try
-                    {
-                        var gadgetInfo = new NUIGadgetInfo(info);
-                        _gadgetInfos.TryAdd(gadgetInfo.ResourceType, gadgetInfo);
-                    }
-                    catch (Exception e)
-                    {
-                        Log.Error("Exception occurs while creating NUIGadgetInfo. packageId: " + info.PackageId + ", " + e);
-                    }
+                    var gadgetInfo = new NUIGadgetInfo(info);
+                    _gadgetInfos.TryAdd(gadgetInfo.ResourceType, gadgetInfo);
                 }
-            }
-            catch (Exception e)
-            {
-                Log.Error("Exception occurs in LoadGadgetInfos. " + e);
+                catch (Exception e) when (e is ArgumentNullException || e is OverflowException)
+                {
+                    Log.Error("Exception occurs. " + e.Message);
+                }
             }
         }
 
@@ -572,17 +558,10 @@ namespace Tizen.NUI
         /// <since_tizen> 13 </since_tizen>
         public static void Refresh()
         {
-            try
-            {
-                UIGadgetManager.Refresh();
-                _gadgetInfos.Clear();
-                LoadGadgetInfos();
-                Log.Info("# of Gadget after refresh (" + _gadgetInfos.Count + ")");
-            }
-            catch (Exception e)
-            {
-                Log.Error("Exception occurs in NUIGadgetManager.Refresh. " + e);
-            }
+            UIGadgetManager.Refresh();
+            _gadgetInfos.Clear();
+            LoadGadgetInfos();
+            Log.Info("# of Gadget after refresh (" + _gadgetInfos.Count + ")");
         }
     }
 }

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
@@ -56,10 +56,7 @@ namespace Tizen.NUI
                     try
                     {
                         var gadgetInfo = new NUIGadgetInfo(info);
-                        if (gadgetInfo != null)
-                        {
-                            _gadgetInfos.TryAdd(gadgetInfo.ResourceType, gadgetInfo);
-                        }
+                        _gadgetInfos.TryAdd(gadgetInfo.ResourceType, gadgetInfo);
                     }
                     catch (Exception e)
                     {

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2023 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -36,26 +36,40 @@ namespace Tizen.NUI
 
         static NUIGadgetManager()
         {
-            LoadGadgetInfos();
-            UIGadgetLifecycleEventBroker.LifecycleChanged += OnUIGadgetLifecycleChanged;
+            try
+            {
+                LoadGadgetInfos();
+                UIGadgetLifecycleEventBroker.LifecycleChanged += OnUIGadgetLifecycleChanged;
+            }
+            catch (Exception e)
+            {
+                Log.Error("Exception occurs in NUIGadgetManager static constructor. " + e);
+            }
         }
 
         private static void LoadGadgetInfos()
         {
-            foreach (var info in UIGadgetManager.GetUIGadgetInfos())
+            try
             {
-                try
+                foreach (var info in UIGadgetManager.GetUIGadgetInfos())
                 {
-                    var gadgetInfo = new NUIGadgetInfo(info);
-                    if (gadgetInfo != null)
+                    try
                     {
-                        _gadgetInfos.TryAdd(gadgetInfo.ResourceType, gadgetInfo);
+                        var gadgetInfo = new NUIGadgetInfo(info);
+                        if (gadgetInfo != null)
+                        {
+                            _gadgetInfos.TryAdd(gadgetInfo.ResourceType, gadgetInfo);
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Error("Exception occurs while creating NUIGadgetInfo. packageId: " + info.PackageId + ", " + e);
                     }
                 }
-                catch (Exception e) when (e is ArgumentNullException || e is OverflowException)
-                {
-                    Log.Error("Exception occurs. " + e.Message);
-                }
+            }
+            catch (Exception e)
+            {
+                Log.Error("Exception occurs in LoadGadgetInfos. " + e);
             }
         }
 
@@ -561,10 +575,17 @@ namespace Tizen.NUI
         /// <since_tizen> 13 </since_tizen>
         public static void Refresh()
         {
-            UIGadgetManager.Refresh();
-            _gadgetInfos.Clear();
-            LoadGadgetInfos();
-            Log.Info("# of Gadget after refresh (" + _gadgetInfos.Count + ")");
+            try
+            {
+                UIGadgetManager.Refresh();
+                _gadgetInfos.Clear();
+                LoadGadgetInfos();
+                Log.Info("# of Gadget after refresh (" + _gadgetInfos.Count + ")");
+            }
+            catch (Exception e)
+            {
+                Log.Error("Exception occurs in NUIGadgetManager.Refresh. " + e);
+            }
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
- Wrap UIGadgetInfo.CreateUIGadgetInfo with try/catch and log packageId on exception
- Add try/catch in UIGadgetManager static constructor to prevent TypeInitializationException
- Add try/catch in foreach loop to continue loading other packages on failure
- Add try/catch in UIGadgetManager.Refresh() with packageId in error logs
- Add try/catch in NUIGadgetManager static constructor, LoadGadgetInfos, and Refresh


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: N/A

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
