### PR TITLE
[NUI][API14][TCSACR-652] Make deprecated class `Tizen.NUI.Adaptor` as internal

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/Adaptor.cs
+++ b/src/Tizen.NUI/src/internal/Common/Adaptor.cs
@@ -36,9 +36,10 @@ namespace Tizen.NUI
     /// need to wait for an initialize signal as per the Tizen.NUI.Application class).
     ///
     /// </summary>
-    /// <since_tizen> 4 </since_tizen>
-    [Obsolete("This has been deprecated in API8 and will be removed in API10. This is not used anymore, do not use.")]
-    public class Adaptor : Disposable
+    /// <remarks>
+    /// Deprecated at API8; made internal in API14.
+    /// </remarks>
+    internal class Adaptor : Disposable
     {
         private static readonly Adaptor instance = Adaptor.Get();
 
@@ -50,9 +51,7 @@ namespace Tizen.NUI
         /// Returns a reference to the instance of the adaptor used by the current thread.
         /// </summary>
         /// <remarks>The adaptor has been initialized. This is only valid in the main thread.</remarks>
-        /// <since_tizen> 4 </since_tizen>
-        [Obsolete("This has been deprecated in API8 and will be removed in API10. This is not used anymore, do not use.")]
-        public static Adaptor Instance
+        internal static Adaptor Instance
         {
             get
             {
@@ -64,9 +63,7 @@ namespace Tizen.NUI
         /// Feeds a wheel event to the adaptor.
         /// </summary>
         /// <param name="wheelEvent">The wheel event.</param>
-        /// <since_tizen> 4 </since_tizen>
-        [Obsolete("This has been deprecated in API8 and will be removed in API10. This is not used anymore, do not use.")]
-        public void FeedWheelEvent(Wheel wheelEvent)
+        internal void FeedWheelEvent(Wheel wheelEvent)
         {
             Interop.Adaptor.FeedWheelEvent(SwigCPtr, Wheel.getCPtr(wheelEvent));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -76,9 +73,7 @@ namespace Tizen.NUI
         /// Feeds a key event to the adaptor.
         /// </summary>
         /// <param name="keyEvent">The key event holding the key information.</param>
-        /// <since_tizen> 4 </since_tizen>
-        [Obsolete("This has been deprecated in API8 and will be removed in API10. This is not used anymore, do not use.")]
-        public void FeedKeyEvent(Key keyEvent)
+        internal void FeedKeyEvent(Key keyEvent)
         {
             Interop.Adaptor.FeedKeyEvent(SwigCPtr, Key.getCPtr(keyEvent));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -126,7 +121,6 @@ namespace Tizen.NUI
         /// ReleaseSwigCPtr
         /// </summary>
         /// <param name="swigCPtr"></param>
-        [Obsolete("This has been deprecated in API8 and will be removed in API10. This is not used anymore, do not use.")]
         // This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

[NUI] Make deprecated class `Tizen.NUI.Adaptor` as internal

Note : Some friend assembled project use `Adaptor.Instance` so we cannot remove it. Just keep it as internal.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: [TCSACR-652](https://jira.sec.samsung.net/browse/TCSACR-652)

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->

Removed:
 - class Tizen.NUI.Adaptor
 - static Adaptor Instance { get; }
 - void FeedWheelEvent(Wheel);
 - void FeedKeyEvent(Key);