### PR TITLE
[Tizen.WindowSystem] Replace manual null checks with ArgumentNullException.ThrowIfNull()

### DIFF
--- a/src/Tizen.WindowSystem/src/KVMService.cs
+++ b/src/Tizen.WindowSystem/src/KVMService.cs
@@ -50,18 +50,12 @@ namespace Tizen.WindowSystem.Shell
         /// <since_tizen> 12 </since_tizen>
         public KVMService(TizenShell tzShell, IWindowProvider win)
         {
-            if (tzShell == null)
-            {
-                throw new ArgumentNullException(nameof(tzShell));
-            }
+            ArgumentNullException.ThrowIfNull(tzShell);
             if (tzShell.SafeHandle == null || tzShell.SafeHandle.IsInvalid)
             {
                 throw new ArgumentException("tzShell is not initialized.");
             }
-            if (win == null)
-            {
-                throw new ArgumentNullException(nameof(win));
-            }
+            ArgumentNullException.ThrowIfNull(win);
 
             _tzsh = tzShell;
             _tzshWin = WindowSystem.Interop.EcoreWl2.GetWindowId(win.WindowHandle);

--- a/src/Tizen.WindowSystem/src/QuickPanelClient.cs
+++ b/src/Tizen.WindowSystem/src/QuickPanelClient.cs
@@ -60,18 +60,12 @@ namespace Tizen.WindowSystem.Shell
         public QuickPanelClient(TizenShell tzShell, IWindowProvider win, QuickPanelCategory type)
         {
             int width = 0, height = 0;
-            if (tzShell == null)
-            {
-                throw new ArgumentNullException("tzShell");
-            }
+            ArgumentNullException.ThrowIfNull(tzShell);
             if (tzShell.SafeHandle == null || tzShell.SafeHandle.IsInvalid)
             {
                 throw new ArgumentException("tzShell is not initialized.");
             }
-            if (win == null)
-            {
-                throw new ArgumentNullException("win");
-            }
+            ArgumentNullException.ThrowIfNull(win);
 
             _tzsh = tzShell;
             _tzshWin = WindowSystem.Interop.EcoreWl2.GetWindowId(win.WindowHandle);

--- a/src/Tizen.WindowSystem/src/QuickPanelService.cs
+++ b/src/Tizen.WindowSystem/src/QuickPanelService.cs
@@ -47,18 +47,12 @@ namespace Tizen.WindowSystem.Shell
         /// <since_tizen> 12 </since_tizen>
         public QuickPanelService(TizenShell tzShell, IWindowProvider win, QuickPanelCategory type)
         {
-            if (tzShell == null)
-            {
-                throw new ArgumentNullException(nameof(tzShell));
-            }
+            ArgumentNullException.ThrowIfNull(tzShell);
             if (tzShell.SafeHandle == null || tzShell.SafeHandle.IsInvalid)
             {
                 throw new ArgumentException("tzShell is not initialized.");
             }
-            if (win == null)
-            {
-                throw new ArgumentNullException(nameof(win));
-            }
+            ArgumentNullException.ThrowIfNull(win);
 
             _tzsh = tzShell;
             _tzshWin = WindowSystem.Interop.EcoreWl2.GetWindowId(win.WindowHandle);
@@ -187,10 +181,7 @@ namespace Tizen.WindowSystem.Shell
         /// <exception cref="ArgumentNullException">Thrown when an argument is null.</exception>
         public void SetContentRegion(uint angle, params (int x, int y, int width, int height)[] regions)
         {
-            if (regions == null)
-            {
-                throw new ArgumentNullException(nameof(regions));
-            }
+            ArgumentNullException.ThrowIfNull(regions);
 
             var regionHandle = Interop.TizenShellRegion.Create(_tzsh.SafeHandle);
             if (regionHandle.IsInvalid)
@@ -224,10 +215,7 @@ namespace Tizen.WindowSystem.Shell
         /// <exception cref="ArgumentNullException">Thrown when an argument is null.</exception>
         public void SetHandlerRegion(uint angle, params (int x, int y, int width, int height)[] regions)
         {
-            if (regions == null)
-            {
-                throw new ArgumentNullException(nameof(regions));
-            }
+            ArgumentNullException.ThrowIfNull(regions);
 
             var regionHandle = Interop.TizenShellRegion.Create(_tzsh.SafeHandle);
             if (regionHandle.IsInvalid)

--- a/src/Tizen.WindowSystem/src/ScreensaverService.cs
+++ b/src/Tizen.WindowSystem/src/ScreensaverService.cs
@@ -42,18 +42,12 @@ namespace Tizen.WindowSystem.Shell
         /// <exception cref="ArgumentNullException">Thrown when an argument is null.</exception>
         public ScreensaverService(TizenShell tzShell, IWindowProvider win)
         {
-            if (tzShell == null)
-            {
-                throw new ArgumentNullException(nameof(tzShell));
-            }
+            ArgumentNullException.ThrowIfNull(tzShell);
             if (tzShell.SafeHandle == null || tzShell.SafeHandle.IsInvalid)
             {
                 throw new ArgumentException("tzShell is not initialized.");
             }
-            if (win == null)
-            {
-                throw new ArgumentNullException(nameof(win));
-            }
+            ArgumentNullException.ThrowIfNull(win);
 
             _tzsh = tzShell;
             _tzshWin = WindowSystem.Interop.EcoreWl2.GetWindowId(win.WindowHandle);

--- a/src/Tizen.WindowSystem/src/SoftkeyClient.cs
+++ b/src/Tizen.WindowSystem/src/SoftkeyClient.cs
@@ -47,18 +47,12 @@ namespace Tizen.WindowSystem.Shell
         /// <since_tizen> 12 </since_tizen>        
         public SoftkeyClient(TizenShell tzShell, IWindowProvider win)
         {
-            if (tzShell == null)
-            {
-                throw new ArgumentNullException(nameof(tzShell));
-            }
+            ArgumentNullException.ThrowIfNull(tzShell);
             if (tzShell.SafeHandle == null || tzShell.SafeHandle.IsInvalid)
             {
                 throw new ArgumentException("tzShell is not initialized.");
             }
-            if (win == null)
-            {
-                throw new ArgumentNullException(nameof(win));
-            }
+            ArgumentNullException.ThrowIfNull(win);
 
             _tzsh = tzShell;
             _tzshWin = WindowSystem.Interop.EcoreWl2.GetWindowId(win.WindowHandle);

--- a/src/Tizen.WindowSystem/src/SoftkeyService.cs
+++ b/src/Tizen.WindowSystem/src/SoftkeyService.cs
@@ -50,18 +50,12 @@ namespace Tizen.WindowSystem.Shell
         /// <exception cref="ArgumentNullException">Thrown when a argument is null.</exception>
         public SoftkeyService(TizenShell tzShell, IWindowProvider win)
         {
-            if (tzShell == null)
-            {
-                throw new ArgumentNullException(nameof(tzShell));
-            }
+            ArgumentNullException.ThrowIfNull(tzShell);
             if (tzShell.SafeHandle == null || tzShell.SafeHandle.IsInvalid)
             {
                 throw new ArgumentException("tzShell is not initialized.");
             }
-            if (win == null)
-            {
-                throw new ArgumentNullException(nameof(win));
-            }
+            ArgumentNullException.ThrowIfNull(win);
 
             _tzsh = tzShell;
             _tzshWin = WindowSystem.Interop.EcoreWl2.GetWindowId(win.WindowHandle);

--- a/src/Tizen.WindowSystem/src/TaskbarService.cs
+++ b/src/Tizen.WindowSystem/src/TaskbarService.cs
@@ -44,18 +44,12 @@ namespace Tizen.WindowSystem.Shell
         /// <exception cref="ArgumentNullException">Thrown when a argument is null.</exception>
         public TaskbarService(TizenShell tzShell, IWindowProvider win, TaskbarPosition position = TaskbarPosition.Bottom)
         {
-            if (tzShell == null)
-            {
-                throw new ArgumentNullException(nameof(tzShell));
-            }
+            ArgumentNullException.ThrowIfNull(tzShell);
             if (tzShell.SafeHandle == null || tzShell.SafeHandle.IsInvalid)
             {
                 throw new ArgumentException("tzShell is not initialized.");
             }
-            if (win == null)
-            {
-                throw new ArgumentNullException(nameof(win));
-            }
+            ArgumentNullException.ThrowIfNull(win);
 
             _tzsh = tzShell;
             _tzshWin = WindowSystem.Interop.EcoreWl2.GetWindowId(win.WindowHandle);


### PR DESCRIPTION
## Summary
Replaces legacy `if (arg == null) throw new ArgumentNullException(nameof(arg));` patterns in `src/Tizen.WindowSystem` with the single-statement helper `ArgumentNullException.ThrowIfNull(arg)` introduced in .NET 6.

This is the second module-level slice of the umbrella refactor tracked in #7548 (the first slice, `Tizen.Applications.Common`, is in PR #7566).

## Changes
- `src/Tizen.WindowSystem/src/KVMService.cs` — constructor null checks for `tzShell`, `win`
- `src/Tizen.WindowSystem/src/QuickPanelService.cs` — constructor null checks for `tzShell`, `win`; `SetContentRegion` and `SetHandlerRegion` null check for `regions`
- `src/Tizen.WindowSystem/src/QuickPanelClient.cs` — constructor null checks for `tzShell`, `win` (also normalizes the pre-existing literal-string `paramName`s `"tzShell"` / `"win"` — `ArgumentNullException.ThrowIfNull` derives the same paramName via `CallerArgumentExpression`)
- `src/Tizen.WindowSystem/src/ScreensaverService.cs` — constructor null checks for `tzShell`, `win`
- `src/Tizen.WindowSystem/src/TaskbarService.cs` — constructor null checks for `tzShell`, `win`
- `src/Tizen.WindowSystem/src/SoftkeyClient.cs` — constructor null checks for `tzShell`, `win`
- `src/Tizen.WindowSystem/src/SoftkeyService.cs` — constructor null checks for `tzShell`, `win`

Net change: 7 files, +16 / -64 lines.

## Mode
Refactoring

## API Compatibility
| Item | Result |
|---|---|
| Public API signatures | Unchanged |
| Thrown exception type | Unchanged (`ArgumentNullException`) |
| `paramName` carried by exception | Unchanged (same `nameof(arg)` value; for the previous literal-string sites in `QuickPanelClient.cs`, the literal already matched the parameter name) |
| Native interop surface | Unchanged |
| Backward compatibility | 100% preserved |

## Verification
- [x] Build: `dotnet build src/Tizen.WindowSystem` → 0 errors, 4 unrelated warnings inherited from `Tizen.Applications.Common`
- [x] Tests: N/A — no behavior change; existing unit tests in dependent suites remain valid
- [x] Benchmark: skipped — the change is a behavior-preserving IL-size reduction; per-call cost is identical and these are not on hot paths. No sdb device available in this environment for runtime measurement.

Refs #7548
