### PR TITLE
[Tizen.Multimedia.AudioIO] Narrow Dispose() catch instead of swallowing all exceptions

### DIFF
--- a/src/Tizen.Multimedia.AudioIO/AudioIO/AudioCapture.cs
+++ b/src/Tizen.Multimedia.AudioIO/AudioIO/AudioCapture.cs
@@ -132,8 +132,17 @@ namespace Tizen.Multimedia
                     {
                         Unprepare();
                     }
-                    catch (Exception)
+                    catch (ObjectDisposedException)
                     {
+                        // Expected during shutdown races.
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        // Expected if the underlying handle has already been torn down.
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(GetType().Name, $"Unexpected error during Dispose: {ex}");
                     }
                 }
 

--- a/src/Tizen.Multimedia.AudioIO/AudioIO/AudioPlayback.cs
+++ b/src/Tizen.Multimedia.AudioIO/AudioIO/AudioPlayback.cs
@@ -169,8 +169,17 @@ namespace Tizen.Multimedia
                     {
                         Unprepare();
                     }
-                    catch (Exception)
+                    catch (ObjectDisposedException)
                     {
+                        // Expected during shutdown races.
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        // Expected if the underlying handle has already been torn down.
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(GetType().Name, $"Unexpected error during Dispose: {ex}");
                     }
                 }
 


### PR DESCRIPTION
## Summary
Replaces the catch-all `catch (Exception) { }` swallow pattern in `AudioCaptureBase.Dispose(bool)` and `AudioPlayback.Dispose(bool)` with a narrower set of catch clauses, so unexpected failures inside `Unprepare()` show up in dlog instead of disappearing.

## Changes
- `src/Tizen.Multimedia.AudioIO/AudioIO/AudioCapture.cs` (`Dispose(bool)`, around L131)
- `src/Tizen.Multimedia.AudioIO/AudioIO/AudioPlayback.cs` (`Dispose(bool)`, around L168)

For both files the previous block:

```csharp
try
{
    Unprepare();
}
catch (Exception)
{
}
```

is now:

```csharp
try
{
    Unprepare();
}
catch (ObjectDisposedException)
{
    // Expected during shutdown races.
}
catch (InvalidOperationException)
{
    // Expected if the underlying handle has already been torn down.
}
catch (Exception ex)
{
    Log.Error(GetType().Name, $"Unexpected error during Dispose: {ex}");
}
```

`ObjectDisposedException` is listed first because it derives from `InvalidOperationException` (C# requires the more-derived catch first).

## Mode
Refactoring

## Behavior & API Compatibility
| Item | Result |
|---|---|
| `Dispose(bool)` signature | Unchanged |
| Throws from `Dispose(bool)` | Still none (`Log.Error` is the only added side-effect for the unexpected case) |
| Normal teardown path | Same (the two formerly-silent exception types stay silent) |
| Public API surface | Unchanged |
| Tizen.Log dependency | Already present in `Tizen.Multimedia.AudioIO` (see existing usage at `AudioCapture.cs:474`) |

## Verification
- [x] Build: `dotnet build src/Tizen.Multimedia.AudioIO` → 0 errors, 0 new warnings
- [x] Tests: N/A — no behavior change for the documented contract; existing AudioIO tests remain valid
- [x] Benchmark: skipped — change is on the dispose path, not a hot path, and only adds error-path logging. No sdb device available in this environment for runtime measurement.

Fixes #7610
