### PR TITLE
[AI Task] [Tizen.Network.WiFi] Add RunContinuationsAsynchronously to async TCS

### DIFF
--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiAP.cs
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiAP.cs
@@ -228,7 +228,7 @@ namespace Tizen.Network.WiFi
             {
                 throw new ObjectDisposedException("Invalid AP instance (Object may have been disposed or released)");
             }
-            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
+            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             IntPtr id;
             lock (_callback_map)
             {
@@ -309,7 +309,7 @@ namespace Tizen.Network.WiFi
                 throw new ObjectDisposedException("Invalid AP instance (Object may have been disposed or released)");
             }
 
-            TaskCompletionSource<bool> wpsTask = new TaskCompletionSource<bool>();
+            TaskCompletionSource<bool> wpsTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             _wpsTaskMap[_apHandle] = wpsTask;
 
             IntPtr id;
@@ -407,7 +407,7 @@ namespace Tizen.Network.WiFi
         public static Task<WiFiAP> ConnectWpsWithoutSsidAsync(WpsInfo info)
         {
             Log.Info(Globals.LogTag, "ConnectWpsWithoutSsidAsync");
-            wpsWithoutSsidTask = new TaskCompletionSource<WiFiAP>();
+            wpsWithoutSsidTask = new TaskCompletionSource<WiFiAP>(TaskCreationOptions.RunContinuationsAsynchronously);
             IntPtr id;
             lock (s_callbackMap)
             {
@@ -536,7 +536,7 @@ namespace Tizen.Network.WiFi
             {
                 throw new ObjectDisposedException("Invalid AP instance (Object may have been disposed or released)");
             }
-            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
+            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             IntPtr id;
             lock (_callback_map)
             {
@@ -638,7 +638,7 @@ namespace Tizen.Network.WiFi
             {
                 throw new ObjectDisposedException("Invalid AP instance (Object may have been disposed or released)");
             }
-            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
+            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             IntPtr id;
             lock (_callback_map)
             {

--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
@@ -316,7 +316,7 @@ namespace Tizen.Network.WiFi
         internal Task ActivateAsync()
         {
             Log.Info(Globals.LogTag, "ActivateAsync");
-            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
+            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             IntPtr id;
             lock (_callback_map)
             {
@@ -362,7 +362,7 @@ namespace Tizen.Network.WiFi
         internal Task ActivateWithWiFiPickerTestedAsync()
         {
             Log.Info(Globals.LogTag, "ActivateWithWiFiPickerTestedAsync");
-            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
+            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             IntPtr id;
             lock (_callback_map)
             {
@@ -408,7 +408,7 @@ namespace Tizen.Network.WiFi
         internal Task DeactivateAsync()
         {
             Log.Info(Globals.LogTag, "DeactivateAsync");
-            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
+            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             IntPtr id;
             lock (_callback_map)
             {
@@ -454,7 +454,7 @@ namespace Tizen.Network.WiFi
         internal Task ScanAsync()
         {
             Log.Info(Globals.LogTag, "ScanAsync");
-            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
+            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             IntPtr id;
             lock (_callback_map)
             {
@@ -500,7 +500,7 @@ namespace Tizen.Network.WiFi
         internal Task ScanSpecificAPAsync(string essid)
         {
             Log.Info(Globals.LogTag, $"ScanSpecificAPAsync {essid}");
-            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
+            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             IntPtr id;
             lock (_callback_map)
             {
@@ -546,7 +546,7 @@ namespace Tizen.Network.WiFi
         internal Task BssidScanAsync()
         {
             Log.Info(Globals.LogTag, "BssidScanAsync");
-            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
+            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             IntPtr id;
             lock (_callback_map)
             {
@@ -599,7 +599,7 @@ namespace Tizen.Network.WiFi
         internal Task HiddenAPConnectAsync(string essid, int secType, string passphrase)
         {
             Log.Info(Globals.LogTag, "HiddenAPConnect");
-            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
+            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             IntPtr id;
             lock (_callback_map)
             {
@@ -667,7 +667,7 @@ namespace Tizen.Network.WiFi
         internal Task StartMultiScan()
         {
             Log.Debug(Globals.LogTag, "StartMultiScan");
-            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
+            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             IntPtr id;
             lock (_callback_map)
             {


### PR DESCRIPTION
## Summary
Add `TaskCreationOptions.RunContinuationsAsynchronously` to all 13 `TaskCompletionSource` construction sites in `Tizen.Network.WiFi` so that awaiter continuations no longer execute inline on the native callback thread.

## Changes
- `src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs` — 8 sites (`ActivateAsync`, `ActivateWithWiFiPickerTestedAsync`, `DeactivateAsync`, `ScanAsync`, `ScanSpecificAPAsync`, `BssidScanAsync`, `HiddenAPConnectAsync`, `StartMultiScan`).
- `src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiAP.cs` — 5 sites (`ConnectAsync`, `ConnectWpsAsync`, `ConnectWpsWithoutSsidAsync`, `DisconnectAsync`, `ForgetAPAsync`).

The only change per site is passing `TaskCreationOptions.RunContinuationsAsynchronously` to the `TaskCompletionSource` constructor. No signature changes, no behavior change apart from where continuations run.

## Mode
Refactoring

## Verification
- [x] Build: passed (`dotnet build` on `src/Tizen.Network.WiFi`, 0 errors)
- [ ] Tests: N/A (no unit tests for this internal async path in the repo)
- [ ] Benchmark: skipped (no sdb device available in this run; manual verification recommended on target)

Fixes #7620
