### PR TITLE
[AI Task] [Tizen.Multimedia.Camera] Remove params allocation from Camera.ValidateState

### DIFF
--- a/src/Tizen.Multimedia.Camera/Camera/Camera.cs
+++ b/src/Tizen.Multimedia.Camera/Camera/Camera.cs
@@ -215,19 +215,31 @@ namespace Tizen.Multimedia
         }
         #endregion Dispose support
 
-        internal void ValidateState(params CameraState[] required)
+        internal void ValidateState(CameraState required)
         {
             ValidateNotDisposed();
 
-            Debug.Assert(required.Length > 0);
-
             var curState = _state;
-            if (!required.Contains(curState))
+            if (curState != required)
             {
-                throw new InvalidOperationException($"The camera is not in a valid state. " +
-                    $"Current State : { curState }, Valid State : { string.Join(", ", required) }.");
+                ThrowInvalidState(curState, required);
             }
         }
+
+        internal void ValidateState(CameraState required1, CameraState required2)
+        {
+            ValidateNotDisposed();
+
+            var curState = _state;
+            if (curState != required1 && curState != required2)
+            {
+                ThrowInvalidState(curState, required1, required2);
+            }
+        }
+
+        private static void ThrowInvalidState(CameraState curState, params CameraState[] required) =>
+            throw new InvalidOperationException($"The camera is not in a valid state. " +
+                $"Current State : { curState }, Valid State : { string.Join(", ", required) }.");
 
         internal void SetState(CameraState state)
         {

--- a/src/Tizen.Multimedia.Camera/Camera/Camera.cs
+++ b/src/Tizen.Multimedia.Camera/Camera/Camera.cs
@@ -237,6 +237,7 @@ namespace Tizen.Multimedia
             }
         }
 
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         private static void ThrowInvalidState(CameraState curState, params CameraState[] required) =>
             throw new InvalidOperationException($"The camera is not in a valid state. " +
                 $"Current State : { curState }, Valid State : { string.Join(", ", required) }.");


### PR DESCRIPTION
## Summary
Split `Camera.ValidateState(params CameraState[])` into explicit 1-arg and 2-arg overloads to eliminate the per-call `CameraState[]` allocation plus LINQ `Contains` enumerator at every camera state guard.

## Changes
- `src/Tizen.Multimedia.Camera/Camera/Camera.cs`
  - Replace `internal void ValidateState(params CameraState[] required)` with two non-allocating overloads (`(CameraState)` and `(CameraState, CameraState)`).
  - Extract the exception path into a `private static ThrowInvalidState` helper that keeps the original `params`-based formatting so the thrown message is byte-identical.
- All 10 existing call sites (8 in `Camera.cs`, 2 in `Camera.Properties.cs`) pass exactly 1 or 2 constants and now bind to the new overloads without any change at the call site.

## Mode
Refactoring

## Verification
- [x] Build: passed (`dotnet build` on `src/Tizen.Multimedia.Camera`, 0 errors)
- [ ] Tests: N/A
- [ ] Benchmark: skipped (no sdb device available in this run; manual verification recommended on target)

Fixes #7623
