### PR TITLE
[Tizen.Applications] Hide UiContextWindow on TeamLoop startup

### DIFF
--- a/src/Tizen.Applications.Team/Tizen.Applications.CoreBackend/TeamUICoreBackend.cs
+++ b/src/Tizen.Applications.Team/Tizen.Applications.CoreBackend/TeamUICoreBackend.cs
@@ -292,9 +292,8 @@ namespace Tizen.Applications
                     Log.Error(LogTag, $"Error in Terminated handler: {ex.Message}");
                     Log.Error(LogTag, $"{ex.StackTrace}");
                 }
-
-                UnsetDefaultWindow();
             }
+            UnsetDefaultWindow();
         }
 
         private void OnAppControlNative(IntPtr context, IntPtr appControl, IntPtr userdata)

--- a/src/Tizen.Applications.Team/Tizen.Applications/TeamLoop.cs
+++ b/src/Tizen.Applications.Team/Tizen.Applications/TeamLoop.cs
@@ -218,6 +218,9 @@ namespace Tizen.Applications
         {
             Log.Info(LogTag, "DoOnLoopCreate() called");
             NUIApplicationInitializer.Initialize();
+            UIContext.Instance?.GetDefaultWindow()?.SetPositionSize(new Rectangle(0, 0, 1, 1));
+            UIContext.Instance?.GetDefaultWindow()?.SetTransparency(true);
+            UIContext.Instance?.GetDefaultWindow()?.Hide();
 
             // Empty implementation for C# launcher
         }

--- a/src/Tizen.Applications.TeamLauncher/TeamLauncher.cs
+++ b/src/Tizen.Applications.TeamLauncher/TeamLauncher.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;
-using System.Runtime.Loader;
 using Tizen.NUI.BaseComponents;
 
 namespace Tizen.Applications
@@ -30,11 +29,11 @@ namespace Tizen.Applications
       {
         Log.Info("TeamLauncher", $"Loop Start");
         string[] argsClone = new string[args == null ? 1 : args.Length + 1];
-        if (args != null && args.Length > 1)
+        if (args != null && args.Length > 0)
         {
             args.CopyTo(argsClone, 1);
         }
-        argsClone[0] = "Tizen.ApplicationsLauncher.dll";
+        argsClone[0] = "Tizen.Applications.TeamLauncher.dll";
         TeamManager.Init(argsClone);
       }
       else


### PR DESCRIPTION
- When using TeamUiApplication, although it does not require dali default window, it shows and initializes the window. This patch fix teamloop to hide and set 1,1 to avoid unwanted window shown.
- Fix some typo and static analysis issue by AI