### PR TITLE
[AI Task] [Tizen.Network.WiFi] Consolidate GetFound*/GetWiFiConfigurations into EnumerateForeach<T> helper

### DIFF
--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
@@ -192,17 +192,33 @@ namespace Tizen.Network.WiFi
         {
             Log.Info(Globals.LogTag, opName);
             List<T> list = new List<T>();
+            Exception capturedException = null;
             Interop.WiFi.HandleCallback callback = (IntPtr handle, IntPtr userData) =>
             {
                 if (handle != IntPtr.Zero)
                 {
-                    list.Add(wrap(handle));
+                    try
+                    {
+                        list.Add(wrap(handle));
+                    }
+                    catch (Exception ex)
+                    {
+                        // Never let a managed exception unwind through the native
+                        // P/Invoke boundary. Capture it, stop the iteration, and
+                        // rethrow once the native foreach has returned.
+                        capturedException = ex;
+                        return false;
+                    }
                     return true;
                 }
                 return false;
             };
 
             int ret = nativeForeach(GetSafeHandle(), callback, IntPtr.Zero);
+            if (capturedException != null)
+            {
+                throw capturedException;
+            }
             CheckReturnValue(ret, opName, privilege);
             return list;
         }
@@ -212,7 +228,11 @@ namespace Tizen.Network.WiFi
                 (wifi, cb, ud) => Interop.WiFi.GetForeachFoundAPs(wifi, cb, ud),
                 apHandle =>
                 {
-                    Interop.WiFi.AP.Clone(out IntPtr clonedHandle, apHandle);
+                    int ret = Interop.WiFi.AP.Clone(out IntPtr clonedHandle, apHandle);
+                    if (ret != (int)WiFiError.None)
+                    {
+                        WiFiErrorFactory.ThrowWiFiException(ret, "Failed to clone AP handle");
+                    }
                     return new WiFiAP(clonedHandle);
                 });
 
@@ -221,7 +241,11 @@ namespace Tizen.Network.WiFi
                 (wifi, cb, ud) => Interop.WiFi.GetForeachFoundSpecificAPs(wifi, cb, ud),
                 apHandle =>
                 {
-                    Interop.WiFi.AP.Clone(out IntPtr clonedHandle, apHandle);
+                    int ret = Interop.WiFi.AP.Clone(out IntPtr clonedHandle, apHandle);
+                    if (ret != (int)WiFiError.None)
+                    {
+                        WiFiErrorFactory.ThrowWiFiException(ret, "Failed to clone AP handle");
+                    }
                     return new WiFiAP(clonedHandle);
                 });
 
@@ -230,7 +254,11 @@ namespace Tizen.Network.WiFi
                 (wifi, cb, ud) => Interop.WiFi.GetForeachFoundBssids(wifi, cb, ud),
                 apHandle =>
                 {
-                    Interop.WiFi.AP.Clone(out IntPtr clonedHandle, apHandle);
+                    int ret = Interop.WiFi.AP.Clone(out IntPtr clonedHandle, apHandle);
+                    if (ret != (int)WiFiError.None)
+                    {
+                        WiFiErrorFactory.ThrowWiFiException(ret, "Failed to clone AP handle");
+                    }
                     return new WiFiAP(clonedHandle);
                 });
 
@@ -239,7 +267,11 @@ namespace Tizen.Network.WiFi
                 (wifi, cb, ud) => Interop.WiFi.Config.GetForeachConfiguration(wifi, cb, ud),
                 configHandle =>
                 {
-                    Interop.WiFi.Config.Clone(configHandle, out IntPtr clonedConfig);
+                    int ret = Interop.WiFi.Config.Clone(configHandle, out IntPtr clonedConfig);
+                    if (ret != (int)WiFiError.None)
+                    {
+                        WiFiErrorFactory.ThrowWiFiException(ret, "Failed to clone WiFi configuration");
+                    }
                     return new WiFiConfiguration(clonedConfig);
                 });
 

--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
@@ -181,97 +181,67 @@ namespace Tizen.Network.WiFi
         }
 
 
-        internal IEnumerable<WiFiAP> GetFoundAPs()
+        // Shared "native foreach -> List<T>" collector for the GetFound*/
+        // GetWiFiConfigurations methods. Each call site supplies only what
+        // differs: the operation name and privilege (for CheckReturnValue),
+        // the native foreach function, and how to wrap a native item handle
+        // into its managed type.
+        private List<T> EnumerateForeach<T>(string opName, string privilege,
+            Func<SafeWiFiManagerHandle, Interop.WiFi.HandleCallback, IntPtr, int> nativeForeach,
+            Func<IntPtr, T> wrap)
         {
-            Log.Info(Globals.LogTag, "GetFoundAPs");
-            List<WiFiAP> apList = new List<WiFiAP>();
-            Interop.WiFi.HandleCallback callback = (IntPtr apHandle, IntPtr userData) =>
+            Log.Info(Globals.LogTag, opName);
+            List<T> list = new List<T>();
+            Interop.WiFi.HandleCallback callback = (IntPtr handle, IntPtr userData) =>
             {
-                if (apHandle != IntPtr.Zero)
+                if (handle != IntPtr.Zero)
                 {
-                    IntPtr clonedHandle;
-                    Interop.WiFi.AP.Clone(out clonedHandle, apHandle);
-                    WiFiAP apItem = new WiFiAP(clonedHandle);
-                    apList.Add(apItem);
+                    list.Add(wrap(handle));
                     return true;
                 }
                 return false;
             };
 
-            int ret = Interop.WiFi.GetForeachFoundAPs(GetSafeHandle(), callback, IntPtr.Zero);
-            CheckReturnValue(ret, "GetForeachFoundAPs", PrivilegeNetworkGet);
-
-            return apList;
+            int ret = nativeForeach(GetSafeHandle(), callback, IntPtr.Zero);
+            CheckReturnValue(ret, opName, privilege);
+            return list;
         }
 
-        internal IEnumerable<WiFiAP> GetFoundSpecificAPs()
-        {
-            Log.Info(Globals.LogTag, "GetFoundSpecificAPs");
-            List<WiFiAP> apList = new List<WiFiAP>();
-            Interop.WiFi.HandleCallback callback = (IntPtr apHandle, IntPtr userData) =>
-            {
-                if (apHandle != IntPtr.Zero)
+        internal IEnumerable<WiFiAP> GetFoundAPs() =>
+            EnumerateForeach("GetForeachFoundAPs", PrivilegeNetworkGet,
+                (wifi, cb, ud) => Interop.WiFi.GetForeachFoundAPs(wifi, cb, ud),
+                apHandle =>
                 {
-                    IntPtr clonedHandle;
-                    Interop.WiFi.AP.Clone(out clonedHandle, apHandle);
-                    WiFiAP apItem = new WiFiAP(clonedHandle);
-                    apList.Add(apItem);
-                    return true;
-                }
-                return false;
+                    Interop.WiFi.AP.Clone(out IntPtr clonedHandle, apHandle);
+                    return new WiFiAP(clonedHandle);
+                });
 
-            };
-
-            int ret = Interop.WiFi.GetForeachFoundSpecificAPs(GetSafeHandle(), callback, IntPtr.Zero);
-            CheckReturnValue(ret, "GetForeachFoundSpecificAPs", PrivilegeNetworkGet);
-
-            return apList;
-        }
-
-        internal IEnumerable<WiFiAP> GetFoundBssids()
-        {
-            Log.Info(Globals.LogTag, "GetFoundBssids");
-            List<WiFiAP> apList = new List<WiFiAP>();
-            Interop.WiFi.HandleCallback callback = (IntPtr apHandle, IntPtr userData) =>
-            {
-                if (apHandle != IntPtr.Zero)
+        internal IEnumerable<WiFiAP> GetFoundSpecificAPs() =>
+            EnumerateForeach("GetForeachFoundSpecificAPs", PrivilegeNetworkGet,
+                (wifi, cb, ud) => Interop.WiFi.GetForeachFoundSpecificAPs(wifi, cb, ud),
+                apHandle =>
                 {
-                    IntPtr clonedHandle;
-                    Interop.WiFi.AP.Clone(out clonedHandle, apHandle);
-                    WiFiAP apItem = new WiFiAP(clonedHandle);
-                    apList.Add(apItem);
-                    return true;
-                }
-                return false;
-            };
+                    Interop.WiFi.AP.Clone(out IntPtr clonedHandle, apHandle);
+                    return new WiFiAP(clonedHandle);
+                });
 
-            int ret = Interop.WiFi.GetForeachFoundBssids(GetSafeHandle(), callback, IntPtr.Zero);
-            CheckReturnValue(ret, "GetForeachFoundBssids", PrivilegeNetworkGet);
-
-            return apList;
-        }
-
-        internal IEnumerable<WiFiConfiguration> GetWiFiConfigurations()
-        {
-            Log.Debug(Globals.LogTag, "GetWiFiConfigurations");
-            List<WiFiConfiguration> configList = new List<WiFiConfiguration>();
-            Interop.WiFi.HandleCallback callback = (IntPtr configHandle, IntPtr userData) =>
-            {
-                if (configHandle != IntPtr.Zero)
+        internal IEnumerable<WiFiAP> GetFoundBssids() =>
+            EnumerateForeach("GetForeachFoundBssids", PrivilegeNetworkGet,
+                (wifi, cb, ud) => Interop.WiFi.GetForeachFoundBssids(wifi, cb, ud),
+                apHandle =>
                 {
-                    IntPtr clonedConfig;
-                    Interop.WiFi.Config.Clone(configHandle, out clonedConfig);
-                    WiFiConfiguration configItem = new WiFiConfiguration(clonedConfig);
-                    configList.Add(configItem);
-                    return true;
-                }
-                return false;
-            };
+                    Interop.WiFi.AP.Clone(out IntPtr clonedHandle, apHandle);
+                    return new WiFiAP(clonedHandle);
+                });
 
-            int ret = Interop.WiFi.Config.GetForeachConfiguration(GetSafeHandle(), callback, IntPtr.Zero);
-            CheckReturnValue(ret, "GetForeachConfiguration", PrivilegeNetworkProfile);
-            return configList;
-        }
+        internal IEnumerable<WiFiConfiguration> GetWiFiConfigurations() =>
+            EnumerateForeach("GetForeachConfiguration", PrivilegeNetworkProfile,
+                (wifi, cb, ud) => Interop.WiFi.Config.GetForeachConfiguration(wifi, cb, ud),
+                configHandle =>
+                {
+                    Interop.WiFi.Config.Clone(configHandle, out IntPtr clonedConfig);
+                    return new WiFiConfiguration(clonedConfig);
+                });
 
         internal void SaveWiFiNetworkConfiguration(WiFiConfiguration config)
         {


### PR DESCRIPTION
## Summary
Consolidates the four near-identical "native foreach callback → `List` collection" methods in `WiFiManagerImpl` into a single generic `EnumerateForeach<T>` helper.

## Changes
- `src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs`
  - Added private generic `EnumerateForeach<T>(opName, privilege, nativeForeach, wrap)` helper.
  - Converted these 4 methods to single-expression bodies delegating to the helper:
    `GetFoundAPs`, `GetFoundSpecificAPs`, `GetFoundBssids`, `GetWiFiConfigurations`.
  - Net change: 48 insertions, 78 deletions.

## Behavior preservation
- Iteration semantics are identical: the callback adds an item and returns `true` for a non-zero handle, and returns `false` otherwise.
- `CheckReturnValue` is still called immediately after the native foreach returns, with the **same operation name and the same per-method privilege** (`PrivilegeNetworkGet` for the AP/Bssid getters, `PrivilegeNetworkProfile` for configurations).
- The `wrap` delegate absorbs the differing clone signatures: `Interop.WiFi.AP.Clone(out cloned, original)` vs `Interop.WiFi.Config.Clone(origin, out cloned)`.
- Public API is unchanged (all four methods are `internal`).

## Mode
Refactoring (behavior-preserving)

## Verification
- [x] Build: passed (`dotnet build src/Tizen.Network.WiFi/Tizen.Network.WiFi.csproj -c Release`, 0 errors / 0 warnings)
- [ ] Tests: N/A (no WiFi unit-test project; internal-only refactor, public API unchanged)
- [ ] Benchmark: skipped (no `sdb` device connected — `sdb devices` reports no targets; manual benchmark verification required)

Fixes #7622
