### PR TITLE
Add BSD-2-Clause license declaration for Markdig

### DIFF
--- a/LICENSE.BSD-2-Clause
+++ b/LICENSE.BSD-2-Clause
@@ -1,0 +1,26 @@
+Following third-party component is under BSD-2-Clause license.
+- Markdig (https://github.com/xoofx/markdig), referenced by src/Tizen.NUI.MarkdownRenderer
+
+Copyright (c) 2018-2019, Alexandre Mutel
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification
+, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packaging/csapi-tizenfx.spec
+++ b/packaging/csapi-tizenfx.spec
@@ -22,7 +22,7 @@ Summary:    Assemblies of Tizen .NET
 Version:    %{TIZEN_NET_RPM_VERSION}
 Release:    1
 Group:      Development/Libraries
-License:    Apache-2.0 and MIT
+License:    Apache-2.0 and MIT and BSD-2-Clause
 URL:        https://www.tizen.org
 Source0:    %{name}-%{version}.tar.gz
 Source1:    %{name}.manifest
@@ -226,6 +226,7 @@ echo "db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS}" >> %{D
 %files
 %license LICENSE
 %license LICENSE.MIT
+%license LICENSE.BSD-2-Clause
 %attr(0755,root,root) %{UPGRADE_SCRIPT_PATH}/500.tizenfx_upgrade.sh
 
 %files nuget

--- a/packaging/csapi-tizenfx.spec.in
+++ b/packaging/csapi-tizenfx.spec.in
@@ -21,7 +21,7 @@ Summary:    Assemblies of Tizen .NET
 Version:    %{TIZEN_NET_RPM_VERSION}
 Release:    1
 Group:      Development/Libraries
-License:    Apache-2.0 and MIT
+License:    Apache-2.0 and MIT and BSD-2-Clause
 URL:        https://www.tizen.org
 Source0:    %{name}-%{version}.tar.gz
 Source1:    %{name}.manifest
@@ -225,6 +225,7 @@ echo "db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS}" >> %{D
 %files
 %license LICENSE
 %license LICENSE.MIT
+%license LICENSE.BSD-2-Clause
 %attr(0755,root,root) %{UPGRADE_SCRIPT_PATH}/500.tizenfx_upgrade.sh
 
 %files nuget


### PR DESCRIPTION
## Description

`Tizen.NUI.MarkdownRenderer` includes the third-party Markdig library
(`packaging/third-party/markdig.signed.0.41.3.nupkg`), which is licensed
under BSD-2-Clause, but this was not declared in the build spec.
This was reported by the license verification (LiON).

## Changes

- Add `BSD-2-Clause` to the `License:` tag in `csapi-tizenfx.spec` / `csapi-tizenfx.spec.in`
- Add `%license LICENSE.BSD-2-Clause` entry
- Add `LICENSE.BSD-2-Clause` notice file at the repository root (full license text
  of Markdig, following the existing `LICENSE.MIT` convention)

No code or API changes. License metadata only.