### PR TITLE
[NUI](Gesture) Add SourceSubType property to expose gesture input subtype

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Gesture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Gesture.cs
@@ -41,6 +41,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_sourceData_get")]
             public static extern int SourceDataGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_sourceSubType_get")]
+            public static extern int SourceSubTypeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Events/Gesture.cs
+++ b/src/Tizen.NUI/src/public/Events/Gesture.cs
@@ -167,6 +167,59 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Enumeration for subclass of gesture input source.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public enum SourceSubType
+        {
+            /// <summary>Not a device.</summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            None = 0,
+            /// <summary>The normal flat of your finger.</summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Finger = 1,
+            /// <summary>A fingernail.</summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Fingernail = 2,
+            /// <summary>A Knuckle.</summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Knuckle = 3,
+            /// <summary>The palm of a user's hand.</summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Palm = 4,
+            /// <summary>The side of your hand.</summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            HandSide = 5,
+            /// <summary>The flat of your hand.</summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            HandFlat = 6,
+            /// <summary>The tip of a pen.</summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            PenTip = 7,
+            /// <summary>A trackpad style mouse.</summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Trackpad = 8,
+            /// <summary>A trackpoint style mouse.</summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Trackpoint = 9,
+            /// <summary>A trackball style mouse.</summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Trackball = 10,
+            /// <summary>A remote controller.</summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Remocon = 11,
+            /// <summary>A virtual keyboard.</summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            VirtualKeyboard = 12,
+            /// <summary>A virtual remocon.</summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            VirtualRemocon = 13,
+            /// <summary>A virtual mouse.</summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            VirtualMouse = 14,
+        }
+
+        /// <summary>
         /// Gets the type of gesture.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
@@ -228,6 +281,19 @@ namespace Tizen.NUI
             }
         }
 
+        /// <summary>
+        /// This is a property of the source subclass (read-only).
+        /// Provides detailed input type: Finger, Knuckle, Palm for touch, Trackpad, Trackball for mouse.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Gesture.SourceSubType SourceSub
+        {
+            get
+            {
+                return sourceSubType;
+            }
+        }
+
         private Gesture.GestureType type
         {
             get
@@ -262,9 +328,16 @@ namespace Tizen.NUI
         {
             get
             {
-                Gesture.SourceType ret = (Gesture.SourceType)Interop.Gesture.SourceTypeGet(SwigCPtr);
+                int rawValue = Interop.Gesture.SourceTypeGet(SwigCPtr);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return ret;
+                // Binder returns Device::Class::Type values (MOUSE=3, TOUCH=4).
+                // Map to Gesture.SourceType (Mouse=1, Touch=2) for backward compatibility.
+                switch (rawValue)
+                {
+                    case 3: return Gesture.SourceType.Mouse;
+                    case 4: return Gesture.SourceType.Touch;
+                    default: return Gesture.SourceType.Invalid;
+                }
             }
         }
 
@@ -273,6 +346,16 @@ namespace Tizen.NUI
             get
             {
                 Gesture.SourceDataType ret = (Gesture.SourceDataType)Interop.Gesture.SourceDataGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        private Gesture.SourceSubType sourceSubType
+        {
+            get
+            {
+                Gesture.SourceSubType ret = (Gesture.SourceSubType)Interop.Gesture.SourceSubTypeGet(SwigCPtr);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 return ret;
             }


### PR DESCRIPTION

### Description of Change ###
<!-- Describe your changes here. -->

Expose GestureSourceSubType to C# as Gesture.SourceSubType (enum) and Gesture.SourceSubType (property), providing detailed input type info (Finger, Knuckle, Palm for touch; Trackpad, Trackball for mouse) aligned with Device::Subclass::Type values.

- Add SourceSubType enum (None through VirtualMouse) to Gesture
- Add read-only SourceSubType property backed by CSharp_Dali_Gesture_sourceSubType_get
- Add SourceSubTypeGet() DllImport to Interop.Gesture

https://review.tizen.org/gerrit/c/platform/core/uifw/dali-core/+/345393
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/345394

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
