### PR TITLE
[AI Task] [Tizen.Multimedia.Recorder] Remove params allocation from Recorder.ValidateState

### DIFF
--- a/src/Tizen.Multimedia.Recorder/Recorder/Recorder.cs
+++ b/src/Tizen.Multimedia.Recorder/Recorder/Recorder.cs
@@ -16,7 +16,7 @@
 
 using System;
 using System.Diagnostics;
-using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Native = Interop.Recorder;
 using NativeHandle = Interop.RecorderHandle;
@@ -110,17 +110,39 @@ namespace Tizen.Multimedia
         #endregion Dispose support
 
         #region State validation
+        internal void ValidateState(RecorderState required)
+        {
+            var curState = _state;
+            if (curState != required)
+            {
+                ThrowInvalidState(curState, required);
+            }
+        }
+
+        internal void ValidateState(RecorderState required1, RecorderState required2)
+        {
+            var curState = _state;
+            if (curState != required1 && curState != required2)
+            {
+                ThrowInvalidState(curState, required1, required2);
+            }
+        }
+
         internal void ValidateState(params RecorderState[] required)
         {
             Debug.Assert(required.Length > 0);
 
             var curState = _state;
-            if (!required.Contains(curState))
+            if (Array.IndexOf(required, curState) < 0)
             {
-                throw new InvalidOperationException("The recorder is not in a valid state. " +
-                    $"Current State : { curState }, Valid State : { string.Join(", ", required) }.");
+                ThrowInvalidState(curState, required);
             }
         }
+
+        [DoesNotReturn]
+        private static void ThrowInvalidState(RecorderState curState, params RecorderState[] required)
+            => throw new InvalidOperationException("The recorder is not in a valid state. " +
+                $"Current State : { curState }, Valid State : { string.Join(", ", required) }.");
 
         private void SetState(RecorderState state)
         {


### PR DESCRIPTION
## Summary
`Recorder.ValidateState(params RecorderState[] required)` allocated a new `RecorderState[]` on every call because of the `params` array. It is called from ~19 hot sites (Prepare/Unprepare/Start/Pause/Resume/Commit/Cancel, property setters, VideoRecorder), and all of them pass **1 or 2** states — so rapid Pause/Resume toggling or quick setter sequences accumulate small short-lived arrays in Gen0.

This adds zero-alloc single- and two-argument overloads that the compiler dispatches to automatically (no call-site changes). The `params` overload is kept for the 3+ argument case, and the exception-message construction moves to a cold `[DoesNotReturn]` `ThrowInvalidState` helper so the success path allocates nothing. This mirrors the AudioIO fix in #7609.

## Changes
- `src/Tizen.Multimedia.Recorder/Recorder/Recorder.cs`
  - Add `ValidateState(RecorderState)` and `ValidateState(RecorderState, RecorderState)` zero-alloc overloads.
  - Keep `ValidateState(params RecorderState[])`; switch its check from LINQ `!Contains` to `Array.IndexOf(...) < 0`.
  - Extract the throw path into a `[DoesNotReturn] ThrowInvalidState` helper (identical exception message).
  - Drop the now-unused `using System.Linq;`, add `using System.Diagnostics.CodeAnalysis;`.

Call sites are unchanged — overload resolution dispatches 1/2-arg calls to the new allocation-free overloads. Behavior is preserved: the 1-arg check (`!=`), 2-arg check (`&& !=`), and params check (`Array.IndexOf < 0`) are all equivalent to the original `!required.Contains(curState)`, and the exception message is byte-for-byte identical.

## Mode
Refactoring

## Verification
- [x] Build: passed (`dotnet build -c Release` on `Tizen.Multimedia.Recorder`, 0 errors)
- [ ] Tests: N/A (internal method; no behavior or public API change)
- [ ] Benchmark: skipped (sdb error: no device connected — `sdb devices` lists none). Manual benchmark verification required.

Fixes #7640
