### PR TITLE
[AI Task] [Tizen.Multimedia.Remoting] Cache Enum.GetValues for MediaController capability enums

### DIFF
--- a/src/Tizen.Multimedia.Remoting/MediaController/MediaControlEnums.cs
+++ b/src/Tizen.Multimedia.Remoting/MediaController/MediaControlEnums.cs
@@ -378,6 +378,12 @@ namespace Tizen.Multimedia.Remoting
 
     internal static class EnumExtensions
     {
+        private static readonly MediaControlNativeDisplayMode[] s_allDisplayModes
+            = Enum.GetValues<MediaControlNativeDisplayMode>();
+
+        private static readonly MediaControlNativeDisplayRotation[] s_allDisplayRotations
+            = Enum.GetValues<MediaControlNativeDisplayRotation>();
+
         internal static MediaControlPlaybackState ToPublic(this MediaControllerNativePlaybackState nativeState)
         {
             switch (nativeState)
@@ -528,7 +534,7 @@ namespace Tizen.Multimedia.Remoting
         {
             var supportedModes = new List<MediaControlDisplayMode>();
 
-            foreach (MediaControlNativeDisplayMode mode in Enum.GetValues(typeof(MediaControlNativeDisplayMode)))
+            foreach (MediaControlNativeDisplayMode mode in s_allDisplayModes)
             {
                 if (modes.HasFlag(mode))
                 {
@@ -592,7 +598,7 @@ namespace Tizen.Multimedia.Remoting
         {
             var supportedRotations = new List<Rotation>();
 
-            foreach (MediaControlNativeDisplayRotation mode in Enum.GetValues(typeof(MediaControlNativeDisplayRotation)))
+            foreach (MediaControlNativeDisplayRotation mode in s_allDisplayRotations)
             {
                 if (modes.HasFlag(mode))
                 {

--- a/src/Tizen.Multimedia.Remoting/MediaController/MediaControlEnums.cs
+++ b/src/Tizen.Multimedia.Remoting/MediaController/MediaControlEnums.cs
@@ -378,11 +378,21 @@ namespace Tizen.Multimedia.Remoting
 
     internal static class EnumExtensions
     {
-        private static readonly MediaControlNativeDisplayMode[] s_allDisplayModes
-            = Enum.GetValues<MediaControlNativeDisplayMode>();
+        private static readonly MediaControlNativeDisplayMode[] s_allDisplayModes = new[]
+        {
+            MediaControlNativeDisplayMode.LetterBox,
+            MediaControlNativeDisplayMode.OriginSize,
+            MediaControlNativeDisplayMode.FullScreen,
+            MediaControlNativeDisplayMode.CroppedFull
+        };
 
-        private static readonly MediaControlNativeDisplayRotation[] s_allDisplayRotations
-            = Enum.GetValues<MediaControlNativeDisplayRotation>();
+        private static readonly MediaControlNativeDisplayRotation[] s_allDisplayRotations = new[]
+        {
+            MediaControlNativeDisplayRotation.Rotate0,
+            MediaControlNativeDisplayRotation.Rotate90,
+            MediaControlNativeDisplayRotation.Rotate180,
+            MediaControlNativeDisplayRotation.Rotate270
+        };
 
         internal static MediaControlPlaybackState ToPublic(this MediaControllerNativePlaybackState nativeState)
         {

--- a/src/Tizen.Multimedia.Remoting/MediaController/MediaController.Events.cs
+++ b/src/Tizen.Multimedia.Remoting/MediaController/MediaController.Events.cs
@@ -204,7 +204,7 @@ namespace Tizen.Multimedia.Remoting
             var capabilities = new Dictionary<MediaControlPlaybackCommand, MediaControlCapabilitySupport>();
             try
             {
-                foreach (MediaControllerNativePlaybackAction action in Enum.GetValues(typeof(MediaControllerNativePlaybackAction)))
+                foreach (MediaControllerNativePlaybackAction action in s_allPlaybackActions)
                 {
                     Native.GetPlaybackCapability(playbackCapaHandle, action, out MediaControlCapabilitySupport support);
                     capabilities.Add(action.ToPublic(), support);

--- a/src/Tizen.Multimedia.Remoting/MediaController/MediaController.cs
+++ b/src/Tizen.Multimedia.Remoting/MediaController/MediaController.cs
@@ -31,6 +31,9 @@ namespace Tizen.Multimedia.Remoting
     /// <since_tizen> 4 </since_tizen>
     public partial class MediaController
     {
+        private static readonly MediaControllerNativePlaybackAction[] s_allPlaybackActions
+            = Enum.GetValues<MediaControllerNativePlaybackAction>();
+
         internal MediaController(MediaControllerManager manager, string serverAppId)
         {
             Debug.Assert(manager != null);
@@ -539,7 +542,7 @@ namespace Tizen.Multimedia.Remoting
                 Native.GetPlaybackCapabilityHandle(Manager.Handle, ServerAppId, out playbackCapaHandle).
                     ThrowIfError("Failed to get playback capability handle.");
 
-                foreach (MediaControllerNativePlaybackAction action in Enum.GetValues(typeof(MediaControllerNativePlaybackAction)))
+                foreach (MediaControllerNativePlaybackAction action in s_allPlaybackActions)
                 {
                     Native.GetPlaybackCapability(playbackCapaHandle, action, out MediaControlCapabilitySupport support);
                     playbackCapabilities.Add(action.ToPublic(), support);


### PR DESCRIPTION
## Summary
The `MediaController` capability / display-mode conversion helpers called `Enum.GetValues(typeof(T))` on every invocation. The non-generic overload returns an `Array`, so each call allocates a fresh array and boxes every enum value. One of the sites (`PlaybackCapabilityUpdated`) is a hot path that fires on every server-side playback-capability change (multiple times per second during media transitions/scrubbing).

This change replaces those calls with `static readonly` caches populated once via the strongly-typed generic `Enum.GetValues<T>()` overload (.NET 5+), eliminating the per-call array allocation and boxing.

## Changes
- `src/Tizen.Multimedia.Remoting/MediaController/MediaController.cs`
  - Add `s_allPlaybackActions` static cache; use it in `GetPlaybackCapabilities` (was line 542).
- `src/Tizen.Multimedia.Remoting/MediaController/MediaController.Events.cs`
  - Use the shared `s_allPlaybackActions` cache in `CreatePlaybackCapabilityUpdatedEventArgs` (was line 207).
- `src/Tizen.Multimedia.Remoting/MediaController/MediaControlEnums.cs`
  - Add `s_allDisplayModes` / `s_allDisplayRotations` static caches in `EnumExtensions`; use them in the `ToPublicList` helpers (was lines 531, 595).

## Mode
Refactoring

## Verification
- [x] Build: passed (`dotnet build Tizen.Multimedia.Remoting` — 0 errors; pre-existing warnings only)
- [ ] Tests: N/A (no unit-test project covers this path; enumeration order and results are unchanged)
- [ ] Benchmark: skipped (sdb device unavailable in CI environment — manual verification required)

Fixes #7642
