### PR TITLE
[Tizen.NUI.WindowSystem] Change to use tizen_core_wl instead of efl_util

### DIFF
--- a/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.InputGenerator.cs
+++ b/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.InputGenerator.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Runtime.InteropServices;
 
 namespace Tizen.NUI.WindowSystem
 {
@@ -8,34 +7,34 @@ namespace Tizen.NUI.WindowSystem
     {
         internal static partial class InputGenerator
         {
-            const string lib = "libcapi-ui-efl-util.so.0";
+            const string lib = "libtizen-core-wl.so.0";
 
-            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "efl_util_input_initialize_generator")]
-            internal static extern IntPtr Init(int devType);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_input_generator_create")]
+            internal static extern int Create(IntPtr display, int devType, out IntPtr generator);
 
-            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "efl_util_input_initialize_generator_with_name")]
-            internal static extern IntPtr InitWithName(int devType, string devName);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_input_generator_create_with_name")]
+            internal static extern int CreateWithName(IntPtr display, int devType, string devName, out IntPtr generator);
 
-            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "efl_util_input_initialize_generator_with_sync")]
-            internal static extern IntPtr SyncInit(int devType, string devName);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_input_generator_create_with_sync")]
+            internal static extern int CreateWithSync(IntPtr display, int devType, string devName, out IntPtr generator);
 
-            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "efl_util_input_deinitialize_generator")]
-            internal static extern ErrorCode Deinit(IntPtr inputGenHandler);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_input_generator_destroy")]
+            internal static extern int Destroy(IntPtr generator);
 
-            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "efl_util_input_generate_key")]
-            internal static extern ErrorCode GenerateKey(IntPtr inputGenHandler, string keyName, int pressed);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_input_generator_generate_key")]
+            internal static extern int GenerateKey(IntPtr generator, string keyName, [MarshalAs(UnmanagedType.I1)] bool pressed);
 
-            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "efl_util_input_generate_pointer")]
-            internal static extern ErrorCode GeneratePointer(IntPtr inputGenHandler, int buttons, int pointerType, int x, int y);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_input_generator_generate_pointer")]
+            internal static extern int GeneratePointer(IntPtr generator, int buttons, int pointerType, int x, int y);
 
-            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "efl_util_input_generate_wheel")]
-            internal static extern ErrorCode GenerateWheel(IntPtr inputGenHandler, int wheelType, int value);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_input_generator_generate_wheel")]
+            internal static extern int GenerateWheel(IntPtr generator, int wheelType, int value);
 
-            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "efl_util_input_generate_touch")]
-            internal static extern ErrorCode GenerateTouch(IntPtr inputGenHandler, int idx, int touchType, int x, int y);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_input_generator_generate_touch")]
+            internal static extern int GenerateTouch(IntPtr generator, int idx, int touchType, int x, int y);
 
-            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "efl_util_input_generate_touch_axis")]
-            internal static extern ErrorCode GenerateTouchAxis(IntPtr inputGenHandler, int idx, int touchType, int x, int y, double radius_x, double radius_y, double pressure, double angle, double palm);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_input_generator_generate_touch_with_axis")]
+            internal static extern int GenerateTouchAxis(IntPtr generator, int idx, int touchType, int x, int y, double radius_x, double radius_y, double pressure, double angle, double palm);
 
             // Enumeration of input device types.
             // The device type may be used overlapped.
@@ -51,7 +50,6 @@ namespace Tizen.NUI.WindowSystem
             // Enumeration of touch event types
             internal enum TouchType
             {
-                None,
                 Begin,
                 Update,
                 End,
@@ -72,17 +70,14 @@ namespace Tizen.NUI.WindowSystem
                 Horizontal,
             }
 
-            private const int ErrorTzsh = -0x02860000;
-
             internal enum ErrorCode
             {
                 None = Tizen.Internals.Errors.ErrorCode.None,                            // Successful
                 OutOfMemory = Tizen.Internals.Errors.ErrorCode.OutOfMemory,              // Out of memory
                 InvalidParameter = Tizen.Internals.Errors.ErrorCode.InvalidParameter,    // Invalid parameter
-                InvalidOperation = Tizen.Internals.Errors.ErrorCode.InvalidOperation,    // Invalid operation
-                PermissionDenied = Tizen.Internals.Errors.ErrorCode.PermissionDenied,    // Permission denied
                 NotSupported = Tizen.Internals.Errors.ErrorCode.NotSupported,            // NOT supported
-                NoService = ErrorTzsh | 0x01,                                            // Service does not exist
+                PermissionDenied = Tizen.Internals.Errors.ErrorCode.PermissionDenied,    // Permission denied
+                NotConnected = -0x02000000 | 0xA000 | 0x01,                             // No connection to display server
             }
         }
     }

--- a/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.InputGesture.cs
+++ b/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.InputGesture.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Runtime.InteropServices;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Tizen.NUI.WindowSystem
 {
@@ -9,87 +7,87 @@ namespace Tizen.NUI.WindowSystem
     {
         internal static class InputGesture
         {
-            const string lib = "libcapi-ui-efl-util.so.0";
+            const string lib = "libtizen-core-wl.so.0";
 
             internal static string LogTag = "Tizen.NUI.WindowSystem";
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_initialize")]
-            internal static extern IntPtr Initialize();
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_create")]
+            internal static extern int Create(IntPtr display, out IntPtr gesture);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_deinitialize")]
-            internal static extern ErrorCode Deinitialize(IntPtr gestureHandler);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_destroy")]
+            internal static extern int Destroy(IntPtr gesture);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_edge_swipe_new")]
-            internal static extern IntPtr EdgeSwipeNew(IntPtr gestureHandler, int fingers, int edge);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_edge_swipe_new")]
+            internal static extern int EdgeSwipeNew(IntPtr gesture, uint fingers, int edge, out IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_edge_swipe_free")]
-            internal static extern ErrorCode EdgeSwipeFree(IntPtr gestureHandler, IntPtr gestureData);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_edge_swipe_free")]
+            internal static extern int EdgeSwipeFree(IntPtr gesture, IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_edge_swipe_size_set")]
-            internal static extern ErrorCode EdgeSwipeSizeSet(IntPtr gestureData, int edgeSize, int startPoint, int endPoint);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_edge_swipe_size_set")]
+            internal static extern int EdgeSwipeSizeSet(IntPtr data, int edgeSize, uint startPoint, uint endPoint);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_edge_drag_new")]
-            internal static extern IntPtr EdgeDragNew(IntPtr gestureHandler, int fingers, int edge);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_edge_drag_new")]
+            internal static extern int EdgeDragNew(IntPtr gesture, uint fingers, int edge, out IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_edge_drag_free")]
-            internal static extern ErrorCode EdgeDragFree(IntPtr gestureHandler, IntPtr gestureData);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_edge_drag_free")]
+            internal static extern int EdgeDragFree(IntPtr gesture, IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_edge_drag_size_set")]
-            internal static extern ErrorCode EdgeDragSizeSet(IntPtr gestureData, int edgeSize, int startPoint, int endPoint);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_edge_drag_size_set")]
+            internal static extern int EdgeDragSizeSet(IntPtr data, int edgeSize, uint startPoint, uint endPoint);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_tap_new")]
-            internal static extern IntPtr TapNew(IntPtr gestureHandler, int fingers, int repeats);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_tap_new")]
+            internal static extern int TapNew(IntPtr gesture, uint fingers, uint repeats, out IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_tap_free")]
-            internal static extern ErrorCode TapFree(IntPtr gestureHandler, IntPtr gestureData);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_tap_free")]
+            internal static extern int TapFree(IntPtr gesture, IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_palm_cover_new")]
-            internal static extern IntPtr PalmCoverNew(IntPtr gestureHandler);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_palm_cover_new")]
+            internal static extern int PalmCoverNew(IntPtr gesture, out IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_palm_cover_free")]
-            internal static extern ErrorCode PalmCoverFree(IntPtr gestureHandler, IntPtr gestureData);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_palm_cover_free")]
+            internal static extern int PalmCoverFree(IntPtr gesture, IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_grab")]
-            internal static extern ErrorCode GestureGrab(IntPtr gestureHandler, IntPtr gestureData);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_grab")]
+            internal static extern int GestureGrab(IntPtr gesture, IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_grab_mode_set")]
-            internal static extern ErrorCode SetGestureGrabMode(IntPtr gestureHandler, IntPtr gestureData, int mode);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_grab_mode_set")]
+            internal static extern int SetGestureGrabMode(IntPtr gesture, IntPtr data, int mode);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_ungrab")]
-            internal static extern ErrorCode GestureUngrab(IntPtr gestureHandler, IntPtr gestureData);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_ungrab")]
+            internal static extern int GestureUngrab(IntPtr gesture, IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_edge_swipe_cb_set")]
-            internal static extern ErrorCode SetEdgeSwipeCb(IntPtr gestureHandler, EdgeSwipeCb cbFunc, IntPtr usergestureData);
-
-            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-            internal delegate void EdgeSwipeCb(IntPtr usergestureData, int mode, int fingers, int sx, int sy, int edge);
-
-            [DllImport(lib, EntryPoint = "efl_util_gesture_edge_drag_cb_set")]
-            internal static extern ErrorCode SetEdgeDragCb(IntPtr gestureHandler, EdgeDragCb cbFunc, IntPtr usergestureData);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_edge_swipe_cb_set")]
+            internal static extern int SetEdgeSwipeCb(IntPtr gesture, EdgeSwipeCb cbFunc, IntPtr userData);
 
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-            internal delegate void EdgeDragCb(IntPtr usergestureData, int mode, int fingers, int cx, int cy, int edge);
+            internal delegate void EdgeSwipeCb(IntPtr userData, int mode, int fingers, int sx, int sy, int edge);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_tap_cb_set")]
-            internal static extern ErrorCode SetTapCb(IntPtr gestureHandler, TapCb cbFunc, IntPtr usergestureData);
-
-            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-            internal delegate void TapCb(IntPtr usergestureData, int mode, int fingers, int repeats);
-
-            [DllImport(lib, EntryPoint = "efl_util_gesture_palm_cover_cb_set")]
-            internal static extern ErrorCode SetPalmCoverCb(IntPtr gestureHandler, PalmCoverCb cbFunc, IntPtr usergestureData);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_edge_drag_cb_set")]
+            internal static extern int SetEdgeDragCb(IntPtr gesture, EdgeDragCb cbFunc, IntPtr userData);
 
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-            internal delegate void PalmCoverCb(IntPtr usergestureData, int mode, int duration, int cx, int cy, int size, double pressure);
+            internal delegate void EdgeDragCb(IntPtr userData, int mode, int fingers, int cx, int cy, int edge);
+
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_tap_cb_set")]
+            internal static extern int SetTapCb(IntPtr gesture, TapCb cbFunc, IntPtr userData);
+
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            internal delegate void TapCb(IntPtr userData, int mode, int fingers, int repeats);
+
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_palm_cover_cb_set")]
+            internal static extern int SetPalmCoverCb(IntPtr gesture, PalmCoverCb cbFunc, IntPtr userData);
+
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            internal delegate void PalmCoverCb(IntPtr userData, int mode, int duration, int cx, int cy, int size, double pressure);
 
             internal enum ErrorCode
             {
                 None = Tizen.Internals.Errors.ErrorCode.None,                            // Successful
                 OutOfMemory = Tizen.Internals.Errors.ErrorCode.OutOfMemory,              // Out of memory
                 InvalidParameter = Tizen.Internals.Errors.ErrorCode.InvalidParameter,    // Invalid parameter
-                InvalidOperation = Tizen.Internals.Errors.ErrorCode.InvalidOperation,    // Invalid operation
-                PermissionDenied = Tizen.Internals.Errors.ErrorCode.PermissionDenied,    // Permission denied
                 NotSupported = Tizen.Internals.Errors.ErrorCode.NotSupported,            // NOT supported
+                PermissionDenied = Tizen.Internals.Errors.ErrorCode.PermissionDenied,    // Permission denied
+                NotConnected = -0x02000000 | 0xA000 | 0x01,                             // No connection to display server
             };
         }
     }

--- a/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.TizenCoreWl.cs
+++ b/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.TizenCoreWl.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Tizen.NUI.WindowSystem
+{
+    internal static partial class Interop
+    {
+        internal static partial class TizenCoreWl
+        {
+            const string lib = "libtizen-core-wl.so.0";
+
+            [DllImport(lib, EntryPoint = "tizen_core_wl_init")]
+            internal static extern int Init();
+
+            [DllImport(lib, EntryPoint = "tizen_core_wl_shutdown")]
+            internal static extern int Shutdown();
+
+            [DllImport(lib, EntryPoint = "tizen_core_wl_display_create")]
+            internal static extern int DisplayCreate(out IntPtr display);
+
+            [DllImport(lib, EntryPoint = "tizen_core_wl_display_connect")]
+            internal static extern int DisplayConnect(IntPtr display, string name);
+
+            [DllImport(lib, EntryPoint = "tizen_core_wl_display_disconnect")]
+            internal static extern int DisplayDisconnect(IntPtr display);
+
+            [DllImport(lib, EntryPoint = "tizen_core_wl_display_destroy")]
+            internal static extern int DisplayDestroy(IntPtr display);
+
+            internal enum ErrorCode
+            {
+                None = Tizen.Internals.Errors.ErrorCode.None,
+                InvalidParameter = Tizen.Internals.Errors.ErrorCode.InvalidParameter,
+                OutOfMemory = Tizen.Internals.Errors.ErrorCode.OutOfMemory,
+                NotSupported = Tizen.Internals.Errors.ErrorCode.NotSupported,
+                PermissionDenied = Tizen.Internals.Errors.ErrorCode.PermissionDenied,
+                NotConnected = -0x02000000 | 0xA000 | 0x01,
+                NoResourceAvailable = -0x02000000 | 0xA000 | 0x02,
+            }
+        }
+    }
+}

--- a/src/Tizen.NUI.WindowSystem/src/public/InputGenerator.cs
+++ b/src/Tizen.NUI.WindowSystem/src/public/InputGenerator.cs
@@ -31,6 +31,7 @@ namespace Tizen.NUI.WindowSystem
     public class InputGenerator : IDisposable
     {
         private IntPtr _handler;
+        private TizenCoreWlDisplay _display;
         private bool disposed = false;
         private bool isDisposeQueued = false;
 
@@ -70,11 +71,6 @@ namespace Tizen.NUI.WindowSystem
         /// </summary>
         public enum TouchType
         {
-            /// <summary>
-            /// None.
-            /// </summary>
-            None = Interop.InputGenerator.TouchType.None,
-
             /// <summary>
             /// Touch begin.
             /// </summary>
@@ -142,40 +138,105 @@ namespace Tizen.NUI.WindowSystem
                     throw new Tizen.Applications.Exceptions.PermissionDeniedException("Permission denied");
                 case Interop.InputGenerator.ErrorCode.NotSupported :
                     throw new NotSupportedException("Not Supported");
-                case Interop.InputGenerator.ErrorCode.NoService :
-                    throw new InvalidOperationException("No Service");
+                case Interop.InputGenerator.ErrorCode.NotConnected :
+                    throw new InvalidOperationException("Not Connected");
                 default :
-                    throw new InvalidOperationException("Unknown Error");
+                    throw new InvalidOperationException($"Unknown Error: {error}");
             }
         }
 
         /// <summary>
         /// Creates a new InputGenerator.
         /// </summary>
+        /// <param name="display">The TizenCoreWlDisplay instance.</param>
         /// <param name="devType">The Device type of the new input generator.</param>
         /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
         /// <exception cref="ArgumentNullException">Thrown when a argument is null.</exception>
-        public InputGenerator(DeviceType devType)
+        public InputGenerator(TizenCoreWlDisplay display, DeviceType devType)
         {
+            if (display == null)
+            {
+                Tizen.Log.Error("InputGenerator", "InputGenerator: display is null");
+                throw new ArgumentNullException(nameof(display));
+            }
             if (devType == DeviceType.None)
             {
+                Tizen.Log.Error("InputGenerator", "InputGenerator: Invalid device type (None)");
                 throw new ArgumentException("Invalid device type");
             }
 
-            _handler = Interop.InputGenerator.Init((int)devType);
+            IntPtr displayHandle = display.GetNativeHandle();
+            if (displayHandle == IntPtr.Zero)
+            {
+                Tizen.Log.Error("InputGenerator", "InputGenerator: display has been disposed");
+                throw new ObjectDisposedException(nameof(display));
+            }
+
+            _display = display;
+            Tizen.Log.Debug("InputGenerator", $"InputGenerator: Creating with devType={devType}");
+            int ret = Interop.InputGenerator.Create(displayHandle, (int)devType, out _handler);
+            if (ret != (int)Interop.InputGenerator.ErrorCode.None)
+            {
+                Tizen.Log.Error("InputGenerator", $"InputGenerator: Create() failed with error={ret}");
+                disposed = true;
+                GC.SuppressFinalize(this);
+                ErrorCodeThrow((Interop.InputGenerator.ErrorCode)ret);
+            }
+            Tizen.Log.Debug("InputGenerator", $"InputGenerator: Create() succeeded, handler=0x{_handler:X}");
         }
 
-        public InputGenerator(DeviceType devType, string name, bool sync = false)
+        /// <summary>
+        /// Creates a new InputGenerator with a custom device name.
+        /// </summary>
+        /// <param name="display">The TizenCoreWlDisplay instance.</param>
+        /// <param name="devType">The Device type of the new input generator.</param>
+        /// <param name="name">The device name.</param>
+        /// <param name="sync">If true, creates synchronously.</param>
+        /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when a argument is null.</exception>
+        public InputGenerator(TizenCoreWlDisplay display, DeviceType devType, string name, bool sync = false)
         {
+            if (display == null)
+            {
+                Tizen.Log.Error("InputGenerator", "InputGenerator: display is null");
+                throw new ArgumentNullException(nameof(display));
+            }
             if (devType == DeviceType.None)
             {
+                Tizen.Log.Error("InputGenerator", "InputGenerator: Invalid device type (None)");
                 throw new ArgumentException("Invalid device type");
             }
 
-            if (sync)
-                _handler = Interop.InputGenerator.SyncInit((int)devType, name);
+            IntPtr displayHandle = display.GetNativeHandle();
+            if (displayHandle == IntPtr.Zero)
+            {
+                Tizen.Log.Error("InputGenerator", "InputGenerator: display has been disposed");
+                throw new ObjectDisposedException(nameof(display));
+            }
+
+            _display = display;
+            Tizen.Log.Debug("InputGenerator", $"InputGenerator: Creating with devType={devType}, name={name}, sync={sync}");
+            int ret;
+            if (string.IsNullOrEmpty(name))
+            {
+                ret = Interop.InputGenerator.Create(displayHandle, (int)devType, out _handler);
+            }
+            else if (sync)
+            {
+                ret = Interop.InputGenerator.CreateWithSync(displayHandle, (int)devType, name, out _handler);
+            }
             else
-                _handler = Interop.InputGenerator.InitWithName((int)devType, name);
+            {
+                ret = Interop.InputGenerator.CreateWithName(displayHandle, (int)devType, name, out _handler);
+            }
+            if (ret != (int)Interop.InputGenerator.ErrorCode.None)
+            {
+                Tizen.Log.Error("InputGenerator", $"InputGenerator: Create with name failed, error={ret}");
+                disposed = true;
+                GC.SuppressFinalize(this);
+                ErrorCodeThrow((Interop.InputGenerator.ErrorCode)ret);
+            }
+            Tizen.Log.Debug("InputGenerator", $"InputGenerator: Create with name succeeded, handler=0x{_handler:X}");
         }
 
         /// <summary>
@@ -209,15 +270,30 @@ namespace Tizen.NUI.WindowSystem
         /// <inheritdoc/>
         protected virtual void Dispose(DisposeTypes type)
         {
-            if (!disposed)
+            if (disposed)
             {
-                if (_handler != IntPtr.Zero)
+                return;
+            }
+
+            disposed = true;
+            if (_handler != IntPtr.Zero)
+            {
+                if (_display != null && _display.GetNativeHandle() != IntPtr.Zero)
                 {
-                    Interop.InputGenerator.ErrorCode res = Interop.InputGenerator.Deinit(_handler);
-                    ErrorCodeThrow(res);
-                    _handler = IntPtr.Zero;
+                    try
+                    {
+                        int res = Interop.InputGenerator.Destroy(_handler);
+                        if (res != (int)Interop.InputGenerator.ErrorCode.None)
+                        {
+                            Tizen.Log.Error("InputGenerator", $"Failed to destroy input generator, error={res}");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Tizen.Log.Error("InputGenerator", $"Exception during destroy: {ex.Message}");
+                    }
                 }
-                disposed = true;
+                _handler = IntPtr.Zero;
             }
         }
 
@@ -226,10 +302,22 @@ namespace Tizen.NUI.WindowSystem
         /// </summary>
         /// <param name="keyName">The key name to generate.</param>
         /// <param name="pressed">Set the key is pressed or released.</param>
-        public void GenerateKey(string keyName, int pressed)
+        public void GenerateKey(string keyName, bool pressed)
         {
-            Interop.InputGenerator.ErrorCode res = Interop.InputGenerator.GenerateKey(_handler, keyName, pressed);
-            ErrorCodeThrow(res);
+            if (disposed || _handler == IntPtr.Zero)
+            {
+                throw new ObjectDisposedException(nameof(InputGenerator));
+            }
+            if (keyName == null)
+            {
+                throw new ArgumentNullException(nameof(keyName));
+            }
+            if (_display == null || _display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Associated display has been disposed");
+            }
+            int res = Interop.InputGenerator.GenerateKey(_handler, keyName, pressed);
+            ErrorCodeThrow((Interop.InputGenerator.ErrorCode)res);
         }
 
         /// <summary>
@@ -241,8 +329,16 @@ namespace Tizen.NUI.WindowSystem
         /// <param name="y">Y coordinate of the pointer.</param>
         public void GeneratePointer(int buttons, PointerType pointerType, int x, int y)
         {
-            Interop.InputGenerator.ErrorCode res = Interop.InputGenerator.GeneratePointer(_handler, buttons, (int)pointerType, x, y);
-            ErrorCodeThrow(res);
+            if (disposed || _handler == IntPtr.Zero)
+            {
+                throw new ObjectDisposedException(nameof(InputGenerator));
+            }
+            if (_display == null || _display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Associated display has been disposed");
+            }
+            int res = Interop.InputGenerator.GeneratePointer(_handler, buttons, (int)pointerType, x, y);
+            ErrorCodeThrow((Interop.InputGenerator.ErrorCode)res);
         }
 
         /// <summary>
@@ -252,8 +348,16 @@ namespace Tizen.NUI.WindowSystem
         /// <param name="value">The value of the wheel.</param>
         public void GenerateWheel(PointerWheelType wheelType, int value)
         {
-            Interop.InputGenerator.ErrorCode res = Interop.InputGenerator.GenerateWheel(_handler, (int)wheelType, value);
-            ErrorCodeThrow(res);
+            if (disposed || _handler == IntPtr.Zero)
+            {
+                throw new ObjectDisposedException(nameof(InputGenerator));
+            }
+            if (_display == null || _display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Associated display has been disposed");
+            }
+            int res = Interop.InputGenerator.GenerateWheel(_handler, (int)wheelType, value);
+            ErrorCodeThrow((Interop.InputGenerator.ErrorCode)res);
         }
 
         /// <summary>
@@ -265,8 +369,16 @@ namespace Tizen.NUI.WindowSystem
         /// <param name="y">Y coordinate of the touch.</param>
         public void GenerateTouch(int idx, TouchType touchType, int x, int y)
         {
-            Interop.InputGenerator.ErrorCode res = Interop.InputGenerator.GenerateTouch(_handler, idx, (int) touchType, x, y);
-            ErrorCodeThrow(res);
+            if (disposed || _handler == IntPtr.Zero)
+            {
+                throw new ObjectDisposedException(nameof(InputGenerator));
+            }
+            if (_display == null || _display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Associated display has been disposed");
+            }
+            int res = Interop.InputGenerator.GenerateTouch(_handler, idx, (int) touchType, x, y);
+            ErrorCodeThrow((Interop.InputGenerator.ErrorCode)res);
         }
 
         /// <summary>
@@ -283,8 +395,16 @@ namespace Tizen.NUI.WindowSystem
         /// <param name="palm">palm of the touch.</param>
         public void GenerateTouchAxis(int idx, TouchType touchType, int x, int y, double radius_x, double radius_y, double pressure, double angle, double palm)
         {
-            Interop.InputGenerator.ErrorCode res = Interop.InputGenerator.GenerateTouchAxis(_handler, idx, (int) touchType, x, y, radius_x, radius_y, pressure, angle, palm);
-            ErrorCodeThrow(res);
+            if (disposed || _handler == IntPtr.Zero)
+            {
+                throw new ObjectDisposedException(nameof(InputGenerator));
+            }
+            if (_display == null || _display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Associated display has been disposed");
+            }
+            int res = Interop.InputGenerator.GenerateTouchAxis(_handler, idx, (int) touchType, x, y, radius_x, radius_y, pressure, angle, palm);
+            ErrorCodeThrow((Interop.InputGenerator.ErrorCode)res);
         }
     }
 }

--- a/src/Tizen.NUI.WindowSystem/src/public/InputGesture.cs
+++ b/src/Tizen.NUI.WindowSystem/src/public/InputGesture.cs
@@ -17,7 +17,6 @@
 
 using System;
 using System.ComponentModel;
-using static Tizen.NUI.WindowSystem.Interop.InputGesture;
 
 namespace Tizen.NUI.WindowSystem
 {
@@ -144,20 +143,21 @@ namespace Tizen.NUI.WindowSystem
     public class InputGesture : IDisposable
     {
         private IntPtr _handler;
+        private TizenCoreWlDisplay _display;
         private bool disposed = false;
         private bool isDisposeQueued = false;
 
         private event EventHandler<EdgeSwipeEventArgs> _edgeSwipeEventHandler;
-        private EdgeSwipeCb _edgeSwipeDelegate;
+        private Interop.InputGesture.EdgeSwipeCb _edgeSwipeDelegate;
 
         private event EventHandler<EdgeDragEventArgs> _edgeDragEventHandler;
-        private EdgeDragCb _edgeDragDelegate;
+        private Interop.InputGesture.EdgeDragCb _edgeDragDelegate;
 
         private event EventHandler<TapEventArgs> _tapEventHandler;
-        private TapCb _tapDelegate;
+        private Interop.InputGesture.TapCb _tapDelegate;
 
         private event EventHandler<PalmCoverEventArgs> _palmCoverEventHandler;
-        private PalmCoverCb _palmCoverDelegate;
+        private Interop.InputGesture.PalmCoverCb _palmCoverDelegate;
 
         internal void ErrorCodeThrow(Interop.InputGesture.ErrorCode error)
         {
@@ -173,27 +173,43 @@ namespace Tizen.NUI.WindowSystem
                     throw new Tizen.Applications.Exceptions.PermissionDeniedException("Permission denied");
                 case Interop.InputGesture.ErrorCode.NotSupported :
                     throw new NotSupportedException("Not Supported");
+                case Interop.InputGesture.ErrorCode.NotConnected :
+                    throw new InvalidOperationException("Not Connected");
                 default :
-                    throw new InvalidOperationException("Unknown Error");
+                    throw new InvalidOperationException($"Unknown Error: {error}");
             }
         }
 
         /// <summary>
         /// Creates a new InputGesture.
         /// </summary>
+        /// <param name="display">The TizenCoreWlDisplay instance.</param>
         /// <remarks> This module operates in a NUI application and requires instantiation and disposal on the main thread.</remarks>
         /// <exception cref="Tizen.Applications.Exceptions.OutOfMemoryException">Thrown when the memory is not enough to allocate.</exception>
         /// <exception cref="NotSupportedException">Thrown when the feature is not supported.</exception>
         /// <exception cref="Tizen.Applications.Exceptions.PermissionDeniedException">Thrown when the permission is denied.</exception>
-        public InputGesture()
+        public InputGesture(TizenCoreWlDisplay display)
         {
-            _handler = Interop.InputGesture.Initialize();
-            if (_handler == IntPtr.Zero)
+            if (display == null)
             {
-                int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();
-                ErrorCodeThrow((Interop.InputGesture.ErrorCode)err);
+                throw new ArgumentNullException(nameof(display));
             }
-            Log.Debug(LogTag, "InputGesture Created");
+
+            IntPtr displayHandle = display.GetNativeHandle();
+            if (displayHandle == IntPtr.Zero)
+            {
+                throw new ObjectDisposedException(nameof(display));
+            }
+
+            _display = display;
+            int ret = Interop.InputGesture.Create(displayHandle, out _handler);
+            if (ret != (int)Interop.InputGesture.ErrorCode.None)
+            {
+                disposed = true;
+                GC.SuppressFinalize(this);
+                ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
+            }
+            Log.Debug(Interop.InputGesture.LogTag, "InputGesture Created");
         }
 
         /// <summary>
@@ -232,6 +248,7 @@ namespace Tizen.NUI.WindowSystem
                 return;
             }
 
+            disposed = true;
             if (type == DisposeTypes.Explicit)
             {
                 //Called by User
@@ -239,17 +256,25 @@ namespace Tizen.NUI.WindowSystem
                 //You should release all of your own disposable objects here.
             }
 
-            //Release your own unmanaged resources here.
-            //You should not access any managed member here except static instance.
-            //because the execution order of Finalizes is non-deterministic.
             if (_handler != global::System.IntPtr.Zero)
             {
-                Interop.InputGesture.ErrorCode res = Interop.InputGesture.Deinitialize(_handler);
-                ErrorCodeThrow(res);
+                if (_display != null && _display.GetNativeHandle() != IntPtr.Zero)
+                {
+                    try
+                    {
+                        int res = Interop.InputGesture.Destroy(_handler);
+                        if (res != (int)Interop.InputGesture.ErrorCode.None)
+                        {
+                            Log.Error(Interop.InputGesture.LogTag, $"Failed to destroy input gesture, error={res}");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(Interop.InputGesture.LogTag, $"Exception during destroy: {ex.Message}");
+                    }
+                }
                 _handler = IntPtr.Zero;
             }
-
-            disposed = true;
         }
 
         /// <summary>
@@ -262,14 +287,26 @@ namespace Tizen.NUI.WindowSystem
         /// <exception cref="Tizen.Applications.Exceptions.OutOfMemoryException">Thrown when the memory is not enough to allocate.</exception>
         public IntPtr CreateEdgeSwipeData(int fingers, GestureEdge edge)
         {
-            IntPtr edgeSwipeG = IntPtr.Zero;
-            edgeSwipeG = Interop.InputGesture.EdgeSwipeNew(_handler, fingers, (int)edge);
-            if (edgeSwipeG == IntPtr.Zero)
+            if (disposed || _handler == IntPtr.Zero)
             {
-                int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();
-                ErrorCodeThrow((Interop.InputGesture.ErrorCode)err);
+                throw new ObjectDisposedException(nameof(InputGesture));
             }
-            Log.Debug(LogTag, $"CreateEdgeSwipeDatafingers: {fingers}", "edge: " + (int)edge);
+            if (_display == null || _display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Associated display has been disposed");
+            }
+            if (fingers <=0)
+            {
+                throw new ArgumentException("fingers must be greater than 0");
+            }
+
+            IntPtr edgeSwipeG = IntPtr.Zero;
+            int ret = Interop.InputGesture.EdgeSwipeNew(_handler, (uint)fingers, (int)edge, out edgeSwipeG);
+            if (ret != (int)Interop.InputGesture.ErrorCode.None)
+            {
+                ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
+            }
+            Log.Debug(Interop.InputGesture.LogTag, $"CreateEdgeSwipeData fingers: {fingers}, edge: {(int)edge}");
             return edgeSwipeG;
         }
 
@@ -280,13 +317,21 @@ namespace Tizen.NUI.WindowSystem
         /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
         public void ReleaseEdgeSwipeData(IntPtr data)
         {
+            if (disposed || _handler == IntPtr.Zero)
+            {
+                throw new ObjectDisposedException(nameof(InputGesture));
+            }
+            if (_display == null || _display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Associated display has been disposed");
+            }
             if (data == IntPtr.Zero)
             {
                 throw new ArgumentException("EdgeSwipeData is not valid.");
             }
-            Interop.InputGesture.ErrorCode res = Interop.InputGesture.EdgeSwipeFree(_handler, data);
-            ErrorCodeThrow(res);
-            Log.Debug(LogTag, "ReleaseEdgeSwipeData");
+            int ret = Interop.InputGesture.EdgeSwipeFree(_handler, data);
+            ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
+            Log.Debug(Interop.InputGesture.LogTag, "ReleaseEdgeSwipeData");
         }
 
         /// <summary>
@@ -299,13 +344,29 @@ namespace Tizen.NUI.WindowSystem
         /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
         public void SetEdgeSwipeSize(IntPtr data, GestureEdgeSize edgeSize, int startPoint, int endPoint)
         {
+            if (disposed || _handler == IntPtr.Zero)
+            {
+                throw new ObjectDisposedException(nameof(InputGesture));
+            }
+            if (_display == null || _display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Associated display has been disposed");
+            }
+            if (startPoint < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startPoint), "startPoint must be greater than or equal to 0");
+            }
+            if (endPoint < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(endPoint), "endPoint must be greater than or equal to 0");
+            }
             if (data == IntPtr.Zero)
             {
                 throw new ArgumentException("EdgeSwipeData is not valid.");
             }
-            Interop.InputGesture.ErrorCode res = Interop.InputGesture.EdgeSwipeSizeSet(data, (int)edgeSize, startPoint, endPoint);
-            ErrorCodeThrow(res);
-            Log.Debug(LogTag, $"SetEdgeSwipeSizesize: {(int)edgeSize }startPoint: {startPoint}endPoint: {endPoint}");
+            int ret = Interop.InputGesture.EdgeSwipeSizeSet(data, (int)edgeSize, (uint)startPoint, (uint)endPoint);
+            ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
+            Log.Debug(Interop.InputGesture.LogTag, $"SetEdgeSwipeSize size: {(int)edgeSize}, startPoint: {startPoint}, endPoint: {endPoint}");
         }
 
         /// <summary>
@@ -318,14 +379,26 @@ namespace Tizen.NUI.WindowSystem
         /// <exception cref="Tizen.Applications.Exceptions.OutOfMemoryException">Thrown when the memory is not enough to allocate.</exception>
         public IntPtr CreateEdgeDragData(int fingers, GestureEdge edge)
         {
-            IntPtr edgeDragG = IntPtr.Zero;
-            edgeDragG = Interop.InputGesture.EdgeDragNew(_handler, fingers, (int)edge);
-            if (edgeDragG == IntPtr.Zero)
+            if (disposed || _handler == IntPtr.Zero)
             {
-                int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();
-                ErrorCodeThrow((Interop.InputGesture.ErrorCode)err);
+                throw new ObjectDisposedException(nameof(InputGesture));
             }
-            Log.Debug(LogTag, $"CreateEdgeDragDatafingers: {fingers}", "edge: " + (int)edge);
+            if (_display == null || _display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Associated display has been disposed");
+            }
+            if (fingers <=0)
+            {
+                throw new ArgumentException("fingers must be greater than 0");
+            }
+
+            IntPtr edgeDragG = IntPtr.Zero;
+            int ret = Interop.InputGesture.EdgeDragNew(_handler, (uint)fingers, (int)edge, out edgeDragG);
+            if (ret != (int)Interop.InputGesture.ErrorCode.None)
+            {
+                ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
+            }
+            Log.Debug(Interop.InputGesture.LogTag, $"CreateEdgeDragData fingers: {fingers}, edge: {(int)edge}");
             return edgeDragG;
         }
 
@@ -336,13 +409,21 @@ namespace Tizen.NUI.WindowSystem
         /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
         public void ReleaseEdgeDrageData(IntPtr data)
         {
+            if (disposed || _handler == IntPtr.Zero)
+            {
+                throw new ObjectDisposedException(nameof(InputGesture));
+            }
+            if (_display == null || _display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Associated display has been disposed");
+            }
             if (data == IntPtr.Zero)
             {
                 throw new ArgumentException("EdgeDragData is not valid.");
             }
-            Interop.InputGesture.ErrorCode res = Interop.InputGesture.EdgeDragFree(_handler, data);
-            ErrorCodeThrow(res);
-            Log.Debug(LogTag, "ReleaseEdgeDrageData");
+            int ret = Interop.InputGesture.EdgeDragFree(_handler, data);
+            ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
+            Log.Debug(Interop.InputGesture.LogTag, "ReleaseEdgeDrageData");
         }
 
         /// <summary>
@@ -355,13 +436,29 @@ namespace Tizen.NUI.WindowSystem
         /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
         public void SetEdgeDragSize(IntPtr data, GestureEdgeSize edgeSize, int startPoint, int endPoint)
         {
+            if (disposed || _handler == IntPtr.Zero)
+            {
+                throw new ObjectDisposedException(nameof(InputGesture));
+            }
+            if (_display == null || _display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Associated display has been disposed");
+            }
+            if (startPoint < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startPoint), "startPoint must be greater than or equal to 0");
+            }
+            if (endPoint < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(endPoint), "endPoint must be greater than or equal to 0");
+            }
             if (data == IntPtr.Zero)
             {
                 throw new ArgumentException("EdgeDragData is not valid.");
             }
-            Interop.InputGesture.ErrorCode res = Interop.InputGesture.EdgeDragSizeSet(data, (int)edgeSize, startPoint, endPoint);
-            ErrorCodeThrow(res);
-            Log.Debug(LogTag, $"SetEdgeDragSizesize: {(int)edgeSize }startPoint: {startPoint}endPoint: {endPoint}");
+            int ret = Interop.InputGesture.EdgeDragSizeSet(data, (int)edgeSize, (uint)startPoint, (uint)endPoint);
+            ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
+            Log.Debug(Interop.InputGesture.LogTag, $"SetEdgeDragSize size: {(int)edgeSize}, startPoint: {startPoint}, endPoint: {endPoint}");
         }
 
         /// <summary>
@@ -374,14 +471,30 @@ namespace Tizen.NUI.WindowSystem
         /// <exception cref="Tizen.Applications.Exceptions.OutOfMemoryException">Thrown when the memory is not enough to allocate.</exception>
         public IntPtr CreateTapData(int fingers, int repeats)
         {
-            IntPtr tapG = IntPtr.Zero;
-            tapG = Interop.InputGesture.TapNew(_handler, fingers, repeats);
-            if (tapG == IntPtr.Zero)
+            if (disposed || _handler == IntPtr.Zero)
             {
-                int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();
-                ErrorCodeThrow((Interop.InputGesture.ErrorCode)err);
+                throw new ObjectDisposedException(nameof(InputGesture));
             }
-            Log.Debug(LogTag, $"CreateTapDatafingers: {fingers}", "repeats: " + repeats);
+            if (_display == null || _display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Associated display has been disposed");
+            }
+            if (fingers <=0)
+            {
+                throw new ArgumentException("fingers must be greater than 0");
+            }
+            if (repeats < 0)
+            {
+                throw new ArgumentException("repeats must be greater than or equal to 0");
+            }
+
+            IntPtr tapG = IntPtr.Zero;
+            int ret = Interop.InputGesture.TapNew(_handler, (uint)fingers, (uint)repeats, out tapG);
+            if (ret != (int)Interop.InputGesture.ErrorCode.None)
+            {
+                ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
+            }
+            Log.Debug(Interop.InputGesture.LogTag, $"CreateTapData fingers: {fingers}, repeats: {repeats}");
             return tapG;
         }
 
@@ -392,13 +505,21 @@ namespace Tizen.NUI.WindowSystem
         /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
         public void ReleaseTapData(IntPtr data)
         {
+            if (disposed || _handler == IntPtr.Zero)
+            {
+                throw new ObjectDisposedException(nameof(InputGesture));
+            }
+            if (_display == null || _display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Associated display has been disposed");
+            }
             if (data == IntPtr.Zero)
             {
                 throw new ArgumentException("tapData is not valid.");
             }
-            Interop.InputGesture.ErrorCode res = Interop.InputGesture.TapFree(_handler, data);
-            ErrorCodeThrow(res);
-            Log.Debug(LogTag, "ReleaseTapData");
+            int ret = Interop.InputGesture.TapFree(_handler, data);
+            ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
+            Log.Debug(Interop.InputGesture.LogTag, "ReleaseTapData");
         }
 
         /// <summary>
@@ -409,14 +530,21 @@ namespace Tizen.NUI.WindowSystem
         /// <exception cref="Tizen.Applications.Exceptions.OutOfMemoryException">Thrown when the memory is not enough to allocate.</exception>
         public IntPtr CreatePalmCoverData()
         {
-            IntPtr palmCoverG = IntPtr.Zero;
-            palmCoverG = Interop.InputGesture.PalmCoverNew(_handler);
-            if (palmCoverG == IntPtr.Zero)
+            if (disposed || _handler == IntPtr.Zero)
             {
-                int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();
-                ErrorCodeThrow((Interop.InputGesture.ErrorCode)err);
+                throw new ObjectDisposedException(nameof(InputGesture));
             }
-            Log.Debug(LogTag, "CreatePalmCoverData");
+            if (_display == null || _display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Associated display has been disposed");
+            }
+            IntPtr palmCoverG = IntPtr.Zero;
+            int ret = Interop.InputGesture.PalmCoverNew(_handler, out palmCoverG);
+            if (ret != (int)Interop.InputGesture.ErrorCode.None)
+            {
+                ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
+            }
+            Log.Debug(Interop.InputGesture.LogTag, "CreatePalmCoverData");
             return palmCoverG;
         }
 
@@ -427,13 +555,21 @@ namespace Tizen.NUI.WindowSystem
         /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
         public void ReleasePalmCoverData(IntPtr data)
         {
+            if (disposed || _handler == IntPtr.Zero)
+            {
+                throw new ObjectDisposedException(nameof(InputGesture));
+            }
+            if (_display == null || _display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Associated display has been disposed");
+            }
             if (data == IntPtr.Zero)
             {
                 throw new ArgumentException("palmCoverData is not valid.");
             }
-            Interop.InputGesture.ErrorCode res = Interop.InputGesture.PalmCoverFree(_handler, data);
-            ErrorCodeThrow(res);
-            Log.Debug(LogTag, "ReleasePalmCoverData");
+            int ret = Interop.InputGesture.PalmCoverFree(_handler, data);
+            ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
+            Log.Debug(Interop.InputGesture.LogTag, "ReleasePalmCoverData");
         }
 
         /// <summary>
@@ -443,13 +579,21 @@ namespace Tizen.NUI.WindowSystem
         /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
         public void GrabGesture(IntPtr data)
         {
+            if (disposed || _handler == IntPtr.Zero)
+            {
+                throw new ObjectDisposedException(nameof(InputGesture));
+            }
+            if (_display == null || _display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Associated display has been disposed");
+            }
             if (data == IntPtr.Zero)
             {
                 throw new ArgumentException("gesture data is not valid.");
             }
-            Interop.InputGesture.ErrorCode res = Interop.InputGesture.GestureGrab(_handler, data);
-            ErrorCodeThrow(res);
-            Log.Debug(LogTag, "GrabGesture");
+            int ret = Interop.InputGesture.GestureGrab(_handler, data);
+            ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
+            Log.Debug(Interop.InputGesture.LogTag, "GrabGesture");
         }
 
         /// <summary>
@@ -460,13 +604,21 @@ namespace Tizen.NUI.WindowSystem
         /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
         public void SetGestureGrabMode(IntPtr data, GestureGrabMode mode)
         {
+            if (disposed || _handler == IntPtr.Zero)
+            {
+                throw new ObjectDisposedException(nameof(InputGesture));
+            }
+            if (_display == null || _display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Associated display has been disposed");
+            }
             if (data == IntPtr.Zero)
             {
                 throw new ArgumentException("gesture data is not valid.");
             }
-            Interop.InputGesture.ErrorCode res = Interop.InputGesture.SetGestureGrabMode(_handler, data, (int)mode);
-            ErrorCodeThrow(res);
-            Log.Debug(LogTag, "SetGestureGrabMode");
+            int ret = Interop.InputGesture.SetGestureGrabMode(_handler, data, (int)mode);
+            ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
+            Log.Debug(Interop.InputGesture.LogTag, "SetGestureGrabMode");
         }
 
         /// <summary>
@@ -476,13 +628,21 @@ namespace Tizen.NUI.WindowSystem
         /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
         public void UngrabGesture(IntPtr data)
         {
+            if (disposed || _handler == IntPtr.Zero)
+            {
+                throw new ObjectDisposedException(nameof(InputGesture));
+            }
+            if (_display == null || _display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("Associated display has been disposed");
+            }
             if (data == IntPtr.Zero)
             {
                 throw new ArgumentException("gesture data is not valid.");
             }
-            Interop.InputGesture.ErrorCode res = Interop.InputGesture.GestureUngrab(_handler, data);
-            ErrorCodeThrow(res);
-            Log.Debug(LogTag, "UngrabGesture");
+            int ret = Interop.InputGesture.GestureUngrab(_handler, data);
+            ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
+            Log.Debug(Interop.InputGesture.LogTag, "UngrabGesture");
         }
 
         /// <summary>
@@ -493,16 +653,21 @@ namespace Tizen.NUI.WindowSystem
         {
             add
             {
+                if (disposed || _handler == IntPtr.Zero)
+                {
+                    throw new ObjectDisposedException(nameof(InputGesture));
+                }
+
                 if (_edgeSwipeEventHandler == null)
                 {
                     _edgeSwipeDelegate = (IntPtr userData, int mode,  int fingers, int sx, int sy, int edge) =>
                     {
                         EdgeSwipeEventArgs args = new EdgeSwipeEventArgs(mode, fingers, sx, sy, edge);
-                        Log.Debug(LogTag, $"EdgeSwipe Event received. mode: {mode}, fingers: {fingers}");
+                        Log.Debug(Interop.InputGesture.LogTag, $"EdgeSwipe Event received. mode: {mode}, fingers: {fingers}");
                         _edgeSwipeEventHandler?.Invoke(null, args);
                     };
-                    Interop.InputGesture.ErrorCode res = Interop.InputGesture.SetEdgeSwipeCb(_handler, _edgeSwipeDelegate, IntPtr.Zero);
-                    ErrorCodeThrow(res);
+                    int ret = Interop.InputGesture.SetEdgeSwipeCb(_handler, _edgeSwipeDelegate, IntPtr.Zero);
+                    ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
                 }
 
                 _edgeSwipeEventHandler += value;
@@ -510,10 +675,15 @@ namespace Tizen.NUI.WindowSystem
             remove
             {
                 _edgeSwipeEventHandler -= value;
-                if (_edgeSwipeEventHandler == null)
+                if (_edgeSwipeEventHandler == null && _edgeSwipeDelegate != null)
                 {
-                    Interop.InputGesture.ErrorCode res = Interop.InputGesture.SetEdgeSwipeCb(_handler, null, IntPtr.Zero);
-                    ErrorCodeThrow(res);
+                    if (disposed || _handler == IntPtr.Zero)
+                    {
+                        return;
+                    }
+                    int ret = Interop.InputGesture.SetEdgeSwipeCb(_handler, null, IntPtr.Zero);
+                    _edgeSwipeDelegate = null;
+                    ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
                 }
             }
         }
@@ -526,16 +696,21 @@ namespace Tizen.NUI.WindowSystem
         {
             add
             {
+                if (disposed || _handler == IntPtr.Zero)
+                {
+                    throw new ObjectDisposedException(nameof(InputGesture));
+                }
+
                 if (_edgeDragEventHandler == null)
                 {
                     _edgeDragDelegate = (IntPtr userData, int mode,  int fingers, int cx, int cy, int edge) =>
                     {
                         EdgeDragEventArgs args = new EdgeDragEventArgs(mode, fingers, cx, cy, edge);
-                        Log.Debug(LogTag, $"EdgeDrag Event received. mode: {mode}, fingers: {fingers}");
+                        Log.Debug(Interop.InputGesture.LogTag, $"EdgeDrag Event received. mode: {mode}, fingers: {fingers}");
                         _edgeDragEventHandler?.Invoke(null, args);
                     };
-                    Interop.InputGesture.ErrorCode res = Interop.InputGesture.SetEdgeDragCb(_handler, _edgeDragDelegate, IntPtr.Zero);
-                    ErrorCodeThrow(res);
+                    int ret = Interop.InputGesture.SetEdgeDragCb(_handler, _edgeDragDelegate, IntPtr.Zero);
+                    ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
                 }
 
                 _edgeDragEventHandler += value;
@@ -543,10 +718,15 @@ namespace Tizen.NUI.WindowSystem
             remove
             {
                 _edgeDragEventHandler -= value;
-                if (_edgeDragEventHandler == null)
+                if (_edgeDragEventHandler == null && _edgeDragDelegate != null)
                 {
-                    Interop.InputGesture.ErrorCode res = Interop.InputGesture.SetEdgeDragCb(_handler, null, IntPtr.Zero);
-                    ErrorCodeThrow(res);
+                    if (disposed || _handler == IntPtr.Zero)
+                    {
+                        return;
+                    }
+                    int ret = Interop.InputGesture.SetEdgeDragCb(_handler, null, IntPtr.Zero);
+                    _edgeDragDelegate = null;
+                    ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
                 }
             }
         }
@@ -559,16 +739,21 @@ namespace Tizen.NUI.WindowSystem
         {
             add
             {
+                if (disposed || _handler == IntPtr.Zero)
+                {
+                    throw new ObjectDisposedException(nameof(InputGesture));
+                }
+
                 if (_tapEventHandler == null)
                 {
                     _tapDelegate = (IntPtr userData, int mode,  int fingers, int repeats) =>
                     {
                         TapEventArgs args = new TapEventArgs(mode, fingers, repeats);
-                        Log.Debug(LogTag, $"Tap Event received. mode: {mode}, fingers: {fingers}, repeats: {repeats}");
+                        Log.Debug(Interop.InputGesture.LogTag, $"Tap Event received. mode: {mode}, fingers: {fingers}, repeats: {repeats}");
                         _tapEventHandler?.Invoke(null, args);
                     };
-                    Interop.InputGesture.ErrorCode res = Interop.InputGesture.SetTapCb(_handler, _tapDelegate, IntPtr.Zero);
-                    ErrorCodeThrow(res);
+                    int ret = Interop.InputGesture.SetTapCb(_handler, _tapDelegate, IntPtr.Zero);
+                    ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
                 }
 
                 _tapEventHandler += value;
@@ -576,10 +761,15 @@ namespace Tizen.NUI.WindowSystem
             remove
             {
                 _tapEventHandler -= value;
-                if (_tapEventHandler == null)
+                if (_tapEventHandler == null && _tapDelegate != null)
                 {
-                    Interop.InputGesture.ErrorCode res = Interop.InputGesture.SetTapCb(_handler, null, IntPtr.Zero);
-                    ErrorCodeThrow(res);
+                    if (disposed || _handler == IntPtr.Zero)
+                    {
+                        return;
+                    }
+                    int ret = Interop.InputGesture.SetTapCb(_handler, null, IntPtr.Zero);
+                    _tapDelegate = null;
+                    ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
                 }
             }
         }
@@ -591,26 +781,36 @@ namespace Tizen.NUI.WindowSystem
         {
             add
             {
+                if (disposed || _handler == IntPtr.Zero)
+                {
+                    throw new ObjectDisposedException(nameof(InputGesture));
+                }
+
                 if (_palmCoverEventHandler == null)
                 {
                     _palmCoverDelegate = (IntPtr userData, int mode,  int duration, int cx, int cy, int size, double pressure) =>
                     {
                         PalmCoverEventArgs args = new PalmCoverEventArgs(mode, duration, cx, cy, size, pressure);
-                        Log.Debug(LogTag, $"PalmCover Event received. mode: {mode}, duration: {duration}");
+                        Log.Debug(Interop.InputGesture.LogTag, $"PalmCover Event received. mode: {mode}, duration: {duration}");
                         _palmCoverEventHandler?.Invoke(null, args);
                     };
-                    Interop.InputGesture.ErrorCode res = Interop.InputGesture.SetPalmCoverCb(_handler, _palmCoverDelegate, IntPtr.Zero);
-                    ErrorCodeThrow(res);
+                    int ret = Interop.InputGesture.SetPalmCoverCb(_handler, _palmCoverDelegate, IntPtr.Zero);
+                    ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
                 }
                 _palmCoverEventHandler += value;
             }
             remove
             {
                 _palmCoverEventHandler -= value;
-                if (_palmCoverEventHandler == null)
+                if (_palmCoverEventHandler == null && _palmCoverDelegate != null)
                 {
-                    Interop.InputGesture.ErrorCode res = Interop.InputGesture.SetPalmCoverCb(_handler, null, IntPtr.Zero);
-                    ErrorCodeThrow(res);
+                    if (disposed || _handler == IntPtr.Zero)
+                    {
+                        return;
+                    }
+                    int ret = Interop.InputGesture.SetPalmCoverCb(_handler, null, IntPtr.Zero);
+                    _palmCoverDelegate = null;
+                    ErrorCodeThrow((Interop.InputGesture.ErrorCode)ret);
                 }
             }
         }

--- a/src/Tizen.NUI.WindowSystem/src/public/TizenCoreWlDisplay.cs
+++ b/src/Tizen.NUI.WindowSystem/src/public/TizenCoreWlDisplay.cs
@@ -1,0 +1,269 @@
+/*
+ * Copyright(c) 2026 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.WindowSystem
+{
+    /// <summary>
+    /// Class for the Tizen Core Wayland Display.
+    /// </summary>
+    /// This class is need to be hidden as inhouse API.
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class TizenCoreWlDisplay : IDisposable
+    {
+        private static int _initRefCount = 0;
+        private static readonly object _refCountLock = new object();
+
+        private IntPtr _display;
+        private bool disposed = false;
+        private bool isDisposeQueued = false;
+        private bool _connected = false;
+        private readonly object _instanceLock = new object();
+
+        internal void ErrorCodeThrow(Interop.TizenCoreWl.ErrorCode error)
+        {
+            switch (error)
+            {
+                case Interop.TizenCoreWl.ErrorCode.None:
+                    return;
+                case Interop.TizenCoreWl.ErrorCode.OutOfMemory:
+                    throw new Tizen.Applications.Exceptions.OutOfMemoryException("Out of Memory");
+                case Interop.TizenCoreWl.ErrorCode.InvalidParameter:
+                    throw new ArgumentException("Invalid Parameter");
+                case Interop.TizenCoreWl.ErrorCode.PermissionDenied:
+                    throw new Tizen.Applications.Exceptions.PermissionDeniedException("Permission denied");
+                case Interop.TizenCoreWl.ErrorCode.NotSupported:
+                    throw new NotSupportedException("Not Supported");
+                case Interop.TizenCoreWl.ErrorCode.NotConnected:
+                    throw new InvalidOperationException("Not Connected");
+                case Interop.TizenCoreWl.ErrorCode.NoResourceAvailable:
+                    throw new InvalidOperationException("No Resource Available");
+                default:
+                    throw new InvalidOperationException($"Unknown Error: {error}");
+            }
+        }
+
+        /// <summary>
+        /// Creates a new TizenCoreWlDisplay.
+        /// </summary>
+        /// <exception cref="Tizen.Applications.Exceptions.OutOfMemoryException">Thrown when the memory is not enough to allocate.</exception>
+        /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
+        public TizenCoreWlDisplay()
+        {
+            bool initialized = false;
+            lock (_refCountLock)
+            {
+                Tizen.Log.Debug("TIZEN_CORE_WL", "TizenCoreWlDisplay: calling tizen_core_wl_init()");
+                if (_initRefCount == 0)
+                {
+                    int initRet = Interop.TizenCoreWl.Init();
+                    if (initRet != (int)Interop.TizenCoreWl.ErrorCode.None)
+                    {
+                        Tizen.Log.Error("TIZEN_CORE_WL", $"TizenCoreWlDisplay: tizen_core_wl_init() failed with error={initRet}");
+                        disposed = true;
+                        GC.SuppressFinalize(this);
+                        ErrorCodeThrow((Interop.TizenCoreWl.ErrorCode)initRet);
+                    }
+                }
+                _initRefCount++;
+                initialized = true;
+            }
+
+            try
+            {
+                int ret = Interop.TizenCoreWl.DisplayCreate(out _display);
+                if (ret != (int)Interop.TizenCoreWl.ErrorCode.None)
+                {
+                    Tizen.Log.Error("TIZEN_CORE_WL", $"TizenCoreWlDisplay: DisplayCreate() failed with error={ret}");
+                    ErrorCodeThrow((Interop.TizenCoreWl.ErrorCode)ret);
+                }
+                Tizen.Log.Debug("TIZEN_CORE_WL", $"TizenCoreWlDisplay: DisplayCreate() succeeded, handle=0x{_display:X}");
+            }
+            catch
+            {
+                disposed = true;
+                GC.SuppressFinalize(this);
+                if (initialized)
+                {
+                    lock (_refCountLock)
+                    {
+                        _initRefCount--;
+                        if (_initRefCount == 0)
+                        {
+                            try
+                            {
+                                Interop.TizenCoreWl.Shutdown();
+                            }
+                            catch (Exception ex)
+                            {
+                                Tizen.Log.Error("TIZEN_CORE_WL", $"TizenCoreWlDisplay: Shutdown() failed during exception recovery: {ex.Message}");
+                            }
+                        }
+                    }
+                }
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Connects to the Wayland display server.
+        /// </summary>
+        /// <param name="name">The name of the display to connect to, or null for the default display.</param>
+        /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed to connect.</exception>
+        /// <exception cref="ObjectDisposedException">Thrown when the instance is already disposed.</exception>
+        public void Connect(string name = null)
+        {
+            lock (_instanceLock)
+            {
+                if (disposed || _display == IntPtr.Zero)
+                {
+                    throw new ObjectDisposedException(nameof(TizenCoreWlDisplay));
+                }
+
+                if (_connected)
+                {
+                    throw new InvalidOperationException("Display is already connected");
+                }
+
+                Tizen.Log.Debug("TIZEN_CORE_WL", $"TizenCoreWlDisplay: Connect(name={name ?? "null"}) called");
+                int ret = Interop.TizenCoreWl.DisplayConnect(_display, name);
+                if (ret != (int)Interop.TizenCoreWl.ErrorCode.None)
+                {
+                    Tizen.Log.Error("TIZEN_CORE_WL", $"TizenCoreWlDisplay: DisplayConnect() failed with error={ret}");
+                    ErrorCodeThrow((Interop.TizenCoreWl.ErrorCode)ret);
+                }
+                _connected = true;
+                Tizen.Log.Debug("TIZEN_CORE_WL", "TizenCoreWlDisplay: DisplayConnect() succeeded");
+            }
+        }
+
+        /// <summary>
+        /// Destructor.
+        /// </summary>
+        ~TizenCoreWlDisplay()
+        {
+            if (!isDisposeQueued)
+            { 
+                isDisposeQueued = true;
+                try
+                {
+                    DisposeQueue.Instance.Add(this);
+                }
+                catch (Exception ex)
+                {
+                    Tizen.Log.Error("TIZEN_CORE_WL", $"Failed to queue dispose: {ex.Message}");
+                    Dispose(DisposeTypes.Implicit);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Dispose.
+        /// </summary>
+        public void Dispose()
+        {
+            if (isDisposeQueued)
+            {
+                Dispose(DisposeTypes.Implicit);
+            }
+            else
+            {
+                Dispose(DisposeTypes.Explicit);
+                GC.SuppressFinalize(this);
+            }
+        }
+
+        /// <inheritdoc/>
+        protected virtual void Dispose(DisposeTypes type)
+        {
+            lock (_instanceLock)
+            {
+                if (disposed)
+                {
+                    return;
+                }
+
+                disposed = true;
+                if (_display != IntPtr.Zero)
+                { 
+                    Tizen.Log.Debug("TIZEN_CORE_WL", "TizenCoreWlDisplay: Disconnecting and destroying display");
+                    if (_connected)
+                    { 
+                        try
+                        { 
+                            int ret = Interop.TizenCoreWl.DisplayDisconnect(_display);
+                            if (ret != (int)Interop.TizenCoreWl.ErrorCode.None)
+                            {
+                                Tizen.Log.Error("TIZEN_CORE_WL", $"TizenCoreWlDisplay: DisplayDisconnect() failed with error={ret}");
+                            }
+                        }
+                        catch (Exception ex)
+                        { 
+                            Tizen.Log.Error("TIZEN_CORE_WL", $"TizenCoreWlDisplay: DisplayDisconnect() threw exception: {ex.Message}");
+                        }
+                        _connected = false;
+                    }
+                    try
+                    { 
+                        int destroyRet = Interop.TizenCoreWl.DisplayDestroy(_display);
+                        if (destroyRet != (int)Interop.TizenCoreWl.ErrorCode.None)
+                        {
+                            Tizen.Log.Error("TIZEN_CORE_WL", $"TizenCoreWlDisplay: DisplayDestroy() failed with error={destroyRet}");
+                        }
+                    }
+                    catch (Exception ex)
+                    { 
+                        Tizen.Log.Error("TIZEN_CORE_WL", $"TizenCoreWlDisplay: DisplayDestroy() threw exception: {ex.Message}");
+                    }
+                    _display = IntPtr.Zero;
+                }
+            }
+
+            lock (_refCountLock)
+            {
+                _initRefCount--;
+                if (_initRefCount == 0)
+                {
+                    Tizen.Log.Debug("TIZEN_CORE_WL", "TizenCoreWlDisplay: calling tizen_core_wl_shutdown()");
+                    try
+                    {
+                        int shutdownRet = Interop.TizenCoreWl.Shutdown();
+                        if (shutdownRet != (int)Interop.TizenCoreWl.ErrorCode.None)
+                        {
+                            Tizen.Log.Error("TIZEN_CORE_WL", $"TizenCoreWlDisplay: Shutdown() failed with error={shutdownRet}");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Tizen.Log.Error("TIZEN_CORE_WL", $"TizenCoreWlDisplay: Shutdown() threw exception: {ex.Message}");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the native display handle.
+        /// </summary>
+        internal IntPtr GetNativeHandle()
+        {
+            return _display;
+        }
+    }
+}

--- a/test/Tizen.NUI.WindowSystem.InputGenerator/Tizen.NUI.WindowSystem.InputGenerator.cs
+++ b/test/Tizen.NUI.WindowSystem.InputGenerator/Tizen.NUI.WindowSystem.InputGenerator.cs
@@ -34,8 +34,32 @@ namespace Tizen.NUI.WindowSystem
 
         void Initialize()
         {
+            Log.Debug("GeneratorSample", "Initialize() started");
+
             Window win = Window.Instance;
-            inputGen = new InputGenerator(InputGenerator.DeviceType.All, null);
+            Log.Debug("GeneratorSample", "Window.Instance obtained");
+
+            try
+            {
+                Log.Debug("GeneratorSample", "Creating TizenCoreWlDisplay...");
+                display = new TizenCoreWlDisplay();
+                Log.Debug("GeneratorSample", "TizenCoreWlDisplay created");
+
+                Log.Debug("GeneratorSample", "Connecting TizenCoreWlDisplay...");
+                display.Connect();
+                Log.Debug("GeneratorSample", "TizenCoreWlDisplay connected");
+
+                Log.Debug("GeneratorSample", "Creating InputGenerator with DeviceType.All...");
+                inputGen = new InputGenerator(display, InputGenerator.DeviceType.All, null);
+                Log.Debug("GeneratorSample", "InputGenerator created");
+            }
+            catch (Exception e)
+            {
+                Log.Error("GeneratorSample", $"Failed to initialize TizenCoreWl/InputGenerator: {e.GetType().Name}: {e.Message}");
+                Log.Error("GeneratorSample", $"StackTrace: {e.StackTrace}");
+                display?.Dispose();
+                display = null;
+            }
 
             win.WindowSize = new Size2D(500, 500);
             win.KeyEvent += OnKeyEvent;
@@ -57,6 +81,7 @@ namespace Tizen.NUI.WindowSystem
             windowView.Add(centerLabel);
 
             repeatCounter = 0;
+            Log.Debug("GeneratorSample", "Initialize() completed");
         }
 
         private void OnKeyEvent(object sender, Window.KeyEventArgs e)
@@ -76,8 +101,8 @@ namespace Tizen.NUI.WindowSystem
         {
             if (e.Touch.GetState(0) == PointStateType.Down)
             {
-                inputGen.GenerateKey("Return", 1);
-                inputGen.GenerateKey("Return", 0);
+                inputGen?.GenerateKey("Return", true);
+                inputGen?.GenerateKey("Return", false);
 
                 return true;
             }
@@ -91,6 +116,7 @@ namespace Tizen.NUI.WindowSystem
             app.Run(args);
         }
 
+        private TizenCoreWlDisplay display;
         private InputGenerator inputGen;
         private TextLabel centerLabel;
         int repeatCounter = 0;

--- a/test/Tizen.NUI.WindowSystem.InputGesture/Tizen.NUI.WindowSystem.InputGesture.cs
+++ b/test/Tizen.NUI.WindowSystem.InputGesture/Tizen.NUI.WindowSystem.InputGesture.cs
@@ -18,7 +18,20 @@ namespace Tizen.NUI.WindowSystem
         void Initialize()
         {
             Window win = Window.Instance;
-            inputGesture = new InputGesture();
+            try
+            {
+                display = new TizenCoreWlDisplay();
+                display.Connect();
+                inputGesture = new InputGesture(display);
+            }
+            catch (Exception e)
+            {
+                Log.Error("GestureSample", $"Failed to initialize TizenCoreWl/InputGesture: {e.GetType().Name}: {e.Message}");
+                Log.Error("GestureSample", $"StackTrace: {e.StackTrace}");
+                display?.Dispose();
+                display = null;
+                inputGesture = null;
+            }
 
             win.WindowSize = new Size2D(500, 500);
             win.KeyEvent += OnKeyEvent;
@@ -52,6 +65,11 @@ namespace Tizen.NUI.WindowSystem
             {
                 repeatCounter++;
                 centerLabel.Text = "Return Key Pressed, counter: " + repeatCounter.ToString();
+            }
+
+            if (inputGesture == null)
+            {
+                return;
             }
 
             if (e.Key.State == Key.StateType.Down && (e.Key.KeyPressedName == "S" || e.Key.KeyPressedName == "s"))
@@ -241,6 +259,7 @@ namespace Tizen.NUI.WindowSystem
             app.Run(args);
         }
 
+        private TizenCoreWlDisplay display;
         private InputGesture inputGesture;
         IntPtr edgeSwipeG;
         IntPtr edgeDragG;


### PR DESCRIPTION
Description of Change

[Tizen.NUI.WindowSystem] Migrate InputGenerator and InputGesture from efl_util to tizen_core_wl

API Changes

Added:
- class Tizen.NUI.TizenCoreWlDisplay

Modified:
- InputGenerator
- InputGesture

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
