### PR TITLE
Apply security reviews

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Build
       id: build
-      uses: TizenAPI/tizenfx-build-actions/problem-filter@master
+      uses: TizenAPI/tizenfx-build-actions/problem-filter@0237152c5708e470b6e9634ae4ad702701d1451a # master @ 2026-06-22
       with:
         run: ./build.sh full /p:BuildWithAnalyzer=True -consoleloggerparameters:NoSummary
         files: ${{ steps.getChangedFiles.outputs.all }}
@@ -48,6 +48,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: TizenAPI/APITool
+        ref: 4e441d70a1d2576848394aabc8dc3095c99b366a # master @ 2026-06-22
         path: .apitool
 
     - name: Extract API Spec
@@ -87,7 +88,7 @@ jobs:
         path: base
 
     - name: Build Base Branch
-      uses: TizenAPI/tizenfx-build-actions/problem-filter@master
+      uses: TizenAPI/tizenfx-build-actions/problem-filter@0237152c5708e470b6e9634ae4ad702701d1451a # master @ 2026-06-22
       with:
         run: ./build.sh full
         working-directory: base
@@ -96,6 +97,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: TizenAPI/APITool
+        ref: 4e441d70a1d2576848394aabc8dc3095c99b366a # master @ 2026-06-22
         path: .apitool
 
     - name: Extract Base API
@@ -105,7 +107,7 @@ jobs:
             -o Artifacts/base-api.json base/Artifacts/bin/public/
 
     - name: Check API Compatibilities
-      uses: TizenAPI/tizenfx-build-actions/apidb-compare@master
+      uses: TizenAPI/tizenfx-build-actions/apidb-compare@0237152c5708e470b6e9634ae4ad702701d1451a # master @ 2026-06-22
       with:
         file: Artifacts/api.json
         base-file: Artifacts/base-api.json

--- a/.github/workflows/deploy-packages.yml
+++ b/.github/workflows/deploy-packages.yml
@@ -36,11 +36,11 @@ jobs:
       run: |
         git config --global user.name "TizenAPI-Bot"
         git config --global user.email "tizenapi@samsung.com"
-        git config core.sshCommand "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+        git config --global core.sshCommand "ssh -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$HOME/.ssh/known_hosts"
 
     - name: Get Branch Metadata
       id: metadata
-      uses: TizenAPI/tizenfx-build-actions/branch-metadata@master
+      uses: TizenAPI/tizenfx-build-actions/branch-metadata@0237152c5708e470b6e9634ae4ad702701d1451a # master @ 2026-06-22
       with:
         ref: ${{ env.TARGET_BRANCH }}
 
@@ -79,6 +79,15 @@ jobs:
       uses: webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+    - name: Pin Gerrit SSH host key
+      if: github.event.inputs.deploy_to_tizen == 'true'
+      env:
+        GERRIT_KNOWN_HOSTS: ${{ secrets.GERRIT_KNOWN_HOSTS }}
+      run: |
+        mkdir -p "$HOME/.ssh" && chmod 700 "$HOME/.ssh"
+        printf '%s\n' "$GERRIT_KNOWN_HOSTS" >> "$HOME/.ssh/known_hosts"
+        chmod 600 "$HOME/.ssh/known_hosts"
 
     - name: Submit changes to Tizen
       if: github.event.inputs.deploy_to_tizen == 'true'

--- a/.github/workflows/postback-pull-request.yml
+++ b/.github/workflows/postback-pull-request.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: Download Artifacts from Build
-      uses: TizenAPI/tizenfx-build-actions/download-workflow-artifacts@master
+      uses: TizenAPI/tizenfx-build-actions/download-workflow-artifacts@0237152c5708e470b6e9634ae4ad702701d1451a # master @ 2026-06-22
       with:
         token: ${{ secrets.TIZENAPI_GITHUB_TOKEN }}
         run-id: ${{ github.event.workflow_run.id }}
@@ -59,7 +59,7 @@ jobs:
 
     - name: Report API comparison result
       if: ${{ github.event.workflow_run.conclusion == 'success' }}
-      uses: TizenAPI/tizenfx-build-actions/apidb-report@master
+      uses: TizenAPI/tizenfx-build-actions/apidb-report@0237152c5708e470b6e9634ae4ad702701d1451a # master @ 2026-06-22
       with:
         token: ${{ secrets.TIZENAPI_GITHUB_TOKEN }}
         issue-number: ${{ steps.pull_request.outputs.number }}


### PR DESCRIPTION
## Summary
Hardens the GitHub Actions workflows against two security findings. No change to
normal build/release behavior when the prerequisite secret (below) is configured.

## Changes
### Pin third-party actions to commit SHAs (supply-chain hardening)
Mutable `@master` refs are replaced with reviewed commit SHAs so external action
code cannot change under us without review:
- `deploy-packages.yml`: `tizenfx-build-actions/branch-metadata`
- `postback-pull-request.yml`: `download-workflow-artifacts`, `apidb-report`
- `build-pull-request.yml`: `problem-filter` (x2), `apidb-compare`, and the
  `TizenAPI/APITool` checkout (now pinned via `ref:`)

All pinned to `tizenfx-build-actions@0237152` / `APITool@4e441d7` (master as of 2026-06-22).

### Enable Gerrit SSH host-key verification (`deploy-packages.yml`)
Replaces `StrictHostKeyChecking=no` (which trusted any host) with strict checking
against a pinned `known_hosts`, preventing MITM/impersonation of the Gerrit endpoint
during credentialed release pushes. A new "Pin Gerrit SSH host key" step writes the
pinned key from a secret before the submit step.

## Required before merge (DONE)
Add a repository secret **`GERRIT_KNOWN_HOSTS`** containing the verified host key for
`review.tizen.org:29418` (from `ssh-keyscan -p 29418 review.tizen.org`, confirmed with
the Gerrit admin). Without it, the `deploy_to_tizen` path will fail host-key verification.
