### PR TITLE
Apply security review

### DIFF
--- a/.github/workflows/update-version-and-create-pr.yml
+++ b/.github/workflows/update-version-and-create-pr.yml
@@ -11,8 +11,16 @@ on:
 jobs:
   release-nui:
     runs-on: ubuntu-latest
-
+    env:
+      VERSION: ${{ inputs.version }}          # expand the expression once; use $VERSION afterwards
     steps:
+    - name: Validate version input
+      run: |
+        if [[ ! "$VERSION" =~ ^[0-9]+$ ]]; then
+          echo "::error::Invalid version '$VERSION' (digits only allowed)"
+          exit 1
+        fi
+
     - name: Debug gh auth status
       env:
         GH_TOKEN: ${{ secrets.MY_PAT }}
@@ -30,38 +38,34 @@ jobs:
         git config user.email "github-actions[bot]@users.noreply.github.com"
 
     - name: Delete remote branch if exists
-      run: |
-        VERSION=${{ inputs.version }}
-        git push origin --delete update-nui-$VERSION || echo "No existing remote branch"
+      run: git push origin --delete "update-nui-$VERSION" || echo "No existing remote branch"
 
     - name: Create new branch for version update
       run: |
-        VERSION=${{ inputs.version }}
         git fetch origin
         git checkout origin/DevelNUI
-        git checkout -b update-nui-$VERSION
+        git checkout -b "update-nui-$VERSION"
 
     - name: Update version.txt
-      run: |
-        sed -i "s/^\(RPM_VERSION_SUFFIX=nui\)[0-9]\+/\1${{ inputs.version }}/" packaging/version.txt
+      run: sed -i "s/^\(RPM_VERSION_SUFFIX=nui\)[0-9]\+/\1$VERSION/" packaging/version.txt
 
     - name: Update csapi-tizenfx.spec
-      run: |
-        sed -i "s/^\(%define TIZEN_NET_RPM_VERSION .*nui\)[0-9]\+/\1${{ inputs.version }}/" packaging/csapi-tizenfx.spec
+      run: sed -i "s/^\(%define TIZEN_NET_RPM_VERSION .*nui\)[0-9]\+/\1$VERSION/" packaging/csapi-tizenfx.spec
 
     - name: Commit and push changes
       run: |
         git add packaging/version.txt packaging/csapi-tizenfx.spec
-        git commit -m "Update NUI version to ${{ inputs.version }}"
+        git commit -m "Update NUI version to $VERSION"
         git push origin HEAD
 
     - name: Create Pull Request to Samsung/TizenFX:DevelNUI
       env:
         GH_TOKEN: ${{ secrets.MY_PAT }}
+        OWNER: ${{ github.repository_owner }}
       run: |
         gh pr create \
-          --title "Update NUI version to ${{ inputs.version }}" \
-          --body "This PR updates NUI version to ${{ inputs.version }}." \
+          --title "Update NUI version to $VERSION" \
+          --body "This PR updates NUI version to $VERSION." \
           --base DevelNUI \
-          --head ${{ github.repository_owner }}:update-nui-${{ inputs.version }} \
+          --head "$OWNER:update-nui-$VERSION" \
           --repo Samsung/TizenFX


### PR DESCRIPTION
## Summary
Hardens `update-version-and-create-pr.yml` against command injection through the
`workflow_dispatch` `version` input. No change to normal behavior for valid version values.

## Problem
The `version` input was interpolated directly as `${{ inputs.version }}` into shell
`run` blocks (shell assignments, `sed`, `git commit`, `gh pr create`). Because the
expression is substituted before the shell parses the script, a dispatcher could inject
shell syntax. The PR-creation step runs with `GH_TOKEN: secrets.MY_PAT`, so injected
commands could misuse the PAT.

## Changes
- Add a `Validate version input` step that rejects anything not matching `^[0-9]+$`.
- Expand the expression once into a job-level `env: VERSION` and reference it only as a
  quoted shell variable (`"$VERSION"`) everywhere; never inline `${{ inputs.version }}`
  into `run` scripts.
- Pass `github.repository_owner` via `env` (`OWNER`) the same way.

## Notes
- Valid numeric versions behave exactly as before; only malformed input is now rejected.
- No new secrets or configuration required.