### PR TITLE
[Tizen.Security.PrivacyPrivilegeManager][Non-ACR] Fix multiple priv. callback

### DIFF
--- a/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/PrivacyPrivilegeManager.cs
+++ b/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/PrivacyPrivilegeManager.cs
@@ -382,16 +382,19 @@ namespace Tizen.Security
 
             var tcs = s_multipleRequestMap[requestId];
             RequestMultipleResponseEventArgs requestResponse = new RequestMultipleResponseEventArgs();
+
             PermissionRequestResponse[] permissionResponses = new PermissionRequestResponse[privilegesCount];
+            bool isAnswer = (CallCause)cause == CallCause.Answer;
 
             for (int iterator = 0; iterator < privilegesCount; ++iterator)
             {
                 permissionResponses[iterator] = new PermissionRequestResponse
                 {
                     Privilege = requestedPrivileges[iterator],
-                    Result = (RequestResult)results[iterator]
+                    Result = isAnswer ? (RequestResult)results[iterator] : default(RequestResult)
                 };
             }
+
             requestResponse.Cause = (CallCause)cause;
             requestResponse.Responses = permissionResponses;
 


### PR DESCRIPTION
In case the callback is called for reason different than actual answer, underlying native implementation is not populating the results array and code cannot iterate over it.

This commit fixes this behavior for multiple-privileges callback. Sinlgle-privilege callback doesn't suffer from this as it gets results as an enum parameter.