### PR TITLE
[Tizen.WindowSystem] Change to use tizen_core_wl instead of efl_util

### DIFF
--- a/src/Tizen.WindowSystem/src/Enums/GestureEdge.cs
+++ b/src/Tizen.WindowSystem/src/Enums/GestureEdge.cs
@@ -12,7 +12,7 @@ namespace Tizen.WindowSystem
         /// <summary>
         /// edge top.
         /// </summary>
-        Top,
+        Top = 1,
 
         /// <summary>
         /// edge right.

--- a/src/Tizen.WindowSystem/src/ErrorUtils.cs
+++ b/src/Tizen.WindowSystem/src/ErrorUtils.cs
@@ -22,8 +22,7 @@ namespace Tizen.WindowSystem
 {
     internal static class ErrorUtils
     {
-        private const int ErrorTzsh = -0x02860000;
-        private const int NoServiceError = ErrorTzsh | 0x01;
+        private const int NotConnectedError = -0x02000000 | 0xA000 | 0x01;
 
         internal static void ThrowIfError(int error, string message = null)
         {
@@ -50,13 +49,9 @@ namespace Tizen.WindowSystem
             {
                 throw new NotSupportedException("Not Supported");
             }
-            else if (error == (int)Tizen.Internals.Errors.ErrorCode.InvalidOperation)
+            else if (error == NotConnectedError)
             {
-                throw new InvalidOperationException("Invalid Operation");
-            }
-            else if (error == NoServiceError)
-            {
-                throw new InvalidOperationException("No Service");
+                throw new InvalidOperationException("Not Connected");
             }
             else
             {

--- a/src/Tizen.WindowSystem/src/InputGenerator.cs
+++ b/src/Tizen.WindowSystem/src/InputGenerator.cs
@@ -31,49 +31,64 @@ namespace Tizen.WindowSystem
     public class InputGenerator : IDisposable
     {
         private SafeHandles.InputGeneratorHandle _inputGeneratorHandle;
-        private bool disposed = false;
+        private TizenCoreWlDisplay _display;
+        private bool _disposed = false;
         private readonly InputGeneratorDevices _deviceType;
 
         /// <summary>
-        /// Creates a new InputGenerator with all device types.
+        /// Creates a new InputGenerator.
         /// </summary>
-        /// <param name="name">The name of the new input generator.</param>
-        /// <param name="sync">Whether to use synchronous initialization.</param>
-        /// <exception cref="ArgumentException"></exception>
-        public InputGenerator(string name = null, bool sync = false)
-            : this(InputGeneratorDevices.All, name, sync)
+        /// <param name="display">The TizenCoreWlDisplay instance.</param>
+        /// <param name="deviceType">The device types to initialize.</param>
+        /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when a argument is null.</exception>
+        public InputGenerator(TizenCoreWlDisplay display, InputGeneratorDevices deviceType)
+            : this(display, deviceType, null, false)
         {
         }
 
         /// <summary>
-        /// Creates a new InputGenerator with specified device types.
-        /// By specifying only the required device types instead of <see cref="InputGeneratorDevices.All"/>,
-        /// internal native resource overhead can be reduced.
+        /// Creates a new InputGenerator with a custom device name.
         /// </summary>
-        /// <remarks>
-        /// When a specific device type is specified, only methods corresponding to that device type can be called.
-        /// Calling a method that does not match the initialized device type will throw an <see cref="InvalidOperationException"/>.
-        /// For example, if initialized with <see cref="InputGeneratorDevices.Keyboard"/> only,
-        /// calling <see cref="SendPointer(int, PointerAction, int, int, InputGeneratorDevices)"/> will throw an exception.
-        /// </remarks>
-        /// <param name="deviceType">The device types to initialize. Only methods matching the specified device types can be used.</param>
-        /// <param name="name">The name of the new input generator.</param>
-        /// <param name="sync">Whether to use synchronous initialization.</param>
-        /// <exception cref="ArgumentException"></exception>
-        public InputGenerator(InputGeneratorDevices deviceType, string name = null, bool sync = false)
+        /// <param name="display">The TizenCoreWlDisplay instance.</param>
+        /// <param name="deviceType">The device types to initialize.</param>
+        /// <param name="name">The device name.</param>
+        /// <param name="sync">If true, creates synchronously.</param>
+        /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when a argument is null.</exception>
+        public InputGenerator(TizenCoreWlDisplay display, InputGeneratorDevices deviceType, string name, bool sync = false)
         {
+            if (display == null)
+            {
+                throw new ArgumentNullException(nameof(display));
+            }
+
+            if (display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new ArgumentException("The display is not initialized or has been disposed.", nameof(display));
+            }
+
             _deviceType = deviceType;
+            _display = display;
+            int ret;
+            IntPtr handle;
             if (sync)
             {
-                _inputGeneratorHandle = Interop.InputGenerator.SyncInit(deviceType, name);
+                ret = Interop.InputGenerator.CreateWithSync(display.GetNativeHandle(), deviceType, name, out handle);
             }
             else
             {
                 if (name == null)
-                    _inputGeneratorHandle = Interop.InputGenerator.Init(deviceType);
+                    ret = Interop.InputGenerator.Create(display.GetNativeHandle(), deviceType, out handle);
                 else
-                    _inputGeneratorHandle = Interop.InputGenerator.InitWithName(deviceType, name);
+                    ret = Interop.InputGenerator.CreateWithName(display.GetNativeHandle(), deviceType, name, out handle);
             }
+
+            if (ret != (int)Interop.InputGenerator.ErrorCode.None)
+            {
+                ErrorUtils.ThrowIfError(ret, "Failed to create InputGenerator");
+            }
+            _inputGeneratorHandle = new SafeHandles.InputGeneratorHandle(handle, true);
         }
 
         /// <summary>
@@ -93,14 +108,13 @@ namespace Tizen.WindowSystem
         /// <inheritdoc/>
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposed)
+            if (_disposed) return;
+
+            if (disposing)
             {
-                if (disposing)
-                {
-                    _inputGeneratorHandle?.Dispose();
-                }
-                disposed = true;
+                _inputGeneratorHandle?.Dispose();
             }
+            _disposed = true;
         }
 
         /// <summary>
@@ -111,9 +125,19 @@ namespace Tizen.WindowSystem
         /// <exception cref="InvalidOperationException">Thrown when the InputGenerator was not initialized with <see cref="InputGeneratorDevices.Keyboard"/>.</exception>
         public void SendKey(string keyName, bool isPressed)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(InputGenerator));
+            }
+
+            if (keyName == null)
+            {
+                throw new ArgumentNullException(nameof(keyName));
+            }
+
             EnsureDeviceSupported(InputGeneratorDevices.Keyboard);
-            Interop.InputGenerator.ErrorCode res = Interop.InputGenerator.GenerateKey(_inputGeneratorHandle, keyName, isPressed);
-            ErrorUtils.ThrowIfError((int)res, "Unknown Error");
+            int res = Interop.InputGenerator.GenerateKey(_inputGeneratorHandle, keyName, isPressed);
+            ErrorUtils.ThrowIfError(res, "Unknown Error");
         }
 
         /// <summary>
@@ -127,6 +151,11 @@ namespace Tizen.WindowSystem
         /// <exception cref="InvalidOperationException">Thrown when the InputGenerator was not initialized with the specified device type.</exception>
         public void SendPointer(int index, PointerAction action, int x, int y, InputGeneratorDevices device = InputGeneratorDevices.Pointer)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(InputGenerator));
+            }
+
             EnsureDeviceSupported(device);
             if (device == InputGeneratorDevices.Touchscreen)
             {
@@ -137,13 +166,13 @@ namespace Tizen.WindowSystem
                     case PointerAction.Up: touchAction = 3; break; // End
                     case PointerAction.Move: touchAction = 2; break; // Update
                 }
-                Interop.InputGenerator.ErrorCode res = Interop.InputGenerator.GenerateTouch(_inputGeneratorHandle, index, touchAction, x, y);
-                ErrorUtils.ThrowIfError((int)res, "Unknown Error");
+                int res = Interop.InputGenerator.GenerateTouch(_inputGeneratorHandle, index, touchAction, x, y);
+                ErrorUtils.ThrowIfError(res, "Unknown Error");
             }
             else
             {
-                Interop.InputGenerator.ErrorCode res = Interop.InputGenerator.GeneratePointer(_inputGeneratorHandle, index, (int)action, x, y);
-                ErrorUtils.ThrowIfError((int)res, "Unknown Error");
+                int res = Interop.InputGenerator.GeneratePointer(_inputGeneratorHandle, index, (int)action, x, y);
+                ErrorUtils.ThrowIfError(res, "Unknown Error");
             }
         }
 
@@ -155,9 +184,14 @@ namespace Tizen.WindowSystem
         /// <exception cref="InvalidOperationException">Thrown when the InputGenerator was not initialized with <see cref="InputGeneratorDevices.Pointer"/>.</exception>
         public void SendWheel(WheelDirection wheelType, int value)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(InputGenerator));
+            }
+
             EnsureDeviceSupported(InputGeneratorDevices.Pointer);
-            Interop.InputGenerator.ErrorCode res = Interop.InputGenerator.GenerateWheel(_inputGeneratorHandle, wheelType, value);
-            ErrorUtils.ThrowIfError((int)res, "Unknown Error");
+            int res = Interop.InputGenerator.GenerateWheel(_inputGeneratorHandle, wheelType, value);
+            ErrorUtils.ThrowIfError(res, "Unknown Error");
         }
 
         /// <summary>
@@ -175,6 +209,11 @@ namespace Tizen.WindowSystem
         /// <exception cref="InvalidOperationException">Thrown when the InputGenerator was not initialized with <see cref="InputGeneratorDevices.Touchscreen"/>.</exception>
         public void SendPointer(int index, PointerAction action, int x, int y, double radiusX, double radiusY, double pressure, double angle, double palm)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(InputGenerator));
+            }
+
             EnsureDeviceSupported(InputGeneratorDevices.Touchscreen);
             int touchAction = 0; // None
             switch (action)
@@ -184,8 +223,8 @@ namespace Tizen.WindowSystem
                 case PointerAction.Move: touchAction = 2; break; // Update
             }
 
-            Interop.InputGenerator.ErrorCode res = Interop.InputGenerator.GenerateTouchAxis(_inputGeneratorHandle, index, touchAction, x, y, radiusX, radiusY, pressure, angle, palm);
-            ErrorUtils.ThrowIfError((int)res, "Unknown Error");
+            int res = Interop.InputGenerator.GenerateTouchAxis(_inputGeneratorHandle, index, touchAction, x, y, radiusX, radiusY, pressure, angle, palm);
+            ErrorUtils.ThrowIfError(res, "Unknown Error");
         }
 
         /// <summary>

--- a/src/Tizen.WindowSystem/src/InputGesture.cs
+++ b/src/Tizen.WindowSystem/src/InputGesture.cs
@@ -35,8 +35,10 @@ namespace Tizen.WindowSystem
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class InputGesture : IDisposable
     {
-        SafeHandles.InputGestureHandle _handler;
-        bool disposed = false;
+        private SafeHandles.InputGestureHandle _handler;
+        private TizenCoreWlDisplay _display;
+        private bool _disposed = false;
+        private readonly int _creationThreadId;
 
         // Native handles keyed by gesture parameters
         private readonly Dictionary<(int fingers, GestureEdge edge), IntPtr> _edgeSwipeHandles = new Dictionary<(int, GestureEdge), IntPtr>();
@@ -59,23 +61,42 @@ namespace Tizen.WindowSystem
         /// <summary>
         /// Creates a new InputGesture.
         /// </summary>
-        /// <remarks>This module operates in a NUI application and requires instantiation and disposal on the main thread.</remarks>
+        /// <param name="display">The TizenCoreWlDisplay instance.</param>
         /// <exception cref="Tizen.Applications.Exceptions.OutOfMemoryException">Thrown when the memory is not enough to allocate.</exception>
         /// <exception cref="NotSupportedException">Thrown when the feature is not supported.</exception>
         /// <exception cref="Tizen.Applications.Exceptions.PermissionDeniedException">Thrown when the permission is denied.</exception>
-        public InputGesture()
+        public InputGesture(TizenCoreWlDisplay display)
         {
-            _handler = Interop.InputGesture.Initialize();
-            if (_handler.IsInvalid)
+            _creationThreadId = Environment.CurrentManagedThreadId;
+            if (display == null)
             {
-                int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();
-                ErrorUtils.ThrowIfError(err, "Failed to initialize InputGesture");
+                throw new ArgumentNullException(nameof(display));
             }
 
-            SetupNativeCallbacks();
+            if (display.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new ArgumentException("The display is not initialized or has been disposed.", nameof(display));
+            }
+
+            _display = display;
+            int ret = Interop.InputGesture.Create(display.GetNativeHandle(), out IntPtr handle);
+            if (ret != (int)Interop.InputGesture.ErrorCode.None)
+            {
+                ErrorUtils.ThrowIfError(ret, "Failed to create InputGesture");
+            }
+            _handler = new SafeHandles.InputGestureHandle(handle, true);
+
+            try
+            {
+                SetupNativeCallbacks();
+            }
+            catch
+            {
+                _handler.Dispose();
+                throw;
+            }
             Log.Debug(LogTag, "InputGesture Created");
         }
-
         /// <summary>
         /// Sets up native callbacks once during construction.
         /// These persist for the lifetime of the InputGesture instance.
@@ -88,8 +109,8 @@ namespace Tizen.WindowSystem
                 Log.Debug(LogTag, "EdgeSwipe Event received. mode: " + mode + ", fingers: " + fingers);
                 _edgeSwipeDetected?.Invoke(this, args);
             };
-            Interop.InputGesture.ErrorCode res = Interop.InputGesture.SetEdgeSwipeCb(_handler, _edgeSwipeDelegate, IntPtr.Zero);
-            ErrorUtils.ThrowIfError((int)res, "Failed to set edge swipe callback");
+            int res = Interop.InputGesture.SetEdgeSwipeCb(_handler, _edgeSwipeDelegate, IntPtr.Zero);
+            ErrorUtils.ThrowIfError(res, "Failed to set edge swipe callback");
 
             _edgeDragDelegate = (IntPtr userData, GestureState mode, int fingers, int cx, int cy, GestureEdge edge) =>
             {
@@ -98,7 +119,7 @@ namespace Tizen.WindowSystem
                 _edgeDragDetected?.Invoke(this, args);
             };
             res = Interop.InputGesture.SetEdgeDragCb(_handler, _edgeDragDelegate, IntPtr.Zero);
-            ErrorUtils.ThrowIfError((int)res, "Failed to set edge drag callback");
+            ErrorUtils.ThrowIfError(res, "Failed to set edge drag callback");
 
             _tapDelegate = (IntPtr userData, GestureState mode, int fingers, int repeats) =>
             {
@@ -107,7 +128,7 @@ namespace Tizen.WindowSystem
                 _tapDetected?.Invoke(this, args);
             };
             res = Interop.InputGesture.SetTapCb(_handler, _tapDelegate, IntPtr.Zero);
-            ErrorUtils.ThrowIfError((int)res, "Failed to set tap callback");
+            ErrorUtils.ThrowIfError(res, "Failed to set tap callback");
 
             _palmCoverDelegate = (IntPtr userData, GestureState mode, int duration, int cx, int cy, int size, double pressure) =>
             {
@@ -116,7 +137,7 @@ namespace Tizen.WindowSystem
                 _palmCoverDetected?.Invoke(this, args);
             };
             res = Interop.InputGesture.SetPalmCoverCb(_handler, _palmCoverDelegate, IntPtr.Zero);
-            ErrorUtils.ThrowIfError((int)res, "Failed to set palm cover callback");
+            ErrorUtils.ThrowIfError(res, "Failed to set palm cover callback");
         }
 
         /// <summary>
@@ -131,33 +152,39 @@ namespace Tizen.WindowSystem
         /// <inheritdoc/>
         protected virtual void Dispose(bool disposing)
         {
-            if (disposed) return;
-
-            // Free all native gesture handles
-            foreach (var kvp in _edgeSwipeHandles)
-                Interop.InputGesture.EdgeSwipeFree(_handler, kvp.Value);
-            _edgeSwipeHandles.Clear();
-
-            foreach (var kvp in _edgeDragHandles)
-                Interop.InputGesture.EdgeDragFree(_handler, kvp.Value);
-            _edgeDragHandles.Clear();
-
-            foreach (var kvp in _tapHandles)
-                Interop.InputGesture.TapFree(_handler, kvp.Value);
-            _tapHandles.Clear();
-
-            if (_palmCoverHandle != IntPtr.Zero)
-            {
-                Interop.InputGesture.PalmCoverFree(_handler, _palmCoverHandle);
-                _palmCoverHandle = IntPtr.Zero;
-            }
+            if (_disposed) return;
 
             if (disposing)
             {
+                if (Environment.CurrentManagedThreadId != _creationThreadId)
+                {
+                    Log.Error(LogTag, "InputGesture: Dispose called from a different thread. Wayland resource destruction is thread-affine and must be done on the creation thread. Skipping cleanup to avoid crash.");
+                    return;
+                }
+
+                // Free all native gesture handles
+                foreach (var kvp in _edgeSwipeHandles)
+                    Interop.InputGesture.EdgeSwipeFree(_handler, kvp.Value);
+                _edgeSwipeHandles.Clear();
+
+                foreach (var kvp in _edgeDragHandles)
+                    Interop.InputGesture.EdgeDragFree(_handler, kvp.Value);
+                _edgeDragHandles.Clear();
+
+                foreach (var kvp in _tapHandles)
+                    Interop.InputGesture.TapFree(_handler, kvp.Value);
+                _tapHandles.Clear();
+
+                if (_palmCoverHandle != IntPtr.Zero)
+                {
+                    Interop.InputGesture.PalmCoverFree(_handler, _palmCoverHandle);
+                    _palmCoverHandle = IntPtr.Zero;
+                }
+
                 _handler?.Dispose();
             }
 
-            disposed = true;
+            _disposed = true;
         }
 
         /// <summary>
@@ -217,42 +244,62 @@ namespace Tizen.WindowSystem
         /// <exception cref="Tizen.Applications.Exceptions.OutOfMemoryException">Thrown when the memory is not enough to allocate.</exception>
         public void RegisterEdgeSwipe(int fingers, GestureEdge edge, GestureEdgeSize? edgeSize = null, int startPoint = 0, int endPoint = 0, GestureGrabMode? grabMode = null)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(InputGesture));
+            }
+            if (Environment.CurrentManagedThreadId != _creationThreadId)
+            {
+                throw new InvalidOperationException("This method must be called on the creation thread.");
+            }
             var key = (fingers, edge);
+            if (fingers <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(fingers), "Fingers must be greater than zero.");
+            }
+            if (startPoint < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startPoint), "Start point must be non-negative.");
+            }
+            if (endPoint < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(endPoint), "End point must be non-negative.");
+            }
+
             if (_edgeSwipeHandles.ContainsKey(key))
                 throw new ArgumentException("Edge swipe gesture already registered for this (fingers, edge) combination.");
 
-            IntPtr handle = Interop.InputGesture.EdgeSwipeNew(_handler, fingers, edge);
-            if (handle == IntPtr.Zero)
+            int ret = Interop.InputGesture.EdgeSwipeNew(_handler, (uint)fingers, edge, out IntPtr handle);
+            if (ret != (int)Interop.InputGesture.ErrorCode.None)
             {
-                int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();
-                ErrorUtils.ThrowIfError(err, "Failed to create edge swipe gesture");
+                ErrorUtils.ThrowIfError(ret, "Failed to create edge swipe gesture");
             }
 
             if (edgeSize.HasValue)
             {
-                var res = Interop.InputGesture.EdgeSwipeSizeSet(handle, edgeSize.Value, startPoint, endPoint);
-                if (res != Interop.InputGesture.ErrorCode.None)
+                var res = Interop.InputGesture.EdgeSwipeSizeSet(handle, edgeSize.Value, (uint)startPoint, (uint)endPoint);
+                if (res != (int)Interop.InputGesture.ErrorCode.None)
                 {
                     Interop.InputGesture.EdgeSwipeFree(_handler, handle);
-                    ErrorUtils.ThrowIfError((int)res, "Failed to set edge swipe size");
+                    ErrorUtils.ThrowIfError(res, "Failed to set edge swipe size");
                 }
             }
 
             if (grabMode.HasValue)
             {
                 var res = Interop.InputGesture.SetGestureGrabMode(_handler, handle, grabMode.Value);
-                if (res != Interop.InputGesture.ErrorCode.None)
+                if (res != (int)Interop.InputGesture.ErrorCode.None)
                 {
                     Interop.InputGesture.EdgeSwipeFree(_handler, handle);
-                    ErrorUtils.ThrowIfError((int)res, "Failed to set grab mode");
+                    ErrorUtils.ThrowIfError(res, "Failed to set grab mode");
                 }
             }
 
             var grabRes = Interop.InputGesture.GestureGrab(_handler, handle);
-            if (grabRes != Interop.InputGesture.ErrorCode.None)
+            if (grabRes != (int)Interop.InputGesture.ErrorCode.None)
             {
                 Interop.InputGesture.EdgeSwipeFree(_handler, handle);
-                ErrorUtils.ThrowIfError((int)grabRes, "Failed to grab edge swipe gesture");
+                ErrorUtils.ThrowIfError(grabRes, "Failed to grab edge swipe gesture");
             }
 
             _edgeSwipeHandles[key] = handle;
@@ -288,42 +335,62 @@ namespace Tizen.WindowSystem
         /// <exception cref="Tizen.Applications.Exceptions.OutOfMemoryException">Thrown when the memory is not enough to allocate.</exception>
         public void RegisterEdgeDrag(int fingers, GestureEdge edge, GestureEdgeSize? edgeSize = null, int startPoint = 0, int endPoint = 0, GestureGrabMode? grabMode = null)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(InputGesture));
+            }
+            if (Environment.CurrentManagedThreadId != _creationThreadId)
+            {
+                throw new InvalidOperationException("This method must be called on the creation thread.");
+            }
             var key = (fingers, edge);
+            if (fingers <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(fingers), "Fingers must be greater than zero.");
+            }
+            if (startPoint < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startPoint), "Start point must be non-negative.");
+            }
+            if (endPoint < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(endPoint), "End point must be non-negative.");
+            }
+
             if (_edgeDragHandles.ContainsKey(key))
                 throw new ArgumentException("Edge drag gesture already registered for this (fingers, edge) combination.");
 
-            IntPtr handle = Interop.InputGesture.EdgeDragNew(_handler, fingers, edge);
-            if (handle == IntPtr.Zero)
+            int ret = Interop.InputGesture.EdgeDragNew(_handler, (uint)fingers, edge, out IntPtr handle);
+            if (ret != (int)Interop.InputGesture.ErrorCode.None)
             {
-                int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();
-                ErrorUtils.ThrowIfError(err, "Failed to create edge drag gesture");
+                ErrorUtils.ThrowIfError(ret, "Failed to create edge drag gesture");
             }
 
             if (edgeSize.HasValue)
             {
-                var res = Interop.InputGesture.EdgeDragSizeSet(handle, edgeSize.Value, startPoint, endPoint);
-                if (res != Interop.InputGesture.ErrorCode.None)
+                var res = Interop.InputGesture.EdgeDragSizeSet(handle, edgeSize.Value, (uint)startPoint, (uint)endPoint);
+                if (res != (int)Interop.InputGesture.ErrorCode.None)
                 {
                     Interop.InputGesture.EdgeDragFree(_handler, handle);
-                    ErrorUtils.ThrowIfError((int)res, "Failed to set edge drag size");
+                    ErrorUtils.ThrowIfError(res, "Failed to set edge drag size");
                 }
             }
 
             if (grabMode.HasValue)
             {
                 var res = Interop.InputGesture.SetGestureGrabMode(_handler, handle, grabMode.Value);
-                if (res != Interop.InputGesture.ErrorCode.None)
+                if (res != (int)Interop.InputGesture.ErrorCode.None)
                 {
                     Interop.InputGesture.EdgeDragFree(_handler, handle);
-                    ErrorUtils.ThrowIfError((int)res, "Failed to set grab mode");
+                    ErrorUtils.ThrowIfError(res, "Failed to set grab mode");
                 }
             }
 
             var grabRes = Interop.InputGesture.GestureGrab(_handler, handle);
-            if (grabRes != Interop.InputGesture.ErrorCode.None)
+            if (grabRes != (int)Interop.InputGesture.ErrorCode.None)
             {
                 Interop.InputGesture.EdgeDragFree(_handler, handle);
-                ErrorUtils.ThrowIfError((int)grabRes, "Failed to grab edge drag gesture");
+                ErrorUtils.ThrowIfError(grabRes, "Failed to grab edge drag gesture");
             }
 
             _edgeDragHandles[key] = handle;
@@ -356,32 +423,48 @@ namespace Tizen.WindowSystem
         /// <exception cref="Tizen.Applications.Exceptions.OutOfMemoryException">Thrown when the memory is not enough to allocate.</exception>
         public void RegisterTap(int fingers, int repeats, GestureGrabMode? grabMode = null)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(InputGesture));
+            }
+            if (Environment.CurrentManagedThreadId != _creationThreadId)
+            {
+                throw new InvalidOperationException("This method must be called on the creation thread.");
+            }
             var key = (fingers, repeats);
+            if (fingers <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(fingers), "Fingers must be greater than zero.");
+            }
+            if (repeats <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(repeats), "Repeats must be greater than zero.");
+            }
+
             if (_tapHandles.ContainsKey(key))
                 throw new ArgumentException("Tap gesture already registered for this (fingers, repeats) combination.");
 
-            IntPtr handle = Interop.InputGesture.TapNew(_handler, fingers, repeats);
-            if (handle == IntPtr.Zero)
+            int ret = Interop.InputGesture.TapNew(_handler, (uint)fingers, (uint)repeats, out IntPtr handle);
+            if (ret != (int)Interop.InputGesture.ErrorCode.None)
             {
-                int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();
-                ErrorUtils.ThrowIfError(err, "Failed to create tap gesture");
+                ErrorUtils.ThrowIfError(ret, "Failed to create tap gesture");
             }
 
             if (grabMode.HasValue)
             {
                 var res = Interop.InputGesture.SetGestureGrabMode(_handler, handle, grabMode.Value);
-                if (res != Interop.InputGesture.ErrorCode.None)
+                if (res != (int)Interop.InputGesture.ErrorCode.None)
                 {
                     Interop.InputGesture.TapFree(_handler, handle);
-                    ErrorUtils.ThrowIfError((int)res, "Failed to set grab mode");
+                    ErrorUtils.ThrowIfError(res, "Failed to set grab mode");
                 }
             }
 
             var grabRes = Interop.InputGesture.GestureGrab(_handler, handle);
-            if (grabRes != Interop.InputGesture.ErrorCode.None)
+            if (grabRes != (int)Interop.InputGesture.ErrorCode.None)
             {
                 Interop.InputGesture.TapFree(_handler, handle);
-                ErrorUtils.ThrowIfError((int)grabRes, "Failed to grab tap gesture");
+                ErrorUtils.ThrowIfError(grabRes, "Failed to grab tap gesture");
             }
 
             _tapHandles[key] = handle;
@@ -412,31 +495,38 @@ namespace Tizen.WindowSystem
         /// <exception cref="Tizen.Applications.Exceptions.OutOfMemoryException">Thrown when the memory is not enough to allocate.</exception>
         public void RegisterPalmCover(GestureGrabMode? grabMode = null)
         {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(InputGesture));
+            }
+            if (Environment.CurrentManagedThreadId != _creationThreadId)
+            {
+                throw new InvalidOperationException("This method must be called on the creation thread.");
+            }
             if (_palmCoverHandle != IntPtr.Zero)
                 throw new ArgumentException("Palm cover gesture already registered.");
 
-            IntPtr handle = Interop.InputGesture.PalmCoverNew(_handler);
-            if (handle == IntPtr.Zero)
+            int ret = Interop.InputGesture.PalmCoverNew(_handler, out IntPtr handle);
+            if (ret != (int)Interop.InputGesture.ErrorCode.None)
             {
-                int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();
-                ErrorUtils.ThrowIfError(err, "Failed to create palm cover gesture");
+                ErrorUtils.ThrowIfError(ret, "Failed to create palm cover gesture");
             }
 
             if (grabMode.HasValue)
             {
                 var res = Interop.InputGesture.SetGestureGrabMode(_handler, handle, grabMode.Value);
-                if (res != Interop.InputGesture.ErrorCode.None)
+                if (res != (int)Interop.InputGesture.ErrorCode.None)
                 {
                     Interop.InputGesture.PalmCoverFree(_handler, handle);
-                    ErrorUtils.ThrowIfError((int)res, "Failed to set grab mode");
+                    ErrorUtils.ThrowIfError(res, "Failed to set grab mode");
                 }
             }
 
             var grabRes = Interop.InputGesture.GestureGrab(_handler, handle);
-            if (grabRes != Interop.InputGesture.ErrorCode.None)
+            if (grabRes != (int)Interop.InputGesture.ErrorCode.None)
             {
                 Interop.InputGesture.PalmCoverFree(_handler, handle);
-                ErrorUtils.ThrowIfError((int)grabRes, "Failed to grab palm cover gesture");
+                ErrorUtils.ThrowIfError(grabRes, "Failed to grab palm cover gesture");
             }
 
             _palmCoverHandle = handle;

--- a/src/Tizen.WindowSystem/src/Interop/Interop.InputGenerator.cs
+++ b/src/Tizen.WindowSystem/src/Interop/Interop.InputGenerator.cs
@@ -1,6 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Runtime.InteropServices;
 
 namespace Tizen.WindowSystem
 {
@@ -8,46 +7,43 @@ namespace Tizen.WindowSystem
     {
         internal static partial class InputGenerator
         {
-            const string lib = "libcapi-ui-efl-util.so.0";
+            const string lib = "libtizen-core-wl.so.0";
 
-            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "efl_util_input_initialize_generator")]
-            internal static extern SafeHandles.InputGeneratorHandle Init(InputGeneratorDevices devType);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_input_generator_create")]
+            internal static extern int Create(IntPtr display, InputGeneratorDevices devType, out IntPtr generator);
 
-            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "efl_util_input_initialize_generator_with_name")]
-            internal static extern SafeHandles.InputGeneratorHandle InitWithName(InputGeneratorDevices devType, string devName);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_input_generator_create_with_name")]
+            internal static extern int CreateWithName(IntPtr display, InputGeneratorDevices devType, string devName, out IntPtr generator);
 
-            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "efl_util_input_initialize_generator_with_sync")]
-            internal static extern SafeHandles.InputGeneratorHandle SyncInit(InputGeneratorDevices devType, string devName);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_input_generator_create_with_sync")]
+            internal static extern int CreateWithSync(IntPtr display, InputGeneratorDevices devType, string devName, out IntPtr generator);
 
-            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "efl_util_input_deinitialize_generator")]
-            internal static extern ErrorCode Deinit(IntPtr inputGenHandler);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_input_generator_destroy")]
+            internal static extern int Destroy(IntPtr generator);
 
-            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "efl_util_input_generate_key")]
-            internal static extern ErrorCode GenerateKey(SafeHandles.InputGeneratorHandle inputGenHandler, string keyName, bool isPressed);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_input_generator_generate_key")]
+            internal static extern int GenerateKey(SafeHandles.InputGeneratorHandle generator, string keyName, [MarshalAs(UnmanagedType.I1)] bool pressed);
 
-            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "efl_util_input_generate_pointer")]
-            internal static extern ErrorCode GeneratePointer(SafeHandles.InputGeneratorHandle inputGenHandler, int buttons, int pointerType, int x, int y);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_input_generator_generate_pointer")]
+            internal static extern int GeneratePointer(SafeHandles.InputGeneratorHandle generator, int buttons, int pointerType, int x, int y);
 
-            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "efl_util_input_generate_wheel")]
-            internal static extern ErrorCode GenerateWheel(SafeHandles.InputGeneratorHandle inputGenHandler, WheelDirection wheelType, int value);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_input_generator_generate_wheel")]
+            internal static extern int GenerateWheel(SafeHandles.InputGeneratorHandle generator, WheelDirection wheelType, int value);
 
-            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "efl_util_input_generate_touch")]
-            internal static extern ErrorCode GenerateTouch(SafeHandles.InputGeneratorHandle inputGenHandler, int idx, int touchType, int x, int y);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_input_generator_generate_touch")]
+            internal static extern int GenerateTouch(SafeHandles.InputGeneratorHandle generator, int idx, int touchType, int x, int y);
 
-            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "efl_util_input_generate_touch_axis")]
-            internal static extern ErrorCode GenerateTouchAxis(SafeHandles.InputGeneratorHandle inputGenHandler, int idx, int touchType, int x, int y, double radius_x, double radius_y, double pressure, double angle, double palm);
-
-            private const int ErrorTzsh = -0x02860000;
+            [DllImport(lib, EntryPoint = "tizen_core_wl_input_generator_generate_touch_with_axis")]
+            internal static extern int GenerateTouchAxis(SafeHandles.InputGeneratorHandle generator, int idx, int touchType, int x, int y, double radius_x, double radius_y, double pressure, double angle, double palm);
 
             internal enum ErrorCode
             {
                 None = Tizen.Internals.Errors.ErrorCode.None,                            // Successful
                 OutOfMemory = Tizen.Internals.Errors.ErrorCode.OutOfMemory,              // Out of memory
                 InvalidParameter = Tizen.Internals.Errors.ErrorCode.InvalidParameter,    // Invalid parameter
-                InvalidOperation = Tizen.Internals.Errors.ErrorCode.InvalidOperation,    // Invalid operation
-                PermissionDenied = Tizen.Internals.Errors.ErrorCode.PermissionDenied,    // Permission denied
                 NotSupported = Tizen.Internals.Errors.ErrorCode.NotSupported,            // NOT supported
-                NoService = ErrorTzsh | 0x01,                                            // Service does not exist
+                PermissionDenied = Tizen.Internals.Errors.ErrorCode.PermissionDenied,    // Permission denied
+                NotConnected = -0x02000000 | 0xA000 | 0x01,                              // No connection to display server
             }
         }
     }

--- a/src/Tizen.WindowSystem/src/Interop/Interop.InputGesture.cs
+++ b/src/Tizen.WindowSystem/src/Interop/Interop.InputGesture.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Runtime.InteropServices;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Tizen.WindowSystem
 {
@@ -9,87 +7,87 @@ namespace Tizen.WindowSystem
     {
         internal static class InputGesture
         {
-            const string lib = "libcapi-ui-efl-util.so.0";
+            const string lib = "libtizen-core-wl.so.0";
 
-            internal static string LogTag = "Tizen.NUI.WindowSystem";
+            internal static string LogTag = "Tizen.WindowSystem";
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_initialize")]
-            internal static extern SafeHandles.InputGestureHandle Initialize();
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_create")]
+            internal static extern int Create(IntPtr display, out IntPtr gesture);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_deinitialize")]
-            internal static extern ErrorCode Deinitialize(IntPtr gestureHandler);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_destroy")]
+            internal static extern int Destroy(IntPtr gesture);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_edge_swipe_new")]
-            internal static extern IntPtr EdgeSwipeNew(SafeHandles.InputGestureHandle gestureHandler, int fingers, GestureEdge edge);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_edge_swipe_new")]
+            internal static extern int EdgeSwipeNew(SafeHandles.InputGestureHandle gesture, uint fingers, GestureEdge edge, out IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_edge_swipe_free")]
-            internal static extern ErrorCode EdgeSwipeFree(SafeHandles.InputGestureHandle gestureHandler, IntPtr gestureData);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_edge_swipe_free")]
+            internal static extern int EdgeSwipeFree(SafeHandles.InputGestureHandle gesture, IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_edge_swipe_size_set")]
-            internal static extern ErrorCode EdgeSwipeSizeSet(IntPtr gestureData, GestureEdgeSize edgeSize, int startPoint, int endPoint);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_edge_swipe_size_set")]
+            internal static extern int EdgeSwipeSizeSet(IntPtr data, GestureEdgeSize edgeSize, uint startPoint, uint endPoint);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_edge_drag_new")]
-            internal static extern IntPtr EdgeDragNew(SafeHandles.InputGestureHandle gestureHandler, int fingers, GestureEdge edge);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_edge_drag_new")]
+            internal static extern int EdgeDragNew(SafeHandles.InputGestureHandle gesture, uint fingers, GestureEdge edge, out IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_edge_drag_free")]
-            internal static extern ErrorCode EdgeDragFree(SafeHandles.InputGestureHandle gestureHandler, IntPtr gestureData);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_edge_drag_free")]
+            internal static extern int EdgeDragFree(SafeHandles.InputGestureHandle gesture, IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_edge_drag_size_set")]
-            internal static extern ErrorCode EdgeDragSizeSet(IntPtr gestureData, GestureEdgeSize edgeSize, int startPoint, int endPoint);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_edge_drag_size_set")]
+            internal static extern int EdgeDragSizeSet(IntPtr data, GestureEdgeSize edgeSize, uint startPoint, uint endPoint);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_tap_new")]
-            internal static extern IntPtr TapNew(SafeHandles.InputGestureHandle gestureHandler, int fingers, int repeats);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_tap_new")]
+            internal static extern int TapNew(SafeHandles.InputGestureHandle gesture, uint fingers, uint repeats, out IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_tap_free")]
-            internal static extern ErrorCode TapFree(SafeHandles.InputGestureHandle gestureHandler, IntPtr gestureData);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_tap_free")]
+            internal static extern int TapFree(SafeHandles.InputGestureHandle gesture, IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_palm_cover_new")]
-            internal static extern IntPtr PalmCoverNew(SafeHandles.InputGestureHandle gestureHandler);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_palm_cover_new")]
+            internal static extern int PalmCoverNew(SafeHandles.InputGestureHandle gesture, out IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_palm_cover_free")]
-            internal static extern ErrorCode PalmCoverFree(SafeHandles.InputGestureHandle gestureHandler, IntPtr gestureData);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_palm_cover_free")]
+            internal static extern int PalmCoverFree(SafeHandles.InputGestureHandle gesture, IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_grab")]
-            internal static extern ErrorCode GestureGrab(SafeHandles.InputGestureHandle gestureHandler, IntPtr gestureData);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_grab")]
+            internal static extern int GestureGrab(SafeHandles.InputGestureHandle gesture, IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_grab_mode_set")]
-            internal static extern ErrorCode SetGestureGrabMode(SafeHandles.InputGestureHandle gestureHandler, IntPtr gestureData, GestureGrabMode mode);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_grab_mode_set")]
+            internal static extern int SetGestureGrabMode(SafeHandles.InputGestureHandle gesture, IntPtr data, GestureGrabMode mode);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_ungrab")]
-            internal static extern ErrorCode GestureUngrab(SafeHandles.InputGestureHandle gestureHandler, IntPtr gestureData);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_ungrab")]
+            internal static extern int GestureUngrab(SafeHandles.InputGestureHandle gesture, IntPtr data);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_edge_swipe_cb_set")]
-            internal static extern ErrorCode SetEdgeSwipeCb(SafeHandles.InputGestureHandle gestureHandler, EdgeSwipeCb cbFunc, IntPtr usergestureData);
-
-            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-            internal delegate void EdgeSwipeCb(IntPtr usergestureData, GestureState mode, int fingers, int sx, int sy, GestureEdge edge);
-
-            [DllImport(lib, EntryPoint = "efl_util_gesture_edge_drag_cb_set")]
-            internal static extern ErrorCode SetEdgeDragCb(SafeHandles.InputGestureHandle gestureHandler, EdgeDragCb cbFunc, IntPtr usergestureData);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_edge_swipe_cb_set")]
+            internal static extern int SetEdgeSwipeCb(SafeHandles.InputGestureHandle gesture, EdgeSwipeCb cbFunc, IntPtr userData);
 
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-            internal delegate void EdgeDragCb(IntPtr usergestureData, GestureState mode, int fingers, int cx, int cy, GestureEdge edge);
+            internal delegate void EdgeSwipeCb(IntPtr userData, GestureState mode, int fingers, int sx, int sy, GestureEdge edge);
 
-            [DllImport(lib, EntryPoint = "efl_util_gesture_tap_cb_set")]
-            internal static extern ErrorCode SetTapCb(SafeHandles.InputGestureHandle gestureHandler, TapCb cbFunc, IntPtr usergestureData);
-
-            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-            internal delegate void TapCb(IntPtr usergestureData, GestureState mode, int fingers, int repeats);
-
-            [DllImport(lib, EntryPoint = "efl_util_gesture_palm_cover_cb_set")]
-            internal static extern ErrorCode SetPalmCoverCb(SafeHandles.InputGestureHandle gestureHandler, PalmCoverCb cbFunc, IntPtr usergestureData);
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_edge_drag_cb_set")]
+            internal static extern int SetEdgeDragCb(SafeHandles.InputGestureHandle gesture, EdgeDragCb cbFunc, IntPtr userData);
 
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-            internal delegate void PalmCoverCb(IntPtr usergestureData, GestureState mode, int duration, int cx, int cy, int size, double pressure);
+            internal delegate void EdgeDragCb(IntPtr userData, GestureState mode, int fingers, int cx, int cy, GestureEdge edge);
+
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_tap_cb_set")]
+            internal static extern int SetTapCb(SafeHandles.InputGestureHandle gesture, TapCb cbFunc, IntPtr userData);
+
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            internal delegate void TapCb(IntPtr userData, GestureState mode, int fingers, int repeats);
+
+            [DllImport(lib, EntryPoint = "tizen_core_wl_gesture_palm_cover_cb_set")]
+            internal static extern int SetPalmCoverCb(SafeHandles.InputGestureHandle gesture, PalmCoverCb cbFunc, IntPtr userData);
+
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            internal delegate void PalmCoverCb(IntPtr userData, GestureState mode, int duration, int cx, int cy, int size, double pressure);
 
             internal enum ErrorCode
             {
                 None = Tizen.Internals.Errors.ErrorCode.None,                            // Successful
                 OutOfMemory = Tizen.Internals.Errors.ErrorCode.OutOfMemory,              // Out of memory
                 InvalidParameter = Tizen.Internals.Errors.ErrorCode.InvalidParameter,    // Invalid parameter
-                InvalidOperation = Tizen.Internals.Errors.ErrorCode.InvalidOperation,    // Invalid operation
-                PermissionDenied = Tizen.Internals.Errors.ErrorCode.PermissionDenied,    // Permission denied
                 NotSupported = Tizen.Internals.Errors.ErrorCode.NotSupported,            // NOT supported
+                PermissionDenied = Tizen.Internals.Errors.ErrorCode.PermissionDenied,    // Permission denied
+                NotConnected = -0x02000000 | 0xA000 | 0x01,                              // No connection to display server
             };
         }
     }

--- a/src/Tizen.WindowSystem/src/Interop/Interop.TizenCoreWl.cs
+++ b/src/Tizen.WindowSystem/src/Interop/Interop.TizenCoreWl.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Tizen.WindowSystem
+{
+    internal static partial class Interop
+    {
+        internal static partial class TizenCoreWl
+        {
+            const string lib = "libtizen-core-wl.so.0";
+
+            [DllImport(lib, EntryPoint = "tizen_core_wl_init")]
+            internal static extern int Init();
+
+            [DllImport(lib, EntryPoint = "tizen_core_wl_shutdown")]
+            internal static extern int Shutdown();
+
+            [DllImport(lib, EntryPoint = "tizen_core_wl_display_create")]
+            internal static extern int DisplayCreate(out IntPtr display);
+
+            [DllImport(lib, EntryPoint = "tizen_core_wl_display_connect")]
+            internal static extern int DisplayConnect(IntPtr display, string name);
+
+            [DllImport(lib, EntryPoint = "tizen_core_wl_display_disconnect")]
+            internal static extern int DisplayDisconnect(IntPtr display);
+
+            [DllImport(lib, EntryPoint = "tizen_core_wl_display_destroy")]
+            internal static extern int DisplayDestroy(IntPtr display);
+
+            internal enum ErrorCode
+            {
+                None = Tizen.Internals.Errors.ErrorCode.None,
+                InvalidParameter = Tizen.Internals.Errors.ErrorCode.InvalidParameter,
+                OutOfMemory = Tizen.Internals.Errors.ErrorCode.OutOfMemory,
+                NotSupported = Tizen.Internals.Errors.ErrorCode.NotSupported,
+                PermissionDenied = Tizen.Internals.Errors.ErrorCode.PermissionDenied,
+                NotConnected = -0x02000000 | 0xA000 | 0x01,
+                NoResourceAvailable = -0x02000000 | 0xA000 | 0x02,
+            }
+        }
+    }
+}

--- a/src/Tizen.WindowSystem/src/SafeHandles/InputGeneratorHandle.cs
+++ b/src/Tizen.WindowSystem/src/SafeHandles/InputGeneratorHandle.cs
@@ -8,20 +8,29 @@ namespace Tizen.WindowSystem.SafeHandles
 {
     internal sealed class InputGeneratorHandle : SafeHandle
     {
+        private readonly int _creationThreadId;
+
         public InputGeneratorHandle() : base(IntPtr.Zero, true)
         {
+            _creationThreadId = Environment.CurrentManagedThreadId;
         }
 
         public InputGeneratorHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
         {
             SetHandle(handle);
+            _creationThreadId = Environment.CurrentManagedThreadId;
         }
 
         public override bool IsInvalid => handle == IntPtr.Zero;
 
         protected override bool ReleaseHandle()
         {
-            Tizen.WindowSystem.Interop.InputGenerator.Deinit(handle);
+            if (Environment.CurrentManagedThreadId != _creationThreadId)
+            {
+                Tizen.Log.Error("Tizen.WindowSystem", "InputGeneratorHandle: ReleaseHandle called from a different thread or finalizer. Wayland resource destruction is thread-affine and must be done on the creation thread. Skipping cleanup to avoid crash.");
+                return true;
+            }
+            Tizen.WindowSystem.Interop.InputGenerator.Destroy(handle);
             return true;
         }
     }

--- a/src/Tizen.WindowSystem/src/SafeHandles/InputGestureHandle.cs
+++ b/src/Tizen.WindowSystem/src/SafeHandles/InputGestureHandle.cs
@@ -8,20 +8,29 @@ namespace Tizen.WindowSystem.SafeHandles
 {
     internal sealed class InputGestureHandle : SafeHandle
     {
+        private readonly int _creationThreadId;
+
         public InputGestureHandle() : base(IntPtr.Zero, true)
         {
+            _creationThreadId = Environment.CurrentManagedThreadId;
         }
 
         public InputGestureHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
         {
             SetHandle(handle);
+            _creationThreadId = Environment.CurrentManagedThreadId;
         }
 
         public override bool IsInvalid => handle == IntPtr.Zero;
 
         protected override bool ReleaseHandle()
         {
-            Tizen.WindowSystem.Interop.InputGesture.Deinitialize(handle);
+            if (Environment.CurrentManagedThreadId != _creationThreadId)
+            {
+                Tizen.Log.Error("Tizen.WindowSystem", "InputGestureHandle: ReleaseHandle called from a different thread or finalizer. Wayland resource destruction is thread-affine and must be done on the creation thread. Skipping cleanup to avoid crash.");
+                return true;
+            }
+            Tizen.WindowSystem.Interop.InputGesture.Destroy(handle);
             return true;
         }
     }

--- a/src/Tizen.WindowSystem/src/TizenCoreWlDisplay.cs
+++ b/src/Tizen.WindowSystem/src/TizenCoreWlDisplay.cs
@@ -1,0 +1,160 @@
+/*
+ * Copyright(c) 2026 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+
+namespace Tizen.WindowSystem
+{
+    /// <summary>
+    /// Class for the Tizen Core Wayland Display.
+    /// </summary>
+    /// This class is need to be hidden as inhouse API.
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class TizenCoreWlDisplay : IDisposable
+    {
+        private IntPtr _display;
+        private bool _disposed = false;
+        private bool _connected = false;
+        private readonly int _creationThreadId;
+        private readonly object _instanceLock = new object();
+
+        /// <summary>
+        /// Creates a new TizenCoreWlDisplay.
+        /// </summary>
+        /// <exception cref="Tizen.Applications.Exceptions.OutOfMemoryException">Thrown when the memory is not enough to allocate.</exception>
+        /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
+        public TizenCoreWlDisplay()
+        {
+            _creationThreadId = Environment.CurrentManagedThreadId;
+            Tizen.Log.Debug("TIZEN_CORE_WL", "TizenCoreWlDisplay: calling tizen_core_wl_init()");
+            int initRet = Interop.TizenCoreWl.Init();
+            if (initRet != (int)Interop.TizenCoreWl.ErrorCode.None)
+            {
+                Tizen.Log.Error("TIZEN_CORE_WL", $"TizenCoreWlDisplay: tizen_core_wl_init() failed with error={initRet}");
+                GC.SuppressFinalize(this);
+                ErrorUtils.ThrowIfError(initRet, "Failed to initialize Tizen Core Wayland");
+            }
+
+            int ret = Interop.TizenCoreWl.DisplayCreate(out _display);
+            if (ret != (int)Interop.TizenCoreWl.ErrorCode.None)
+            {
+                Tizen.Log.Error("TIZEN_CORE_WL", $"TizenCoreWlDisplay: DisplayCreate() failed with error={ret}");
+                Interop.TizenCoreWl.Shutdown();
+                GC.SuppressFinalize(this);
+                ErrorUtils.ThrowIfError(ret, "Failed to create display");
+            }
+            Tizen.Log.Debug("TIZEN_CORE_WL", $"TizenCoreWlDisplay: DisplayCreate() succeeded, handle=0x{_display:X}");
+        }
+
+        /// <summary>
+        /// Connects to the Wayland display server.
+        /// </summary>
+        /// <param name="name">The name of the display to connect to, or null for the default display.</param>
+        /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed to connect.</exception>
+        /// <exception cref="ObjectDisposedException">Thrown when the instance is already disposed.</exception>
+        public void Connect(string name = null)
+        {
+            lock (_instanceLock)
+            {
+                if (_disposed)
+                {
+                    throw new ObjectDisposedException(nameof(TizenCoreWlDisplay));
+                }
+
+                if (Environment.CurrentManagedThreadId != _creationThreadId)
+                {
+                    throw new InvalidOperationException("Connect must be called on the creation thread.");
+                }
+
+                if (_connected)
+                {
+                    throw new InvalidOperationException("Already connected to the display server.");
+                }
+
+                Tizen.Log.Debug("TIZEN_CORE_WL", $"TizenCoreWlDisplay: Connect(name={name ?? "null"}) called");
+                int ret = Interop.TizenCoreWl.DisplayConnect(_display, name);
+                if (ret != (int)Interop.TizenCoreWl.ErrorCode.None)
+                {
+                    Tizen.Log.Error("TIZEN_CORE_WL", $"TizenCoreWlDisplay: DisplayConnect() failed with error={ret}");
+                    ErrorUtils.ThrowIfError(ret, "Failed to connect display");
+                }
+                _connected = true;
+                Tizen.Log.Debug("TIZEN_CORE_WL", "TizenCoreWlDisplay: DisplayConnect() succeeded");
+            }
+        }
+
+        /// <summary>
+        /// Finalizes an instance of the <see cref="TizenCoreWlDisplay"/> class.
+        /// </summary>
+        ~TizenCoreWlDisplay()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <inheritdoc/>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (Environment.CurrentManagedThreadId != _creationThreadId)
+            {
+                Tizen.Log.Error("TIZEN_CORE_WL", "TizenCoreWlDisplay: Dispose called from a different thread or finalizer. Wayland display destruction is thread-affine and must be done on the creation thread. Skipping cleanup to avoid crash.");
+                return;
+            }
+
+            lock (_instanceLock)
+            {
+                if (_display != IntPtr.Zero)
+                {
+                    Tizen.Log.Debug("TIZEN_CORE_WL", "TizenCoreWlDisplay: Disconnecting and destroying display");
+                    if (_connected)
+                    {
+                        Interop.TizenCoreWl.DisplayDisconnect(_display);
+                        _connected = false;
+                    }
+                    Interop.TizenCoreWl.DisplayDestroy(_display);
+                    _display = IntPtr.Zero;
+                }
+                Tizen.Log.Debug("TIZEN_CORE_WL", "TizenCoreWlDisplay: calling tizen_core_wl_shutdown()");
+                Interop.TizenCoreWl.Shutdown();
+                _disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets the native display handle.
+        /// </summary>
+        internal IntPtr GetNativeHandle()
+        {
+            return _display;
+        }
+    }
+}

--- a/test/Tizen.WindowSystem.InputGenerator/Tizen.WindowSystem.InputGenerator.cs
+++ b/test/Tizen.WindowSystem.InputGenerator/Tizen.WindowSystem.InputGenerator.cs
@@ -34,7 +34,9 @@ namespace Tizen.WindowSystem.InputGeneratorTest
         void Initialize()
         {
             Window win = Window.Default;
-            inputGen = new InputGenerator();
+            display = new TizenCoreWlDisplay();
+            display.Connect();
+            inputGen = new InputGenerator(display, InputGeneratorDevices.All);
 
             win.WindowSize = new Size2D(500, 500);
             win.KeyEvent += OnKeyEvent;
@@ -133,6 +135,7 @@ namespace Tizen.WindowSystem.InputGeneratorTest
             app.Run(args);
         }
 
+        private TizenCoreWlDisplay display;
         private InputGenerator inputGen;
         private TextLabel centerLabel;
         int touchCounter = 0;

--- a/test/Tizen.WindowSystem.InputGenerator/Tizen.WindowSystem.InputGenerator.csproj
+++ b/test/Tizen.WindowSystem.InputGenerator/Tizen.WindowSystem.InputGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
       <OutputType>Exe</OutputType>
-      <TargetFramework>net8.0-tizen10.0</TargetFramework>
+      <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+      <PackageReference Include="Tizen.NET.Sdk" Version="1.0.9" />
       <ProjectReference Include="../../src/Tizen/Tizen.csproj" />
       <ProjectReference Include="../../src/Tizen.NUI.Components/Tizen.NUI.Components.csproj" />
       <ProjectReference Include="../../src/Tizen.NUI/Tizen.NUI.csproj" />

--- a/test/Tizen.WindowSystem.InputGesture/Tizen.WindowSystem.InputGesture.cs
+++ b/test/Tizen.WindowSystem.InputGesture/Tizen.WindowSystem.InputGesture.cs
@@ -34,7 +34,9 @@ namespace Tizen.WindowSystem.InputGestureTest
         void Initialize()
         {
             Window win = Window.Default;
-            inputGesture = new InputGesture();
+            display = new TizenCoreWlDisplay();
+            display.Connect();
+            inputGesture = new InputGesture(display);
 
             win.WindowSize = new Size2D(500, 500);
             win.KeyEvent += OnKeyEvent;
@@ -191,6 +193,7 @@ namespace Tizen.WindowSystem.InputGestureTest
             app.Run(args);
         }
 
+        private TizenCoreWlDisplay display;
         private InputGesture inputGesture;
         private TextLabel centerLabel;
 

--- a/test/Tizen.WindowSystem.InputGesture/Tizen.WindowSystem.InputGesture.csproj
+++ b/test/Tizen.WindowSystem.InputGesture/Tizen.WindowSystem.InputGesture.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
       <OutputType>Exe</OutputType>
-      <TargetFramework>net8.0-tizen10.0</TargetFramework>
+      <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+      <PackageReference Include="Tizen.NET.Sdk" Version="1.0.9" />
       <ProjectReference Include="../../src/Tizen/Tizen.csproj" />
       <ProjectReference Include="../../src/Tizen.NUI.Components/Tizen.NUI.Components.csproj" />
       <ProjectReference Include="../../src/Tizen.NUI/Tizen.NUI.csproj" />


### PR DESCRIPTION
Description of Change

[Tizen.WindowSystem] Migrate InputGenerator and InputGesture from efl_util to tizen_core_wl

API Changes

Added:
- class Tizen.TizenCoreWlDisplay

Modified:
- InputGenerator
- InputGesture

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
