### PR TITLE
[Security.PrivacyPrivilegeManager] Add AllowSession, DenySession, AllowInUse

### DIFF
--- a/src/Tizen.Security.PrivacyPrivilegeManager/Interop/Interop.PrivacyPrivilegeManager.cs
+++ b/src/Tizen.Security.PrivacyPrivilegeManager/Interop/Interop.PrivacyPrivilegeManager.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2017 - 2018 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -41,6 +41,9 @@ internal static partial class Interop
             Allow = 0,
             Deny = 1,
             Ask = 2,
+            AllowSession = 3,
+            DenySession = 4,
+            AllowInUse = 5,
         }
 
         internal enum RequestResult
@@ -48,6 +51,9 @@ internal static partial class Interop
             AllowForever = 0,
             DenyForever = 1,
             DenyOnce = 2,
+            AllowSession = 3,
+            DenySession = 4,
+            AllowInUse = 5,
         }
 
         //[UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]

--- a/src/Tizen.Security.PrivacyPrivilegeManager/Interop/Interop.PrivacyPrivilegeManager.cs
+++ b/src/Tizen.Security.PrivacyPrivilegeManager/Interop/Interop.PrivacyPrivilegeManager.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2017 - 2018 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);

--- a/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/CheckResult.cs
+++ b/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/CheckResult.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -37,5 +37,20 @@ namespace Tizen.Security
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         Ask = Interop.PrivacyPrivilegeManager.CheckResult.Ask,
+        /// <summary>
+        /// The access to privilege is allowed for the current session only.
+        /// </summary>
+        /// <since_tizen> 14 </since_tizen>
+        AllowSession = Interop.PrivacyPrivilegeManager.CheckResult.AllowSession,
+        /// <summary>
+        /// The access to privilege is denied for the current session only.
+        /// </summary>
+        /// <since_tizen> 14 </since_tizen>
+        DenySession = Interop.PrivacyPrivilegeManager.CheckResult.DenySession,
+        /// <summary>
+        /// The access to privilege is allowed only while the application is in foreground.
+        /// </summary>
+        /// <since_tizen> 14 </since_tizen>
+        AllowInUse = Interop.PrivacyPrivilegeManager.CheckResult.AllowInUse,
     }
 }

--- a/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/CheckResult.cs
+++ b/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/CheckResult.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);

--- a/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/RequestResult.cs
+++ b/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/RequestResult.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -37,5 +37,20 @@ namespace Tizen.Security
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         DenyOnce = Interop.PrivacyPrivilegeManager.RequestResult.DenyOnce,
+        /// <summary>
+        /// The privilege is granted for the current session only.
+        /// </summary>
+        /// <since_tizen> 14 </since_tizen>
+        AllowSession = Interop.PrivacyPrivilegeManager.RequestResult.AllowSession,
+        /// <summary>
+        /// The privilege is denied for the current session only.
+        /// </summary>
+        /// <since_tizen> 14 </since_tizen>
+        DenySession = Interop.PrivacyPrivilegeManager.RequestResult.DenySession,
+        /// <summary>
+        /// The privilege is granted only while the application is in foreground.
+        /// </summary>
+        /// <since_tizen> 14 </since_tizen>
+        AllowInUse = Interop.PrivacyPrivilegeManager.RequestResult.AllowInUse,
     }
 }

--- a/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/RequestResult.cs
+++ b/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/RequestResult.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);


### PR DESCRIPTION
### Description of Change ###
Underlying native API has been extended with additional check and request result codes. Applying the same change to C# API.

### API Changes ###
Adding following values to CheckResult and RequestResult enums.

``` csharp
namespace Tizen.Security
{
  enum CheckResult {
    AllowSession,
    DenySession,
    AllowInUse
  }
  enum RequestResult {
    AllowSession,
    DenySession,
    AllowInUse
  }
}
```