### PR TITLE
Add API for Tethering Mode changed and Update Tethering Info (Migrated from #7541)

### DIFF
--- a/internals/src/Tizen.Network.Tethering/Interop/Interop.TetheringExtension.cs
+++ b/internals/src/Tizen.Network.Tethering/Interop/Interop.TetheringExtension.cs
@@ -30,6 +30,8 @@ internal static partial class Interop
         internal delegate void DisabledCallback(int result, TetheringDisabledCause cause, IntPtr userData);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void ConnectionStateChangedCallback(IntPtr client, bool opened, IntPtr userData);
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void ModeChangedCallback(int mode, IntPtr userData);
 
 
         // Tethering Manager
@@ -57,6 +59,12 @@ internal static partial class Interop
         [DllImport(Libraries.Tethering, EntryPoint = "tethering_ext_unset_connection_state_changed_cb")]
         internal static extern int UnsetConnectionStateChangedCallback(IntPtr tethering);
 
+        [DllImport(Libraries.Tethering, EntryPoint = "tethering_ext_set_mode_changed_cb")]
+        internal static extern int SetModeChangedCallback(IntPtr tethering, ModeChangedCallback callback, IntPtr userData);
+
+        [DllImport(Libraries.Tethering, EntryPoint = "tethering_ext_unset_mode_changed_cb")]
+        internal static extern int UnsetModeChangedCallback(IntPtr tethering);
+
         [DllImport(Libraries.Tethering, EntryPoint = "tethering_ext_activate")]
         internal static extern int Activate(IntPtr tethering);
 
@@ -71,6 +79,9 @@ internal static partial class Interop
 
         [DllImport(Libraries.Tethering, EntryPoint = "tethering_ext_set_passphrase")]
         internal static extern int SetPassphrase(IntPtr tethering, string ssid);
+
+        [DllImport(Libraries.Tethering, EntryPoint = "tethering_ext_update_tethering_info")]
+        internal static extern int UpdateTetheringInfo(IntPtr tethering, string ssid, string passphrase);
 
         [DllImport(Libraries.Tethering, EntryPoint = "tethering_ext_set_channel")]
         internal static extern int SetChannel(IntPtr tethering, int channel);

--- a/internals/src/Tizen.Network.Tethering/Tizen.Network.Tethering/TetheringExtensionEnumerations.cs
+++ b/internals/src/Tizen.Network.Tethering/Tizen.Network.Tethering/TetheringExtensionEnumerations.cs
@@ -164,4 +164,23 @@ namespace Tizen.Network.Tethering
         /// <since_tizen> 13 </since_tizen>
         Sae = 3,
     }
+
+    /// <summary>
+    /// Enumeration for the Tethering Extension mode.
+    /// </summary>
+    /// <since_tizen> 13 </since_tizen>
+    public enum TetheringExtensionMode
+    {
+        /// <summary>
+        /// Tethering is disabled.
+        /// </summary>
+        /// <since_tizen> 13 </since_tizen>
+        Disabled = 0,
+
+        /// <summary>
+        /// Tethering is enabled.
+        /// </summary>
+        /// <since_tizen> 13 </since_tizen>
+        Enabled = 1,
+    }
 }

--- a/internals/src/Tizen.Network.Tethering/Tizen.Network.Tethering/TetheringExtensionEvents.cs
+++ b/internals/src/Tizen.Network.Tethering/Tizen.Network.Tethering/TetheringExtensionEvents.cs
@@ -7,10 +7,12 @@ namespace Tizen.Network.Tethering
         private event EventHandler<TetheringExtensionEnabledEventArgs> _tetheringExtEnabled;
         private event EventHandler<TetheringExtensionDisabledEventArgs> _tetheringExtDisabled;
         private event EventHandler<ConnectionStateChangedEventArgs> _connectionStateChanged;
+        private event EventHandler<TetheringExtensionModeChangedEventArgs> _modeChanged;
 
         private Interop.TetheringExtension.EnabledCallback _enabledCallback;
         private Interop.TetheringExtension.DisabledCallback _disabledCallback;
         private Interop.TetheringExtension.ConnectionStateChangedCallback _connectionStateChangedCallback;
+        private Interop.TetheringExtension.ModeChangedCallback _modeChangedCallback;
 
         internal event EventHandler<TetheringExtensionEnabledEventArgs> TetheringExtensionEnabled
         {
@@ -117,6 +119,41 @@ namespace Tizen.Network.Tethering
             }
         }
 
+        internal event EventHandler<TetheringExtensionModeChangedEventArgs> ModeChanged
+        {
+            add
+            {
+                if (_modeChanged == null)
+                {
+                    try
+                    {
+                        RegisterModeChangedEvent();
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Error(Globals.LogTag, "Exception on adding ModeChanged\n" + e);
+                        return;
+                    }
+                }
+                _modeChanged += value;
+            }
+            remove
+            {
+                _modeChanged -= value;
+                if (_modeChanged == null)
+                {
+                    try
+                    {
+                        UnregisterModeChangedEvent();
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Error(Globals.LogTag, "Exception on removing ModeChanged\n" + e);
+                    }
+                }
+            }
+        }
+
 
         private void RegisterEnabledEvent()
         {
@@ -194,6 +231,34 @@ namespace Tizen.Network.Tethering
             {
                 Log.Error(Globals.LogTag, "Failed to unset connection state changed callback, Error - " + (TetheringError)ret);
             }
+        }
+
+        private void RegisterModeChangedEvent()
+        {
+            Log.Info(Globals.LogTag, "RegisterModeChangedEvent");
+            _modeChangedCallback = (int mode, IntPtr userData) =>
+            {
+                TetheringExtensionMode tetheringMode = (TetheringExtensionMode)mode;
+                TetheringExtensionModeChangedEventArgs e = new TetheringExtensionModeChangedEventArgs(tetheringMode);
+                _modeChanged?.Invoke(this, e);
+            };
+
+            int ret = Interop.TetheringExtension.SetModeChangedCallback(GetHandle(), _modeChangedCallback, IntPtr.Zero);
+            if (ret != (int)TetheringError.None)
+            {
+                Log.Error(Globals.LogTag, "Failed to set mode changed callback, Error - " + (TetheringError)ret);
+            }
+        }
+
+        private void UnregisterModeChangedEvent()
+        {
+            Log.Info(Globals.LogTag, "UnregisterModeChangedEvent");
+            int ret = Interop.TetheringExtension.UnsetModeChangedCallback(GetHandle());
+            if (ret != (int)TetheringError.None)
+            {
+                Log.Error(Globals.LogTag, "Failed to unset mode changed callback, Error - " + (TetheringError)ret);
+            }
+            _modeChangedCallback = null;
         }
 
     }

--- a/internals/src/Tizen.Network.Tethering/Tizen.Network.Tethering/TetheringExtensionManager.cs
+++ b/internals/src/Tizen.Network.Tethering/Tizen.Network.Tethering/TetheringExtensionManager.cs
@@ -93,6 +93,27 @@ namespace Tizen.Network.Tethering
         }
 
         /// <summary>
+        /// ModeChanged is raised when the tethering mode is changed.
+        /// </summary>
+        /// <since_tizen> 13 </since_tizen>
+        /// <privilege>
+        /// http://tizen.org/privilege/tethering.admin
+        /// </privilege>
+        /// <exception cref="TetheringError.InvalidParam">Thrown when the method failed due to an invalid parameter.</exception>
+        /// <exception cref="TetheringError.InvalidOperation">Thrown when the method failed due to an invalid operation.</exception>
+        static public event EventHandler<TetheringExtensionModeChangedEventArgs> ModeChanged
+        {
+            add
+            {
+                TetheringExtensionManagerImpl.Instance.ModeChanged += value;
+            }
+            remove
+            {
+                TetheringExtensionManagerImpl.Instance.ModeChanged -= value;
+            }
+        }
+
+        /// <summary>
         /// Activates the TetheringExtension.
         /// </summary>
         /// <since_tizen> 13 </since_tizen>
@@ -120,6 +141,22 @@ namespace Tizen.Network.Tethering
         static public void Deactivate()
         {
             TetheringExtensionManagerImpl.Instance.DeActivate();
+        }
+
+        /// <summary>
+        /// Updates the tethering information with new SSID and passphrase.
+        /// </summary>
+        /// <since_tizen> 13 </since_tizen>
+        /// <privilege>
+        /// http://tizen.org/privilege/tethering.admin
+        /// </privilege>
+        /// <exception cref="TetheringError.InvalidParam">Thrown when SSID or passphrase is invalid.</exception>
+        /// <exception cref="TetheringError.InvalidOperation">Thrown when tethering is not active or settings match current values.</exception>
+        /// <param name="ssid">The new SSID</param>
+        /// <param name="passphrase">The new passphrase</param>
+        static public void UpdateTetheringInfo(string ssid, string passphrase)
+        {
+            TetheringExtensionManagerImpl.Instance.UpdateTetheringInfo(ssid, passphrase);
         }
 
         /// <summary>

--- a/internals/src/Tizen.Network.Tethering/Tizen.Network.Tethering/TetheringExtensionManagerImpl.cs
+++ b/internals/src/Tizen.Network.Tethering/Tizen.Network.Tethering/TetheringExtensionManagerImpl.cs
@@ -153,6 +153,30 @@ namespace Tizen.Network.Tethering
             CheckReturnValue(ret, "DeActivate", PrivilegeNetworkProfile);
         }
 
+        internal void UpdateTetheringInfo(string ssid, string passphrase)
+        {
+            if (ssid == null)
+            {
+                Log.Error(Globals.LogTag, "SSID cannot be null");
+                throw new ArgumentException("SSID cannot be null");
+            }
+
+            if (passphrase == null)
+            {
+                Log.Error(Globals.LogTag, "Passphrase cannot be null");
+                throw new ArgumentException("Passphrase cannot be null");
+            }
+
+            Log.Info(Globals.LogTag, "Updating tethering info");
+            int ret = Interop.TetheringExtension.UpdateTetheringInfo(GetHandle(), ssid, passphrase);
+
+            if (ret != (int)TetheringError.None)
+            {
+                Log.Error(Globals.LogTag, "Failed to update tethering info, Error - " + (TetheringError)ret);
+                CheckReturnValue(ret, "UpdateTetheringInfo", PrivilegeNetworkProfile);
+            }
+        }
+
         public TetheringInfo GetTetheringInfo()
         {
             Log.Info(Globals.LogTag, "GetTetheringInfo");

--- a/internals/src/Tizen.Network.Tethering/Tizen.Network.Tethering/TetheringExtensionModeChangedEventArgs.cs
+++ b/internals/src/Tizen.Network.Tethering/Tizen.Network.Tethering/TetheringExtensionModeChangedEventArgs.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Tizen.Network.Tethering
+{
+    /// <summary>
+    /// TetheringExtensionModeChangedEventArgs provides the mode information when the ModeChanged event is raised.
+    /// </summary>
+    /// <since_tizen> 13 </since_tizen>
+    public class TetheringExtensionModeChangedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// The tethering mode.
+        /// </summary>
+        /// <since_tizen> 13 </since_tizen>
+        public TetheringExtensionMode Mode { get; }
+
+        /// <summary>
+        /// Constructor for TetheringExtensionModeChangedEventArgs.
+        /// </summary>
+        /// <since_tizen> 13 </since_tizen>
+        /// <param name="mode">The tethering mode (Enabled or Disabled).</param>
+        public TetheringExtensionModeChangedEventArgs(TetheringExtensionMode mode)
+        {
+            Mode = mode;
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###
ethering Mode State Callback
Event is triggered whenever the mode changed callback is received from the native Tethering C API

Dynamic SSID and Passphrase Update API
Updates the tethering information with new SSID (service set identifier) and passphrase.