### PR TITLE
[Security.PrivacyPrivilegeManager] CheckPermissionsAsync(), RequestPermissionsAsync()

### DIFF
--- a/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security.PrivacyPrivilegeManager.csproj
+++ b/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security.PrivacyPrivilegeManager.csproj
@@ -6,5 +6,6 @@
  <ItemGroup>
    <ProjectReference Include="..\Tizen\Tizen.csproj" />
    <ProjectReference Include="..\Tizen.Log\Tizen.Log.csproj" />
+   <ProjectReference Include="..\Tizen.Applications.Common\Tizen.Applications.Common.csproj" />
  </ItemGroup>
 </Project>

--- a/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/PermissionDeniedException.cs
+++ b/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/PermissionDeniedException.cs
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Tizen.Security
+{
+    /// <summary>
+    /// Exception thrown when one or more required permissions are denied.
+    /// </summary>
+    /// <since_tizen> 14 </since_tizen>
+    /// <example>
+    /// <code>
+    /// <![CDATA[
+    /// try
+    /// {
+    ///     await PrivacyPrivilegeManager.RequestPermissionsAsync(required: privileges);
+    /// }
+    /// catch (PermissionDeniedException ex)
+    /// {
+    ///     foreach (var privilege in ex.DeniedPrivileges)
+    ///     {
+    ///         var status = ex.GetStatus(privilege);
+    ///         var name = Tizen.Security.Privilege.GetDisplayName("12", privilege);
+    ///         Console.WriteLine($"{name}: {status}");
+    ///     }
+    /// }
+    /// ]]>
+    /// </code>
+    /// </example>
+    public class PermissionDeniedException : Exception
+    {
+        private readonly IDictionary<string, PermissionStatus> _map;
+
+        /// <summary>
+        /// Gets the list of denied privilege names.
+        /// </summary>
+        /// <since_tizen> 14 </since_tizen>
+        public IEnumerable<string> DeniedPrivileges => _map.Keys;
+
+        /// <summary>
+        /// Initializes a new instance of the PermissionDeniedException class with denied privileges and their statuses.
+        /// </summary>
+        /// <param name="denied">A dictionary mapping denied privilege names to their statuses.</param>
+        /// <since_tizen> 14 </since_tizen>
+        public PermissionDeniedException(IDictionary<string, PermissionStatus> denied)
+            : base("Required permissions denied: " + string.Join(", ", denied.Keys))
+        {
+            _map = new Dictionary<string, PermissionStatus>(denied);
+        }
+
+        /// <summary>
+        /// Gets the permission status for a specific denied privilege.
+        /// </summary>
+        /// <param name="privilege">The privilege name.</param>
+        /// <returns>The permission status of the denied privilege.</returns>
+        /// <exception cref="ArgumentException">Thrown when the privilege is not found in the denied list.</exception>
+        /// <since_tizen> 14 </since_tizen>
+        public PermissionStatus GetStatus(string privilege)
+        {
+            if (!_map.TryGetValue(privilege, out var status))
+            {
+                throw new ArgumentException($"Privilege '{privilege}' is not in the denied list.", nameof(privilege));
+            }
+            return status;
+        }
+    }
+}

--- a/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/PermissionResult.cs
+++ b/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/PermissionResult.cs
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Tizen.Security
+{
+    /// <summary>
+    /// Represents the result of permission checks, implementing IDictionary&lt;string, PermissionState&gt;.
+    /// Provides methods to check if privileges are granted.
+    /// </summary>
+    /// <since_tizen>14</since_tizen>
+    /// <example>
+    /// <code><![CDATA[
+    /// PermissionResult permissions = await PrivacyPrivilegeManager.CheckPermissionsAsync(privileges);
+    ///
+    /// // Check if a specific privilege is granted (returns false for unknown privileges)
+    /// bool isGranted = permissions.IsGranted("http://tizen.org/privilege/account.read");
+    ///
+    /// // Check if all privileges are granted
+    /// bool allGranted = permissions.AllGranted();
+    /// ]]></code>
+    /// </example>
+    public class PermissionResult : Dictionary<string, PermissionStatus>
+    {
+        /// <summary>
+        /// Checks if a specific privilege is granted.
+        /// Returns false for unknown privileges without throwing an exception.
+        /// </summary>
+        /// <param name="privilege">The privilege to check.</param>
+        /// <returns>True if the privilege is granted; otherwise, false.</returns>
+        /// <since_tizen>14</since_tizen>
+        public bool IsGranted(string privilege) =>
+            TryGetValue(privilege, out var status) && status.IsGranted();
+
+        /// <summary>
+        /// Checks if all privileges in this result are granted.
+        /// </summary>
+        /// <returns>True if all privileges are granted; otherwise, false.</returns>
+        /// <since_tizen>14</since_tizen>
+        public bool AreAllGranted() => Values.All(status => status.IsGranted());
+    }
+}

--- a/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/PermissionStatus.cs
+++ b/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/PermissionStatus.cs
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Tizen.Security
+{
+    /// <summary>
+    /// Enumeration for the status of a permission.
+    /// </summary>
+    /// <since_tizen> 14 </since_tizen>
+    public enum PermissionStatus
+    {
+        /// <summary>
+        /// The privilege is granted.
+        /// </summary>
+        Granted = 0,
+        /// <summary>
+        /// The privilege is denied.
+        /// </summary>
+        Denied = 1,
+        /// <summary>
+        /// The permission is denied until user grants it. Use RequestPermissionAsync() to ask the user for the permission.
+        /// </summary>
+        Ask = 2,
+        /// <summary>
+        /// The privilege is granted for the current session only.
+        /// </summary>
+        GrantedSession = 3,
+        /// <summary>
+        /// The privilege is denied for the current session only.
+        /// </summary>
+        DeniedSession = 4,
+        /// <summary>
+        /// The privilege is granted only while the application is in foreground.
+        /// </summary>
+        GrantedInUse = 5,
+        /// <summary>
+        /// The privilege is denied once - user did not allow the permission this time and chose to be asked again later.
+        /// </summary>
+        Deferred = 90,
+    }
+
+    /// <summary>
+    /// Extension methods for PermissionState.
+    /// </summary>
+    /// <since_tizen> 14 </since_tizen>
+    public static class PermissionStateExtensions
+    {
+        /// <summary>
+        /// Checks if the permission state indicates that the privilege is granted.
+        /// </summary>
+        /// <param name="state">The permission state to check.</param>
+        /// <returns>True if the privilege is granted (Granted, GrantedSession, or GrantedInUse); otherwise, false.</returns>
+        /// <since_tizen> 14 </since_tizen>
+        public static bool IsGranted(this PermissionStatus state)
+        {
+            return state == PermissionStatus.Granted ||
+                   state == PermissionStatus.GrantedSession ||
+                   state == PermissionStatus.GrantedInUse;
+        }
+    }
+
+    /// <summary>
+    /// Internal helper class for converting between interop enums and PermissionStatus.
+    /// </summary>
+    internal static class PermissionStatusConverter
+    {
+        /// <summary>
+        /// Converts Interop.CheckResult to PermissionState.
+        /// </summary>
+        internal static PermissionStatus ToPermissionStatus(this Interop.PrivacyPrivilegeManager.CheckResult checkResult)
+        {
+            // Values match directly for all cases.
+            return (PermissionStatus)checkResult;
+        }
+
+        /// <summary>
+        /// Converts RequestResult to PermissionState.
+        /// </summary>
+        internal static PermissionStatus ToPermissionStatus(this RequestResult requestResult)
+        {
+            // Value DenyOnce maps to Deferred (90). Others match directly.
+            if (requestResult == RequestResult.DenyOnce)
+            {
+                return PermissionStatus.Deferred;
+            }
+            return (PermissionStatus)requestResult;
+        }
+    }
+}

--- a/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/PrivacyPrivilegeManager.cs
+++ b/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/PrivacyPrivilegeManager.cs
@@ -19,13 +19,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
+#pragma warning disable 618
+
 namespace Tizen.Security
 {
     /// <summary>
     /// The PrivacyPrivilegeManager provides the properties or methods to check and request a permission for privacy privilege.
     /// </summary>
     /// <since_tizen> 4 </since_tizen>
-    [Obsolete("Deprecated in API11, will be removed in API13. This API will be removed without any alternatives.")]
     public static class PrivacyPrivilegeManager
     {
         private const string LogTag = "Tizen.Privilege";
@@ -113,7 +114,7 @@ namespace Tizen.Security
         /// </code>
         /// </example>
         /// <since_tizen> 4 </since_tizen>
-        [Obsolete("Deprecated in API11, will be removed in API13. This API will be removed without any alternatives.")]
+        [Obsolete("Deprecated in API11, will be removed in API13. Use CheckPermissionsAsync() instead.")]
         public static CheckResult CheckPermission(string privilege)
         {
             Interop.PrivacyPrivilegeManager.CheckResult result;
@@ -160,7 +161,7 @@ namespace Tizen.Security
         /// </code>
         /// </example>
         /// <since_tizen> 6 </since_tizen>
-        [Obsolete("Deprecated in API11, will be removed in API13. This API will be removed without any alternatives.")]
+        [Obsolete("Deprecated in API11, will be removed in API13. Use CheckPermissionsAsync() instead.")]
         public static IEnumerable<CheckResult> CheckPermissions(IEnumerable<string> privileges)
         {
             string[] privilegesArray = CheckPrivilegesArgument(privileges, "CheckPermissions");
@@ -208,7 +209,7 @@ namespace Tizen.Security
         /// </code>
         /// </example>
         /// <since_tizen> 4 </since_tizen>
-        [Obsolete("Deprecated in API11, will be removed in API13. This API will be removed without any alternatives.")]
+        [Obsolete("Deprecated in API11, will be removed in API13. Use RequestPermissionsAsync() instead.")]
         public static void RequestPermission(string privilege)
         {
             if (!s_PrivilegesInProgress.Add(privilege))
@@ -261,7 +262,7 @@ namespace Tizen.Security
         /// </code>
         /// </example>
         /// <since_tizen> 6 </since_tizen>
-        [Obsolete("Deprecated in API11, will be removed in API13. This API will be removed without any alternatives.")]
+        [Obsolete("Deprecated in API11, will be removed in API13. Use RequestPermissionsAsync() instead.")]
         public static Task<RequestMultipleResponseEventArgs> RequestPermissions(IEnumerable<string> privileges)
         {
             string[] privilegesArray = CheckPrivilegesArgument(privileges, "RequestPermissions");
@@ -360,7 +361,7 @@ namespace Tizen.Security
         /// </code>
         /// </example>
         /// <since_tizen> 4 </since_tizen>
-        [Obsolete("Deprecated in API11, will be removed in API13. This API will be removed without any alternatives.")]
+        [Obsolete("Deprecated in API11, will be removed in API13. Use RequestPermissionsAsync() which handles context internally.")]
         public static WeakReference<ResponseContext> GetResponseContext(string privilege)
         {
             if (!(s_responseWeakMap.TryGetValue(privilege, out WeakReference<ResponseContext> weakRef) && weakRef.TryGetTarget(out ResponseContext context)))
@@ -404,11 +405,205 @@ namespace Tizen.Security
         }
 
         /// <summary>
+        /// Gets the status of privacy privileges permission asynchronously.
+        /// </summary>
+        /// <param name="privileges">The privacy privileges to be checked.</param>
+        /// <returns>A task that returns a permission status of the requested privileges.</returns>
+        /// <exception cref="ArgumentException">Thrown when an invalid parameter is passed.</exception>
+        /// <exception cref="OutOfMemoryException">Thrown when a memory error occurred.</exception>
+        /// <exception cref="System.IO.IOException">Thrown when the method failed due to an internal I/O error.</exception>
+        /// <example>
+        /// <code>
+        /// <![CDATA[
+        /// string[] privileges = new [] {"http://tizen.org/privilege/account.read",
+        ///                               "http://tizen.org/privilege/alarm"};
+        /// PermissionResult results = await PrivacyPrivilegeManager.CheckPermissionsAsync(privileges);
+        /// foreach (var (privilege, status) in results)
+        /// {
+        ///     var name = Tizen.Security.Privilege.GetDisplayName("", privilege);
+        ///     Console.WriteLine($"Privilege: {name}, Status: {status}");
+        /// }
+        /// ]]>
+        /// </code>
+        /// </example>
+        /// <example>
+        /// Check if all privileges from manifest are granted.
+        /// <code>
+        /// <![CDATA[
+        /// List<string> manifestPrivileges = await PrivacyPrivilegeManager.LoadPrivilegesFromManifestAsync();
+        /// PermissionResult states = await PrivacyPrivilegeManager.CheckPermissionsAsync(manifestPrivileges);
+        /// bool allGranted = states.AllGranted();
+        /// if (allGranted)
+        /// {
+        ///     Console.WriteLine("All permissions are granted.");
+        /// }
+        /// ]]>
+        /// </code>
+        /// </example>
+        /// <since_tizen> 14 </since_tizen>
+        public static async Task<PermissionResult> CheckPermissionsAsync(IEnumerable<string> privileges)
+        {
+            string[] privilegesArray = CheckPrivilegesArgument(privileges, "CheckPermissionsAsync");
+
+            return await Task.Run(() =>
+            {
+                Interop.PrivacyPrivilegeManager.CheckResult[] results = new Interop.PrivacyPrivilegeManager.CheckResult[privilegesArray.Length];
+                int ret = (int)Interop.PrivacyPrivilegeManager.CheckPermissions(privilegesArray, (uint)privilegesArray.Length, results);
+                if (ret != (int)Interop.PrivacyPrivilegeManager.ErrorCode.None)
+                {
+                    Log.Error(LogTag, "Failed to check permissions " + string.Join(", ", privileges));
+                    throw PrivacyPrivilegeManagerErrorFactory.GetException(ret);
+                }
+
+                var permissionStates = new PermissionResult();
+                for (int iterator = 0; iterator < results.Length; ++iterator)
+                {
+                    permissionStates[privilegesArray[iterator]] = results[iterator].ToPermissionStatus();
+                }
+                return permissionStates;
+            });
+        }
+
+        /// <summary>
+        /// Triggers the permissions request for a user asynchronously.
+        /// </summary>
+        /// <param name="required">The required privacy privileges to be requested.</param>
+        /// <param name="optional">The optional, non-critical privacy privileges to be requested.
+        /// Privileges listed in both required and optional are treated as optional.</param>
+        /// <returns>A task that returns a permission status of the requested privileges.</returns>
+        /// <exception cref="ArgumentException">Thrown when an invalid parameter is passed.</exception>
+        /// <exception cref="PermissionDeniedException">Thrown when one or more required permissions are denied.</exception>
+        /// <exception cref="OutOfMemoryException">Thrown when a memory error occurred.</exception>
+        /// <exception cref="System.IO.IOException">Thrown when the method failed due to an internal I/O error.</exception>
+        /// <example>
+        /// <code>
+        /// <![CDATA[
+        /// try
+        /// {
+        ///     var results = await PrivacyPrivilegeManager.RequestPermissionsAsync(
+        ///         required: await PrivacyPrivilegeManager.LoadPrivilegesFromManifestAsync(),
+        ///         optional: new[] { "http://tizen.org/privilege/alarm" });
+        ///     foreach (var (privilege, state) in results)
+        ///     {
+        ///         Console.WriteLine($"Privilege: {privilege}, State: {state}");
+        ///     }
+        ///     // required privileges have been granted, application can continue
+        ///     if (!results.IsGranted("http://tizen.org/privilege/alarm")) {
+        ///         HideAlarmRelatedUI();
+        ///     }
+        /// }
+        /// catch (PermissionDeniedException ex)
+        /// {
+        ///     foreach (var privilege in ex.DeniedPrivileges)
+        ///     {
+        ///         var name = Tizen.Security.Privilege.GetDisplayName("", privilege);
+        ///         Console.WriteLine($"{name} has been denied");
+        ///     }
+        ///     // application can not run, present a user option to re-request permissions
+        /// }
+        /// }
+        /// ]]>
+        /// </code>
+        /// </example>
+        /// <since_tizen> 14 </since_tizen>
+        public static async Task<PermissionResult> RequestPermissionsAsync(IEnumerable<string> required = null, IEnumerable<string> optional = null)
+        {
+            // Build the set of privileges to request
+            // Privileges in both required and optional are treated as optional
+            var optionalSet = optional != null ? new HashSet<string>(optional) : new HashSet<string>();
+            var requiredList = required != null ? new List<string>(required) : new List<string>();
+
+            // Remove from required any privileges that are also in optional (they become optional)
+            var actualRequired = requiredList.Where(p => !optionalSet.Contains(p)).ToList();
+
+            // Combine all privileges to request (required + optional)
+            var allPrivileges = actualRequired.Concat(optionalSet).ToList();
+
+            var states = new PermissionResult();
+            if (!allPrivileges.Any())
+            {
+                return states;
+            }
+
+            var result = await RequestPermissions(allPrivileges);
+
+            // Build dictionary of results
+            foreach (var response in result.Responses)
+            {
+                states[response.Privilege] = response.Result.ToPermissionStatus();
+            }
+
+            // Check if any required permissions were denied
+            var deniedMap = actualRequired
+                .Where(p => states.ContainsKey(p) && !states[p].IsGranted())
+                .ToDictionary(p => p, p => states[p]);
+
+            if (deniedMap.Any())
+            {
+                throw new PermissionDeniedException(deniedMap);
+            }
+
+            return states;
+        }
+
+        /// <summary>
+        /// Loads privileges from the application manifest file (tizen-manifest.xml) asynchronously.
+        /// </summary>
+        /// <returns>A task that returns a list of privilege strings declared in the manifest.</returns>
+        /// <exception cref="System.IO.FileNotFoundException">Thrown when the manifest file is not found.</exception>
+        /// <exception cref="System.Xml.XmlException">Thrown when the manifest file contains invalid XML.</exception>
+        /// <example>
+        /// <code>
+        /// <![CDATA[
+        /// List<string> privileges = await PrivacyPrivilegeManager.LoadPrivilegesFromManifestAsync();
+        /// foreach (var privilege in privileges)
+        /// {
+        ///     Console.WriteLine($"Privilege: {privilege}");
+        /// }
+        /// ]]>
+        /// </code>
+        /// </example>
+        /// <since_tizen> 14 </since_tizen>
+        public static async Task<IEnumerable<string>> LoadPrivilegesFromManifestAsync()
+        {
+            return await Task.Run(() =>
+            {
+                var manifestPath = System.IO.Path.GetDirectoryName(
+                    System.IO.Path.GetDirectoryName(
+                        Tizen.Applications.Application.Current.ApplicationInfo.ExecutablePath)
+                    ) + "/tizen-manifest.xml";
+                if (!System.IO.File.Exists(manifestPath))
+                {
+                    Log.Error(LogTag, "Manifest file not found: " + manifestPath);
+                    throw new System.IO.FileNotFoundException("Manifest file not found: " + manifestPath);
+                }
+
+                var privileges = new List<string>();
+                var doc = System.Xml.Linq.XDocument.Load(manifestPath);
+                var ns = doc.Root?.Name.Namespace ?? System.Xml.Linq.XNamespace.None;
+
+                var privilegesElement = doc.Root?.Element(ns + "privileges");
+                if (privilegesElement != null)
+                {
+                    foreach (var privilegeElement in privilegesElement.Elements(ns + "privilege"))
+                    {
+                        if (!string.IsNullOrEmpty(privilegeElement.Value))
+                        {
+                            privileges.Add(privilegeElement.Value.Trim());
+                        }
+                    }
+                }
+
+                return privileges;
+            });
+        }
+
+        /// <summary>
         /// This class manages event handlers of the privilege permission requests.
         /// This class enables having event handlers for an individual privilege.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
-        [Obsolete("Deprecated in API11, will be removed in API13. This API will be removed without any alternatives.")]
+        [Obsolete("Deprecated in API11, will be removed in API13. Use RequestPermissionsAsync() which handles context internally.")]
         public class ResponseContext
         {
             private string _privilege;
@@ -422,7 +617,7 @@ namespace Tizen.Security
             /// </summary>
             /// <exception cref="System.InvalidOperationException">Thrown when the bundle instance has been disposed.</exception>
             /// <since_tizen> 4 </since_tizen>
-            [Obsolete("Deprecated in API11, will be removed in API13. This API will be removed without any alternatives.")]
+            [Obsolete("Deprecated in API11, will be removed in API13. Use RequestPermissionsAsync() which handles context internally.")]
             public event EventHandler<RequestResponseEventArgs> ResponseFetched
             {
                 add


### PR DESCRIPTION
### Description of Change ###
A replacement for deprecated privilege requesting API.

### API Changes ###
 - ACR: TCSACR-657

``` csharp
    public static class Tizen.Security.PrivacyPrivilegeManager
    {
        static Task<PermissionResult> CheckPermissionsAsync(IEnumerable<string> privileges)
        static Task<PermissionResult> RequestPermissionsAsync(IEnumerable<string> required = null, IEnumerable<string> optional = null)
        static Task<IEnumerable<string>> LoadPrivilegesFromManifestAsync()
    }
```