### PR TITLE
[NUI] Remove internal API to call Native signal emit directly + Empty checker method

### DIFF
--- a/src/Tizen.NUI/src/internal/Animation/AnimationSignal.cs
+++ b/src/Tizen.NUI/src/internal/Animation/AnimationSignal.cs
@@ -28,13 +28,6 @@ namespace Tizen.NUI
             Interop.Animation.DeleteAnimationSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.Animation.AnimationSignalEmpty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.Animation.AnimationSignalGetConnectionCount(SwigCPtr);
@@ -73,6 +66,8 @@ namespace Tizen.NUI
 
         public void Emit(Animation arg)
         {
+            // TODO : This function only be used at Tizen.NUI.Components Navigator, to emit finished callback immediatly.
+            // Finished callback immediatly is not recommended, because it may cause unexpected behavior. So, must fix Navigator codes in future.
             Interop.Animation.AnimationSignalEmit(SwigCPtr, Animation.getCPtr(arg));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/internal/Application/ApplicationControlSignal.cs
+++ b/src/Tizen.NUI/src/internal/Application/ApplicationControlSignal.cs
@@ -28,13 +28,6 @@ namespace Tizen.NUI
             Interop.ApplicationControlSignal.DeleteApplicationControlSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.ApplicationControlSignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.ApplicationControlSignal.GetConnectionCount(SwigCPtr);
@@ -58,12 +51,6 @@ namespace Tizen.NUI
                 Interop.ApplicationControlSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(Application arg1, System.IntPtr arg2)
-        {
-            Interop.ApplicationControlSignal.Emit(SwigCPtr, Application.getCPtr(arg1), arg2);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public ApplicationControlSignal() : this(Interop.ApplicationControlSignal.NewApplicationControlSignal(), true)

--- a/src/Tizen.NUI/src/internal/Application/ApplicationSignal.cs
+++ b/src/Tizen.NUI/src/internal/Application/ApplicationSignal.cs
@@ -30,13 +30,6 @@ namespace Tizen.NUI
             Interop.ApplicationSignal.DeleteApplicationSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.ApplicationSignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.ApplicationSignal.GetConnectionCount(SwigCPtr);
@@ -60,12 +53,6 @@ namespace Tizen.NUI
                 Interop.ApplicationSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(Application arg)
-        {
-            Interop.ApplicationSignal.Emit(SwigCPtr, Application.getCPtr(arg));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public ApplicationSignal() : this(Interop.ApplicationSignal.NewApplicationSignal(), true)

--- a/src/Tizen.NUI/src/internal/Application/WatchBoolSignal.cs
+++ b/src/Tizen.NUI/src/internal/Application/WatchBoolSignal.cs
@@ -28,13 +28,6 @@ namespace Tizen.NUI
             Interop.Watch.DeleteWatchBoolSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.Watch.WatchBoolSignalEmpty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.Watch.WatchBoolSignalGetConnectionCount(SwigCPtr);
@@ -58,12 +51,6 @@ namespace Tizen.NUI
                 Interop.Watch.WatchBoolSignalDisconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(Application arg1, bool arg2)
-        {
-            Interop.Watch.WatchBoolSignalEmit(SwigCPtr, Application.getCPtr(arg1), arg2);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public WatchBoolSignal() : this(Interop.Watch.NewWatchBoolSignal(), true)

--- a/src/Tizen.NUI/src/internal/Application/WatchTimeSignal.cs
+++ b/src/Tizen.NUI/src/internal/Application/WatchTimeSignal.cs
@@ -28,13 +28,6 @@ namespace Tizen.NUI
             Interop.Watch.DeleteWatchTimeSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.Watch.WatchTimeSignalEmpty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.Watch.WatchTimeSignalGetConnectionCount(SwigCPtr);
@@ -58,12 +51,6 @@ namespace Tizen.NUI
                 Interop.Watch.WatchTimeSignalDisconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(Application arg1, WatchTime arg2)
-        {
-            Interop.Watch.WatchTimeSignalEmit(SwigCPtr, Application.getCPtr(arg1), WatchTime.getCPtr(arg2));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public WatchTimeSignal() : this(Interop.Watch.NewWatchTimeSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/ActivatedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Common/ActivatedSignalType.cs
@@ -32,17 +32,6 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Queries whether there are any connected slots.
-        /// </summary>
-        /// <returns>True if there are any slots connected to the signal</returns>
-        public bool Empty()
-        {
-            bool ret = Interop.ActivatedSignalType.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        /// <summary>
         /// Queries the number of slots.
         /// </summary>
         /// <returns>The number of slots connected to this signal</returns>
@@ -77,16 +66,6 @@ namespace Tizen.NUI
                 Interop.ActivatedSignalType.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        /// <summary>
-        /// Emits the signal.
-        /// </summary>
-        /// <param name="arg">The first value to pass to callbacks</param>
-        public void Emit(InputMethodContext arg)
-        {
-            Interop.ActivatedSignalType.Emit(SwigCPtr, InputMethodContext.getCPtr(arg));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/internal/Common/ClipboardSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/ClipboardSignal.cs
@@ -30,13 +30,6 @@ namespace Tizen.NUI
             Interop.Clipboard.DeleteClipboardSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.Clipboard.ClipboardSignalEmpty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.Clipboard.ClipboardSignalGetConnectionCount(SwigCPtr);
@@ -60,12 +53,6 @@ namespace Tizen.NUI
                 Interop.Clipboard.ClipboardSignalDisconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(Clipboard clipboard)
-        {
-            Interop.Clipboard.ClipboardSignalEmit(SwigCPtr, Clipboard.getCPtr(clipboard));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public ClipboardSignal() : this(Interop.Clipboard.NewClipboardSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/ContentReceivedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Common/ContentReceivedSignalType.cs
@@ -35,17 +35,6 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Queries whether there are any connected slots.
-        /// </summary>
-        /// <returns>True if there are any slots connected to the signal</returns>
-        public bool Empty()
-        {
-            bool ret = Interop.ContentReceivedSignalType.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        /// <summary>
         /// Queries the number of slots.
         /// </summary>
         /// <returns>The number of slots connected to this signal</returns>
@@ -80,18 +69,6 @@ namespace Tizen.NUI
                 Interop.ContentReceivedSignalType.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        /// <summary>
-        /// Connects a member function.
-        /// </summary>
-        /// <param name="arg1">The member function to connect</param>
-        /// <param name="arg2">The member function to connect</param>
-        /// <param name="arg3">The member function to connect</param>
-        public void Emit(string arg1, string arg2, string arg3)
-        {
-            Interop.ContentReceivedSignalType.Emit(SwigCPtr, arg1, arg2, arg3);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/internal/Common/DeviceOrientationChangedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Common/DeviceOrientationChangedSignalType.cs
@@ -28,13 +28,6 @@ namespace Tizen.NUI
             Interop.DeviceOrientationChangedSignalType.DeleteDeviceOrientationChangedSignalType(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.DeviceOrientationChangedSignalType.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.DeviceOrientationChangedSignalType.GetConnectionCount(SwigCPtr);
@@ -58,12 +51,6 @@ namespace Tizen.NUI
                 Interop.DeviceOrientationChangedSignalType.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        internal void Emit(Application.MemoryStatus arg)
-        {
-            Interop.DeviceOrientationChangedSignalType.Emit(SwigCPtr, (int)arg);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public DeviceOrientationChangedSignalType() : this(Interop.DeviceOrientationChangedSignalType.NewDeviceOrientationChangedSignalType(), true)

--- a/src/Tizen.NUI/src/internal/Common/FocusChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/FocusChangedSignal.cs
@@ -30,13 +30,6 @@ namespace Tizen.NUI
             Interop.FocusChangedSignal.DeleteFocusChangedSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.FocusChangedSignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.FocusChangedSignal.GetConnectionCount(SwigCPtr);
@@ -60,12 +53,6 @@ namespace Tizen.NUI
                 Interop.FocusChangedSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(View arg1, View arg2)
-        {
-            Interop.FocusChangedSignal.Emit(SwigCPtr, View.getCPtr(arg1), View.getCPtr(arg2));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public FocusChangedSignal() : this(Interop.FocusChangedSignal.NewFocusChangedSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/FocusGroupChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/FocusGroupChangedSignal.cs
@@ -30,13 +30,6 @@ namespace Tizen.NUI
             Interop.FocusGroupChangedSignal.DeleteFocusGroupChangedSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.FocusGroupChangedSignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.FocusGroupChangedSignal.GetConnectionCount(SwigCPtr);
@@ -60,12 +53,6 @@ namespace Tizen.NUI
                 Interop.FocusGroupChangedSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(View arg1, bool arg2)
-        {
-            Interop.FocusGroupChangedSignal.Emit(SwigCPtr, View.getCPtr(arg1), arg2);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public FocusGroupChangedSignal() : this(Interop.FocusGroupChangedSignal.NewFocusGroupChangedSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/GLWindowResizedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/GLWindowResizedSignal.cs
@@ -28,13 +28,6 @@ namespace Tizen.NUI
             Interop.GLWindowResizedSignal.GlWindowDeleteResizedSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.GLWindowResizedSignal.GlWindowResizedSignalEmpty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.GLWindowResizedSignal.GlWindowResizedSignalGetConnectionCount(SwigCPtr);
@@ -58,12 +51,6 @@ namespace Tizen.NUI
                 Interop.GLWindowResizedSignal.GlWindowResizedSignalDisconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(Size2D arg)
-        {
-            Interop.GLWindowResizedSignal.GlWindowResizedSignalEmit(SwigCPtr, Size2D.getCPtr(arg));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public GLWindowResizedSignal() : this(Interop.GLWindowResizedSignal.NewGlWindowResizedSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/KeyEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/KeyEventSignal.cs
@@ -28,13 +28,6 @@ namespace Tizen.NUI
             Interop.KeyEventSignal.DeleteKeyEventSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.KeyEventSignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.KeyEventSignal.GetConnectionCount(SwigCPtr);
@@ -58,12 +51,6 @@ namespace Tizen.NUI
                 Interop.KeyEventSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(Key arg)
-        {
-            Interop.KeyEventSignal.Emit(SwigCPtr, Key.getCPtr(arg));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public KeyEventSignal() : this(Interop.KeyEventSignal.NewKeyEventSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/KeyboardEventSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Common/KeyboardEventSignalType.cs
@@ -31,17 +31,6 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Queries whether there are any connected slots.
-        /// </summary>
-        /// <returns>True if there are any slots connected to the signal</returns>
-        public bool Empty()
-        {
-            bool ret = Interop.KeyboardEventSignalType.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        /// <summary>
         /// Queries the number of slots.
         /// </summary>
         /// <returns>The number of slots connected to this signal</returns>
@@ -76,19 +65,6 @@ namespace Tizen.NUI
                 Interop.KeyboardEventSignalType.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        /// <summary>
-        /// Emits the signal.
-        /// </summary>
-        /// <param name="arg1">The first value to pass to callbacks</param>
-        /// <param name="arg2">The second value to pass to callbacks</param>
-        /// <returns>The value returned by the last callback, or a default constructed value if no callbacks are connected</returns>
-        public InputMethodContext.CallbackData Emit(InputMethodContext arg1, InputMethodContext.EventData arg2)
-        {
-            InputMethodContext.CallbackData ret = new InputMethodContext.CallbackData(Interop.KeyboardEventSignalType.Emit(SwigCPtr, InputMethodContext.getCPtr(arg1), InputMethodContext.EventData.getCPtr(arg2)), true);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/internal/Common/KeyboardRepeatSettingsChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/KeyboardRepeatSettingsChangedSignal.cs
@@ -29,14 +29,6 @@ namespace Tizen.NUI
             Interop.KeyboardRepeatSettingsChangedSignal.DeleteSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.KeyboardRepeatSettingsChangedSignal.Empty(SwigCPtr);
-
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.KeyboardRepeatSettingsChangedSignal.GetConnectionCount(SwigCPtr);
@@ -61,13 +53,6 @@ namespace Tizen.NUI
                 Interop.KeyboardRepeatSettingsChangedSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public bool Emit()
-        {
-            bool ret = Interop.KeyboardRepeatSettingsChangedSignal.Emit(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
         }
 
         public KeyboardRepeatSettingsChangedSignal(Window window) : this(Interop.KeyboardRepeatSettingsChangedSignal.GetSignal(Window.getCPtr(window)), false)

--- a/src/Tizen.NUI/src/internal/Common/KeyboardResizedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Common/KeyboardResizedSignalType.cs
@@ -32,17 +32,6 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Queries whether there are any connected slots.
-        /// </summary>
-        /// <returns>True if there are any slots connected to the signal</returns>
-        public bool Empty()
-        {
-            bool ret = Interop.KeyboardResizedSignalType.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        /// <summary>
         /// Queries the number of slots.
         /// </summary>
         /// <returns>The number of slots connected to this signal</returns>
@@ -77,16 +66,6 @@ namespace Tizen.NUI
                 Interop.KeyboardResizedSignalType.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        /// <summary>
-        /// Connects a member function.
-        /// </summary>
-        /// <param name="arg">The member function to connect</param>
-        public void Emit(int arg)
-        {
-            Interop.KeyboardResizedSignalType.Emit(SwigCPtr, arg);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/internal/Common/KeyboardTypeSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Common/KeyboardTypeSignalType.cs
@@ -39,17 +39,6 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Queries whether there are any connected slots.
-        /// </summary>
-        /// <returns>True if there are any slots connected to the signal</returns>
-        internal bool Empty()
-        {
-            bool ret = Interop.KeyboardTypeSignalType.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        /// <summary>
         /// Queries the number of slots.
         /// </summary>
         /// <returns>The number of slots connected to this signal</returns>
@@ -84,16 +73,6 @@ namespace Tizen.NUI
                 Interop.KeyboardTypeSignalType.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        /// <summary>
-        /// Connects a member function.
-        /// </summary>
-        /// <param name="arg">The member function to connect</param>
-        internal void Emit(InputMethodContext.KeyboardType arg)
-        {
-            Interop.KeyboardTypeSignalType.Emit(SwigCPtr, (int)arg);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/internal/Common/LanguageChangedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Common/LanguageChangedSignalType.cs
@@ -32,17 +32,6 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Queries whether there are any connected slots.
-        /// </summary>
-        /// <returns>True if there are any slots connected to the signal</returns>
-        public bool Empty()
-        {
-            bool ret = Interop.LanguageChangedSignalType.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        /// <summary>
         /// Queries the number of slots.
         /// </summary>
         /// <returns>The number of slots connected to this signal</returns>
@@ -77,15 +66,6 @@ namespace Tizen.NUI
                 Interop.LanguageChangedSignalType.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        /// <summary>
-        /// Emits the signal.
-        /// </summary>
-        public void Emit(int arg)
-        {
-            Interop.LanguageChangedSignalType.Emit(SwigCPtr, arg);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/internal/Common/LongPressGestureDetectedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/LongPressGestureDetectedSignal.cs
@@ -29,13 +29,6 @@ namespace Tizen.NUI
             Interop.LongPressGestureDetectedSignal.DeleteLongPressGestureDetectedSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.LongPressGestureDetectedSignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.LongPressGestureDetectedSignal.GetConnectionCount(SwigCPtr);
@@ -59,12 +52,6 @@ namespace Tizen.NUI
                 Interop.LongPressGestureDetectedSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(View arg1, LongPressGesture arg2)
-        {
-            Interop.LongPressGestureDetectedSignal.Emit(SwigCPtr, View.getCPtr(arg1), LongPressGesture.getCPtr(arg2));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public LongPressGestureDetectedSignal() : this(Interop.LongPressGestureDetectedSignal.NewLongPressGestureDetectedSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/LowBatterySignalType.cs
+++ b/src/Tizen.NUI/src/internal/Common/LowBatterySignalType.cs
@@ -32,17 +32,6 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Empty
-        /// </summary>
-        /// <returns>true if there is no signal attached</returns>
-        public bool Empty()
-        {
-            bool ret = Interop.LowBatterySignal.LowBatterySignalTypeEmpty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        /// <summary>
         /// GetConnectionCount
         /// </summary>
         /// <returns>number of attached signals</returns>
@@ -77,12 +66,6 @@ namespace Tizen.NUI
                 Interop.LowBatterySignal.LowBatterySignalTypeDisconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        internal void Emit(Application.BatteryStatus arg)
-        {
-            Interop.LowBatterySignal.LowBatterySignalTypeEmit(SwigCPtr, (int)arg);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/internal/Common/LowMemorySignalType.cs
+++ b/src/Tizen.NUI/src/internal/Common/LowMemorySignalType.cs
@@ -28,13 +28,6 @@ namespace Tizen.NUI
             Interop.LowMemorySignalType.DeleteLowMemorySignalType(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.LowMemorySignalType.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.LowMemorySignalType.GetConnectionCount(SwigCPtr);
@@ -58,12 +51,6 @@ namespace Tizen.NUI
                 Interop.LowMemorySignalType.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        internal void Emit(Application.MemoryStatus arg)
-        {
-            Interop.LowMemorySignalType.Emit(SwigCPtr, (int)arg);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public LowMemorySignalType() : this(Interop.LowMemorySignalType.NewLowMemorySignalType(), true)

--- a/src/Tizen.NUI/src/internal/Common/PanGestureDetectedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/PanGestureDetectedSignal.cs
@@ -29,13 +29,6 @@ namespace Tizen.NUI
             Interop.PanGestureDetector.DeletePanGestureDetectedSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.PanGestureDetector.PanGestureDetectedSignalEmpty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.PanGestureDetector.PanGestureDetectedSignalGetConnectionCount(SwigCPtr);
@@ -59,12 +52,6 @@ namespace Tizen.NUI
                 Interop.PanGestureDetector.PanGestureDetectedSignalDisconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(View arg1, PanGesture arg2)
-        {
-            Interop.PanGestureDetector.PanGestureDetectedSignalEmit(SwigCPtr, View.getCPtr(arg1), PanGesture.getCPtr(arg2));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public PanGestureDetectedSignal() : this(Interop.PanGestureDetector.NewPanGestureDetectedSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/PinchGestureDetectedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/PinchGestureDetectedSignal.cs
@@ -30,13 +30,6 @@ namespace Tizen.NUI
             Interop.PinchGesture.DeletePinchGestureDetectedSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.PinchGesture.PinchGestureDetectedSignalEmpty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.PinchGesture.PinchGestureDetectedSignalGetConnectionCount(SwigCPtr);
@@ -60,12 +53,6 @@ namespace Tizen.NUI
                 Interop.PinchGesture.PinchGestureDetectedSignalDisconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(View arg1, PinchGesture arg2)
-        {
-            Interop.PinchGesture.PinchGestureDetectedSignalEmit(SwigCPtr, View.getCPtr(arg1), PinchGesture.getCPtr(arg2));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public PinchGestureDetectedSignal() : this(Interop.PinchGesture.NewPinchGestureDetectedSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/PreFocusChangeSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/PreFocusChangeSignal.cs
@@ -36,13 +36,6 @@ namespace Tizen.NUI
             Interop.PreFocusSignal.DeletePreFocusChangeSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.PreFocusSignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.PreFocusSignal.GetConnectionCount(SwigCPtr);
@@ -63,13 +56,6 @@ namespace Tizen.NUI
                 Interop.PreFocusSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public View Emit(View arg1, View arg2, View.FocusDirection arg3)
-        {
-            View ret = new View(Interop.PreFocusSignal.Emit(SwigCPtr, View.getCPtr(arg1), View.getCPtr(arg2), (int)arg3), true);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
         }
 
         public PreFocusChangeSignal() : this(Interop.PreFocusSignal.NewPreFocusChangeSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/ResizedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/ResizedSignal.cs
@@ -28,13 +28,6 @@ namespace Tizen.NUI
             Interop.ResizeSignal.DeleteResizeSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.ResizeSignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.ResizeSignal.GetConnectionCount(SwigCPtr);
@@ -58,12 +51,6 @@ namespace Tizen.NUI
                 Interop.ResizeSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(Size2D arg)
-        {
-            Interop.ResizeSignal.Emit(SwigCPtr, Size2D.getCPtr(arg));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public ResizeSignal() : this(Interop.ResizeSignal.NewResizeSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/RotationGestureDetectedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/RotationGestureDetectedSignal.cs
@@ -29,13 +29,6 @@ namespace Tizen.NUI
             Interop.RotationGesture.DeleteRotationGestureDetectedSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.RotationGesture.RotationGestureDetectedSignalEmpty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.RotationGesture.RotationGestureDetectedSignalGetConnectionCount(SwigCPtr);
@@ -59,12 +52,6 @@ namespace Tizen.NUI
                 Interop.RotationGesture.RotationGestureDetectedSignalDisconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(View arg1, RotationGesture arg2)
-        {
-            Interop.RotationGesture.RotationGestureDetectedSignalEmit(SwigCPtr, View.getCPtr(arg1), RotationGesture.getCPtr(arg2));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public RotationGestureDetectedSignal() : this(Interop.RotationGesture.NewRotationGestureDetectedSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/ScrollStateChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/ScrollStateChangedSignal.cs
@@ -31,13 +31,6 @@ namespace Tizen.NUI
             Interop.ScrollStateChangedSignal.DeleteScrollStateChangedSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.ScrollStateChangedSignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.ScrollStateChangedSignal.GetConnectionCount(SwigCPtr);
@@ -61,12 +54,6 @@ namespace Tizen.NUI
                 Interop.ScrollStateChangedSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(View arg)
-        {
-            Interop.ScrollStateChangedSignal.Emit(SwigCPtr, View.getCPtr(arg));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public ScrollStateChangedSignal() : this(Interop.ScrollStateChangedSignal.NewScrollStateChangedSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/ScrollableSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/ScrollableSignal.cs
@@ -28,13 +28,6 @@ namespace Tizen.NUI
             Interop.ScrollableSignal.DeleteScrollableSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.ScrollableSignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.ScrollableSignal.GetConnectionCount(SwigCPtr);
@@ -58,12 +51,6 @@ namespace Tizen.NUI
                 Interop.ScrollableSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(Vector2 arg)
-        {
-            Interop.ScrollableSignal.Emit(SwigCPtr, Vector2.getCPtr(arg));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public ScrollableSignal() : this(Interop.ScrollableSignal.NewScrollableSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/StageWheelSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/StageWheelSignal.cs
@@ -28,13 +28,6 @@ namespace Tizen.NUI
             Interop.Wheel.DeleteStageWheelSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.Wheel.StageWheelSignalEmpty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.Wheel.StageWheelSignalGetConnectionCount(SwigCPtr);
@@ -58,12 +51,6 @@ namespace Tizen.NUI
                 Interop.Wheel.StageWheelSignalDisconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(Wheel arg)
-        {
-            Interop.Wheel.StageWheelSignalEmit(SwigCPtr, Wheel.getCPtr(arg));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public StageWheelSignal() : this(Interop.Wheel.NewStageWheelSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/StateChangedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Common/StateChangedSignalType.cs
@@ -28,13 +28,6 @@ namespace Tizen.NUI
             Interop.StateChangeSignalType.DeleteStateChangedSignalType(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.StateChangeSignalType.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.StateChangeSignalType.GetConnectionCount(SwigCPtr);
@@ -58,12 +51,6 @@ namespace Tizen.NUI
                 Interop.StateChangeSignalType.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(TTSPlayer.TTSState arg1, TTSPlayer.TTSState arg2)
-        {
-            Interop.StateChangeSignalType.Emit(SwigCPtr, (int)arg1, (int)arg2);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public StateChangedSignalType() : this(Interop.StateChangeSignalType.NewStateChangedSignalType(), true)

--- a/src/Tizen.NUI/src/internal/Common/StatusSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Common/StatusSignalType.cs
@@ -32,17 +32,6 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Queries whether there are any connected slots.
-        /// </summary>
-        /// <returns>True if there are any slots connected to the signal</returns>
-        public bool Empty()
-        {
-            bool ret = Interop.StatusSignalType.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        /// <summary>
         /// Queries the number of slots.
         /// </summary>
         /// <returns>The number of slots connected to this signal</returns>
@@ -77,16 +66,6 @@ namespace Tizen.NUI
                 Interop.StatusSignalType.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        /// <summary>
-        /// Connects a member function.
-        /// </summary>
-        /// <param name="arg">The member function to connect</param>
-        public void Emit(bool arg)
-        {
-            Interop.StatusSignalType.Emit(SwigCPtr, arg);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/internal/Common/StyleChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/StyleChangedSignal.cs
@@ -28,13 +28,6 @@ namespace Tizen.NUI
             Interop.StyleChangedSignal.DeleteStyleChangedSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.StyleChangedSignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.StyleChangedSignal.GetConnectionCount(SwigCPtr);
@@ -58,12 +51,6 @@ namespace Tizen.NUI
                 Interop.StyleChangedSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(StyleManager arg1, StyleChangeType arg2)
-        {
-            Interop.StyleChangedSignal.Emit(SwigCPtr, StyleManager.getCPtr(arg1), (int)arg2);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public StyleChangedSignal() : this(Interop.StyleChangedSignal.NewStyleChangedSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/TapGestureDetectedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/TapGestureDetectedSignal.cs
@@ -29,13 +29,6 @@ namespace Tizen.NUI
             Interop.TapGestureDetectedSignal.DeleteTapGestureDetectedSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.TapGestureDetectedSignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.TapGestureDetectedSignal.GetConnectionCount(SwigCPtr);
@@ -59,12 +52,6 @@ namespace Tizen.NUI
                 Interop.TapGestureDetectedSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(View arg1, TapGesture arg2)
-        {
-            Interop.TapGestureDetectedSignal.Emit(SwigCPtr, View.getCPtr(arg1), TapGesture.getCPtr(arg2));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public TapGestureDetectedSignal() : this(Interop.TapGestureDetectedSignal.NewTapGestureDetectedSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/TextEditorSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/TextEditorSignal.cs
@@ -30,13 +30,6 @@ namespace Tizen.NUI
             Interop.TextEditor.DeleteTextEditorSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.TextEditor.TextEditorSignalEmpty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.TextEditor.TextEditorSignalGetConnectionCount(SwigCPtr);
@@ -60,12 +53,6 @@ namespace Tizen.NUI
                 Interop.TextEditor.TextEditorSignalDisconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(TextEditor arg)
-        {
-            Interop.TextEditor.TextEditorSignalEmit(SwigCPtr, TextEditor.getCPtr(arg));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public TextEditorSignal() : this(Interop.TextEditor.NewTextEditorSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/TextFieldSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/TextFieldSignal.cs
@@ -30,13 +30,6 @@ namespace Tizen.NUI
             Interop.TextField.DeleteTextFieldSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.TextField.TextFieldSignalEmpty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.TextField.TextFieldSignalGetConnectionCount(SwigCPtr);
@@ -60,12 +53,6 @@ namespace Tizen.NUI
                 Interop.TextField.TextFieldSignalDisconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(TextField arg)
-        {
-            Interop.TextField.TextFieldSignalEmit(SwigCPtr, TextField.getCPtr(arg));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public TextFieldSignal() : this(Interop.TextField.NewTextFieldSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/TextLabelSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/TextLabelSignal.cs
@@ -31,13 +31,6 @@ namespace Tizen.NUI
             Interop.TextLabel.DeleteTextLabelSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.TextLabel.TextLabelSignalEmpty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.TextLabel.TextLabelSignalGetConnectionCount(SwigCPtr);
@@ -61,12 +54,6 @@ namespace Tizen.NUI
                 Interop.TextLabel.TextLabelSignalDisconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(TextLabel arg)
-        {
-            Interop.TextLabel.TextLabelSignalEmit(SwigCPtr, TextLabel.getCPtr(arg));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public TextLabelSignal() : this(Interop.TextLabel.NewTextLabelSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/TimerSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Common/TimerSignalType.cs
@@ -28,13 +28,6 @@ namespace Tizen.NUI
             Interop.Timer.DeleteTimerSignalType(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.Timer.TimerSignalTypeEmpty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.Timer.TimerSignalTypeGetConnectionCount(SwigCPtr);
@@ -70,13 +63,6 @@ namespace Tizen.NUI
         {
             Interop.Timer.TimerSignalTypeDisconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, callback));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        public bool Emit()
-        {
-            bool ret = Interop.Timer.TimerSignalTypeEmit(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
         }
 
         public TimerSignalType() : this(Interop.Timer.NewTimerSignalType(), true)

--- a/src/Tizen.NUI/src/internal/Common/VideoViewSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/VideoViewSignal.cs
@@ -30,13 +30,6 @@ namespace Tizen.NUI
             Interop.VideoView.DeleteVideoViewSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.VideoView.VideoViewSignalEmpty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.VideoView.VideoViewSignalGetConnectionCount(SwigCPtr);
@@ -60,12 +53,6 @@ namespace Tizen.NUI
                 Interop.VideoView.VideoViewSignalDisconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(VideoView arg)
-        {
-            Interop.VideoView.VideoViewSignalEmit(SwigCPtr, VideoView.getCPtr(arg));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public VideoViewSignal() : this(Interop.VideoView.NewVideoViewSignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/ViewResourceReadySignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/ViewResourceReadySignal.cs
@@ -30,13 +30,6 @@ namespace Tizen.NUI
             Interop.ViewResourceReadySignal.DeleteViewResourceReadySignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.ViewResourceReadySignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.ViewResourceReadySignal.GetConnectionCount(SwigCPtr);
@@ -60,12 +53,6 @@ namespace Tizen.NUI
                 Interop.ViewResourceReadySignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(View arg)
-        {
-            Interop.ViewResourceReadySignal.Emit(SwigCPtr, View.getCPtr(arg));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public ViewResourceReadySignal() : this(Interop.ViewResourceReadySignal.NewViewResourceReadySignal(), true)

--- a/src/Tizen.NUI/src/internal/Common/VisualEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/VisualEventSignal.cs
@@ -32,13 +32,6 @@ namespace Tizen.NUI
             Interop.VisualEventSignal.Delete(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.VisualEventSignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.VisualEventSignal.GetConnectionCount(SwigCPtr);
@@ -66,12 +59,6 @@ namespace Tizen.NUI
                 Interop.VisualEventSignal.Disconnect(SwigCPtr, new HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(BaseComponents.View target, int visualIndex, int signalId)
-        {
-            Interop.VisualEventSignal.Emit(SwigCPtr, BaseComponents.View.getCPtr(target), visualIndex, signalId);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         internal VisualEventSignal(IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)

--- a/src/Tizen.NUI/src/internal/Common/VoidSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/VoidSignal.cs
@@ -33,13 +33,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.VoidSignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.VoidSignal.GetConnectionCount(SwigCPtr);
@@ -68,12 +61,6 @@ namespace Tizen.NUI
         internal void Connect(ConnectionTrackerInterface connectionTracker, SWIGTYPE_p_Dali__FunctorDelegate arg1)
         {
             Interop.VoidSignal.Connect(SwigCPtr, ConnectionTrackerInterface.getCPtr(connectionTracker), SWIGTYPE_p_Dali__FunctorDelegate.getCPtr(arg1));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        public void Emit()
-        {
-            Interop.VoidSignal.Emit(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
     }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActivatedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActivatedSignalType.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class ActivatedSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ActivatedSignalType_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ActivatedSignalType_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ActivatedSignalType_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ActivatedSignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ActivatedSignalType")]
             public static extern global::System.IntPtr NewActivatedSignalType();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Animation.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Animation.cs
@@ -231,10 +231,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_Hide")]
             public static extern void Hide(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AnimationSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AnimationSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AnimationSignal_GetConnectionCount")]
             public static extern uint AnimationSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -244,6 +240,8 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AnimationSignal_Disconnect")]
             public static extern void AnimationSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
+            // TODO : This function only be used at Tizen.NUI.Components Navigator, to emit finished callback immediatly.
+            // Finished callback immediatly is not recommended, because it may cause unexpected behavior. So, must fix Navigator codes in future.
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AnimationSignal_Emit")]
             public static extern void AnimationSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ApplicationControlSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ApplicationControlSignal.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class ApplicationControlSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationControlSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationControlSignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationControlSignal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationControlSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, System.IntPtr jarg3);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ApplicationControlSignal")]
             public static extern global::System.IntPtr NewApplicationControlSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ApplicationSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ApplicationSignal.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class ApplicationSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationSignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationSignal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ApplicationSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ApplicationSignal")]
             public static extern global::System.IntPtr NewApplicationSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Capture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Capture.cs
@@ -53,10 +53,6 @@ namespace Tizen.NUI
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool IsExclusive(HandleRef capture);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Signal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SignalEmpty(HandleRef jarg1);
-
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Signal_GetConnectionCount")]
             public static extern uint SignalGetConnectionCount(HandleRef jarg1);
 
@@ -65,9 +61,6 @@ namespace Tizen.NUI
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Signal_Disconnect")]
             public static extern void SignalDisconnect(HandleRef jarg1, HandleRef jarg2);
-
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Signal_Emit")]
-            public static extern void SignalEmit(HandleRef jarg1, HandleRef jarg2, int jarg3);
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Signal_Get")]
             public static extern IntPtr Get(HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Clipboard.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Clipboard.cs
@@ -37,10 +37,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Clipboard_DataSelectedSignal")]
             public static extern global::System.IntPtr ClipboardDataSelectedSignal(global::System.Runtime.InteropServices.HandleRef clipboard);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ClipboardSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool ClipboardSignalEmpty(global::System.Runtime.InteropServices.HandleRef signal);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ClipboardSignal_GetConnectionCount")]
             public static extern uint ClipboardSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef signal);
 
@@ -49,9 +45,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ClipboardSignal_Disconnect")]
             public static extern void ClipboardSignalDisconnect(global::System.Runtime.InteropServices.HandleRef signal, global::System.Runtime.InteropServices.HandleRef clipboard);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ClipboardSignal_Emit")]
-            public static extern void ClipboardSignalEmit(global::System.Runtime.InteropServices.HandleRef signal, global::System.Runtime.InteropServices.HandleRef clipboard);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ClipboardSignal")]
             public static extern global::System.IntPtr NewClipboardSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ContentReceivedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ContentReceivedSignalType.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class ContentReceivedSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ContentReceivedSignalType_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ContentReceivedSignalType_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ContentReceivedSignalType_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ContentReceivedSignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3, string jarg4);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ContentReceivedSignalType")]
             public static extern global::System.IntPtr NewContentReceivedSignalType();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.DeviceOrientationChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.DeviceOrientationChangedSignal.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class DeviceOrientationChangedSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignalType_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignalType_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignalType_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_new_DeviceOrientationChangedSignalType")]
             public static extern global::System.IntPtr NewDeviceOrientationChangedSignalType();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.FocusChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FocusChangedSignal.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class FocusChangedSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusChangedSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusChangedSignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusChangedSignal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusChangedSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FocusChangedSignal")]
             public static extern global::System.IntPtr NewFocusChangedSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.FocusGroupChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FocusGroupChangedSignal.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class FocusGroupChangedSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusGroupChangedSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusGroupChangedSignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusGroupChangedSignal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FocusGroupChangedSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, bool jarg3);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FocusGroupChangedSignal")]
             public static extern global::System.IntPtr NewFocusGroupChangedSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GLWindowResizedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GLWindowResizedSignal.cs
@@ -23,10 +23,6 @@ namespace Tizen.NUI
     {
         internal static partial class GLWindowResizedSignal
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_ResizedSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GlWindowResizedSignalEmpty(HandleRef jarg1);
-
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_ResizedSignal_GetConnectionCount")]
             public static extern uint GlWindowResizedSignalGetConnectionCount(HandleRef jarg1);
 
@@ -35,9 +31,6 @@ namespace Tizen.NUI
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_ResizedSignal_Disconnect")]
             public static extern void GlWindowResizedSignalDisconnect(HandleRef jarg1, HandleRef jarg2);
-
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_ResizedSignal_Emit")]
-            public static extern void GlWindowResizedSignalEmit(HandleRef jarg1, HandleRef jarg2);
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_GlWindow_ResizedSignal")]
             public static extern global::System.IntPtr NewGlWindowResizedSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GLWindowVisibilityChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GLWindowVisibilityChangedSignal.cs
@@ -26,10 +26,6 @@ namespace Tizen.NUI
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal")]
             public static extern global::System.IntPtr GetSignal(HandleRef glWindow);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(HandleRef signalType);
-
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal_GetConnectionCount")]
             public static extern uint GetConnectionCount(HandleRef signalType);
 
@@ -38,9 +34,6 @@ namespace Tizen.NUI
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal_Disconnect")]
             public static extern void Disconnect(HandleRef signalType, HandleRef callback);
-
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal_Emit")]
-            public static extern void Emit(HandleRef signalType, HandleRef window, bool visibility);
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_Visibility_Changed_Signal_delete")]
             public static extern void DeleteSignal(HandleRef signalType);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GaussianBlurViewSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GaussianBlurViewSignal.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class GaussianBlurViewSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurViewSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurViewSignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurViewSignal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurViewSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_GaussianBlurViewSignal")]
             public static extern global::System.IntPtr NewGaussianBlurViewSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.KeyEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.KeyEventSignal.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class KeyEventSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyEventSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyEventSignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyEventSignal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyEventSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_KeyEventSignal")]
             public static extern global::System.IntPtr NewKeyEventSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.KeyboardEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.KeyboardEventSignal.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class KeyboardEventSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardEventSignalType_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardEventSignalType_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardEventSignalType_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardEventSignalType_Emit")]
-            public static extern global::System.IntPtr Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_KeyboardEventSignalType")]
             public static extern global::System.IntPtr NewKeyboardEventSignalType();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.KeyboardRepeatSettingsChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.KeyboardRepeatSettingsChangedSignal.cs
@@ -26,10 +26,6 @@ namespace Tizen.NUI
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_ChangedSignal")]
             public static extern global::System.IntPtr GetSignal(HandleRef jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_Changed_Signal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(HandleRef jarg1);
-
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_Changed_Signal_GetConnectionCount")]
             public static extern uint GetConnectionCount(HandleRef jarg1);
 
@@ -38,10 +34,6 @@ namespace Tizen.NUI
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_Changed_Signal_Disconnect")]
             public static extern void Disconnect(HandleRef jarg1, HandleRef jarg2);
-
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_Changed_Signal_Emit")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Emit(HandleRef jarg1);
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Keyboard_Repeat_Settings_Changed_Signal_delete")]
             public static extern void DeleteSignal(HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.KeyboardResizedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.KeyboardResizedSignalType.cs
@@ -20,10 +20,6 @@ namespace Tizen.NUI
     {
         internal static partial class KeyboardResizedSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardResizedSignalType_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardResizedSignalType_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -32,9 +28,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardResizedSignalType_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardResizedSignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_KeyboardResizedSignalType")]
             public static extern global::System.IntPtr NewKeyboardResizedSignalType();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.KeyboardTypeSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.KeyboardTypeSignalType.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class KeyboardTypeSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardTypeSignalType_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardTypeSignalType_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardTypeSignalType_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardTypeSignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_KeyboardTypeSignalType")]
             public static extern global::System.IntPtr NewKeyboardTypeSignalType();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.LanguageChangedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.LanguageChangedSignalType.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class LanguageChangedSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LanguageChangedSignalType_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LanguageChangedSignalType_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LanguageChangedSignalType_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LanguageChangedSignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_LanguageChangedSignalType")]
             public static extern global::System.IntPtr NewLanguageChangedSignalType();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.LongPressGestureDetectedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.LongPressGestureDetectedSignal.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class LongPressGestureDetectedSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetectedSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetectedSignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetectedSignal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGestureDetectedSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_LongPressGestureDetectedSignal")]
             public static extern global::System.IntPtr NewLongPressGestureDetectedSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.LowBatterySignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.LowBatterySignal.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class LowBatterySignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowBatterySignalType_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool LowBatterySignalTypeEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowBatterySignalType_GetConnectionCount")]
             public static extern uint LowBatterySignalTypeGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowBatterySignalType_Disconnect")]
             public static extern void LowBatterySignalTypeDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowBatterySignalType_Emit")]
-            public static extern void LowBatterySignalTypeEmit(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_new_LowBatterySignalType")]
             public static extern global::System.IntPtr NewLowBatterySignalType();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.LowMemorySignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.LowMemorySignal.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class LowMemorySignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowMemorySignalType_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowMemorySignalType_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowMemorySignalType_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowMemorySignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_new_LowMemorySignalType")]
             public static extern global::System.IntPtr NewLowMemorySignalType();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PanGestureDetector.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PanGestureDetector.cs
@@ -147,10 +147,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_GetScreenDistance")]
             public static extern float PanGestureGetScreenDistance(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetectedSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool PanGestureDetectedSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetectedSignal_GetConnectionCount")]
             public static extern uint PanGestureDetectedSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -159,9 +155,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetectedSignal_Disconnect")]
             public static extern void PanGestureDetectedSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetectedSignal_Emit")]
-            public static extern void PanGestureDetectedSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PanGestureDetectedSignal")]
             public static extern global::System.IntPtr NewPanGestureDetectedSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PinchGesture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PinchGesture.cs
@@ -55,10 +55,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGesture_localCenterPoint_get")]
             public static extern global::System.IntPtr LocalCenterPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetectedSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool PinchGestureDetectedSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetectedSignal_GetConnectionCount")]
             public static extern uint PinchGestureDetectedSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -67,9 +63,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetectedSignal_Disconnect")]
             public static extern void PinchGestureDetectedSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGestureDetectedSignal_Emit")]
-            public static extern void PinchGestureDetectedSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PinchGestureDetectedSignal")]
             public static extern global::System.IntPtr NewPinchGestureDetectedSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PreFocusSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PreFocusSignal.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class PreFocusSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardPreFocusChangeSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardPreFocusChangeSignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardPreFocusChangeSignal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardPreFocusChangeSignal_Emit")]
-            public static extern global::System.IntPtr Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, int jarg4);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_new_KeyboardPreFocusChangeSignal")]
             public static extern global::System.IntPtr NewPreFocusChangeSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PropertyNotifySignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PropertyNotifySignal.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class PropertyNotifySignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotifySignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotifySignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotifySignal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyNotifySignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PropertyNotifySignal")]
             public static extern global::System.IntPtr NewPropertyNotifySignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ResizedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ResizedSignal.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class ResizeSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ResizeSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ResizeSignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ResizeSignal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ResizeSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ResizeSignal")]
             public static extern global::System.IntPtr NewResizeSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.RotationGesture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.RotationGesture.cs
@@ -52,10 +52,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGesture_localCenterPoint_get")]
             public static extern global::System.IntPtr LocalCenterPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetectedSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool RotationGestureDetectedSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetectedSignal_GetConnectionCount")]
             public static extern uint RotationGestureDetectedSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -64,9 +60,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetectedSignal_Disconnect")]
             public static extern void RotationGestureDetectedSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGestureDetectedSignal_Emit")]
-            public static extern void RotationGestureDetectedSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_RotationGestureDetectedSignal")]
             public static extern global::System.IntPtr NewRotationGestureDetectedSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ScrollStateChangeSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ScrollStateChangeSignal.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class ScrollStateChangedSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollStateChangedSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollStateChangedSignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollStateChangedSignal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollStateChangedSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ScrollStateChangedSignal")]
             public static extern global::System.IntPtr NewScrollStateChangedSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ScrollView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ScrollView.cs
@@ -311,10 +311,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollView_SnapStartedSignal")]
             public static extern global::System.IntPtr SnapStartedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewSnapStartedSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool ScrollViewSnapStartedSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewSnapStartedSignal_GetConnectionCount")]
             public static extern uint ScrollViewSnapStartedSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -323,9 +319,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewSnapStartedSignal_Disconnect")]
             public static extern void ScrollViewSnapStartedSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollViewSnapStartedSignal_Emit")]
-            public static extern void ScrollViewSnapStartedSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ScrollViewSnapStartedSignal")]
             public static extern global::System.IntPtr NewScrollViewSnapStartedSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ScrollableSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ScrollableSignal.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class ScrollableSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollableSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollableSignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollableSignal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ScrollableSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ScrollableSignal")]
             public static extern global::System.IntPtr NewScrollableSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.StateChangeSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.StateChangeSignalType.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class StateChangeSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StateChangedSignalType_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StateChangedSignalType_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StateChangedSignalType_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StateChangedSignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StateChangedSignalType")]
             public static extern global::System.IntPtr NewStateChangedSignalType();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.StatusSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.StatusSignalType.cs
@@ -20,10 +20,6 @@ namespace Tizen.NUI
     {
         internal static partial class StatusSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StatusSignalType_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StatusSignalType_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -32,9 +28,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StatusSignalType_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StatusSignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StatusSignalType")]
             public static extern global::System.IntPtr NewStatusSignalType();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.StyleChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.StyleChangedSignal.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class StyleChangedSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleChangedSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleChangedSignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleChangedSignal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleChangedSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StyleChangedSignal")]
             public static extern global::System.IntPtr NewStyleChangedSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TapGestureDetectedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TapGestureDetectedSignal.cs
@@ -20,10 +20,6 @@ namespace Tizen.NUI
     {
         internal static partial class TapGestureDetectedSignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetectedSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetectedSignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -32,9 +28,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetectedSignal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGestureDetectedSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TapGestureDetectedSignal")]
             public static extern global::System.IntPtr NewTapGestureDetectedSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
@@ -177,10 +177,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_SelectionChangedSignal")]
             public static extern global::System.IntPtr SelectionChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditorSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool TextEditorSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditorSignal_GetConnectionCount")]
             public static extern uint TextEditorSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -189,9 +185,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditorSignal_Disconnect")]
             public static extern void TextEditorSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditorSignal_Emit")]
-            public static extern void TextEditorSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TextEditorSignal")]
             public static extern global::System.IntPtr NewTextEditorSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
@@ -186,10 +186,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_SelectionChangedSignal")]
             public static extern global::System.IntPtr SelectionChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextFieldSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool TextFieldSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextFieldSignal_GetConnectionCount")]
             public static extern uint TextFieldSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -198,9 +194,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextFieldSignal_Disconnect")]
             public static extern void TextFieldSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextFieldSignal_Emit")]
-            public static extern void TextFieldSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TextFieldSignal")]
             public static extern global::System.IntPtr NewTextFieldSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -151,10 +151,6 @@ namespace Tizen.NUI
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AnchorClickedSignal")]
             public static extern global::System.IntPtr AnchorClickedSignal(HandleRef jarg1);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_Empty")]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static extern bool TextLabelSignalEmpty(HandleRef jarg1);
-
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_GetConnectionCount")]
             public static extern uint TextLabelSignalGetConnectionCount(HandleRef jarg1);
 
@@ -163,9 +159,6 @@ namespace Tizen.NUI
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_Disconnect")]
             public static extern void TextLabelSignalDisconnect(HandleRef jarg1, HandleRef jarg2);
-
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_Emit")]
-            public static extern void TextLabelSignalEmit(HandleRef jarg1, HandleRef jarg2);
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TextLabelSignal")]
             public static extern global::System.IntPtr NewTextLabelSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Timer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Timer.cs
@@ -50,10 +50,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Timer_TickSignal")]
             public static extern global::System.IntPtr TickSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimerSignalType_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool TimerSignalTypeEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimerSignalType_GetConnectionCount")]
             public static extern uint TimerSignalTypeGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -62,10 +58,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimerSignalType_Disconnect")]
             public static extern void TimerSignalTypeDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TimerSignalType_Emit")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool TimerSignalTypeEmit(global::System.Runtime.InteropServices.HandleRef jarg1);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TimerSignalType")]
             public static extern global::System.IntPtr NewTimerSignalType();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VideoView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VideoView.cs
@@ -83,10 +83,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_FinishedSignal")]
             public static extern global::System.IntPtr FinishedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoViewSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool VideoViewSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoViewSignal_GetConnectionCount")]
             public static extern uint VideoViewSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -95,9 +91,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoViewSignal_Disconnect")]
             public static extern void VideoViewSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoViewSignal_Emit")]
-            public static extern void VideoViewSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VideoViewSignal")]
             public static extern global::System.IntPtr NewVideoViewSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewResourceReadySignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewResourceReadySignal.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class ViewResourceReadySignal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewResourceReadySignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewResourceReadySignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewResourceReadySignal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewResourceReadySignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ViewResourceReadySignal")]
             public static extern global::System.IntPtr NewViewResourceReadySignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VisualEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VisualEventSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
     {
         internal static partial class VisualEventSignal
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualEventSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(HandleRef jarg1);
-
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualEventSignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(HandleRef jarg1);
 
@@ -36,9 +32,6 @@ namespace Tizen.NUI
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualEventSignal_Disconnect")]
             public static extern void Disconnect(HandleRef jarg1, HandleRef jarg2);
-
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualEventSignal_Emit")]
-            public static extern void Emit(HandleRef jarg1, HandleRef jarg2, int jarg3, int jarg4);
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VisualEventSignal")]
             public static extern IntPtr New();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VoidSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VoidSignal.cs
@@ -27,10 +27,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VoidSignal")]
             public static extern void DeleteVoidSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VoidSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VoidSignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -42,9 +38,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VoidSignal_Connect__SWIG_4")]
             public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VoidSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Watch.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Watch.cs
@@ -87,10 +87,6 @@ namespace Tizen.NUI
             public static extern global::System.IntPtr WatchApplicationAmbientChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
             //for watch signal
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTimeSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool WatchTimeSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTimeSignal_GetConnectionCount")]
             public static extern uint WatchTimeSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -100,18 +96,11 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTimeSignal_Disconnect")]
             public static extern void WatchTimeSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchTimeSignal_Emit")]
-            public static extern void WatchTimeSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WatchTimeSignal")]
             public static extern global::System.IntPtr NewWatchTimeSignal();
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WatchTimeSignal")]
             public static extern void DeleteWatchTimeSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchBoolSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool WatchBoolSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchBoolSignal_GetConnectionCount")]
             public static extern uint WatchBoolSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
@@ -121,9 +110,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchBoolSignal_Disconnect")]
             public static extern void WatchBoolSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WatchBoolSignal_Emit")]
-            public static extern void WatchBoolSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, bool jarg3);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WatchBoolSignal")]
             public static extern global::System.IntPtr NewWatchBoolSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Wheel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Wheel.cs
@@ -58,10 +58,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_timeStamp_get")]
             public static extern uint TimeStampGet(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StageWheelSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool StageWheelSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StageWheelSignal_GetConnectionCount")]
             public static extern uint StageWheelSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -70,9 +66,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StageWheelSignal_Disconnect")]
             public static extern void StageWheelSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StageWheelSignal_Emit")]
-            public static extern void StageWheelSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StageWheelSignal")]
             public static extern global::System.IntPtr NewStageWheelSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WidgetView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WidgetView.cs
@@ -110,10 +110,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetView_WidgetFaultedSignal")]
             public static extern global::System.IntPtr WidgetFaultedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool WidgetViewSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewSignal_GetConnectionCount")]
             public static extern uint WidgetViewSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -122,9 +118,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewSignal_Disconnect")]
             public static extern void WidgetViewSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_WidgetViewSignal_Emit")]
-            public static extern void WidgetViewSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.WidgetViewerLib, EntryPoint = "CSharp_Dali_new_WidgetViewSignal")]
             public static extern global::System.IntPtr NewWidgetViewSignal();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowEffectEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowEffectEventSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_EventSignal")]
             public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_Event_Signal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_Event_Signal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -36,10 +32,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_Event_Signal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_Event_Signal_Emit")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3, int jarg4);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Transition_Effect_Event_Signal_delete")]
             public static extern void DeleteSignal(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowFocusSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowFocusSignalType.cs
@@ -21,10 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class WindowFocusSignalType
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowFocusSignalType_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowFocusSignalType_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -33,9 +29,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowFocusSignalType_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowFocusSignalType_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef window, bool focusIn);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowFocusSignalType")]
             public static extern global::System.IntPtr NewWindowFocusSignalType();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowMouseInOutEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowMouseInOutEventSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal")]
             public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -36,9 +32,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef mouseEvent);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowMouseInOutEventSignal")]
             public static extern void DeleteWindowMouseInOutEventSignal(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowMouseRelativeEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowMouseRelativeEventSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseRelativeEventSignal")]
             public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseRelativeEventSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseRelativeEventSignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -36,9 +32,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseRelativeEventSignal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseRelativeEventSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef mouseEvent);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowMouseRelativeEventSignal")]
             public static extern void DeleteWindowMouseRelativeEventSignal(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowMoveCompletedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowMoveCompletedSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Move_Completed_Signal")]
             public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Move_Completed_Signal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Move_Completed_Signal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -36,10 +32,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Move_Completed_Signal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Move_Completed_Signal_Emit")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Move_Completed_Signal")]
             public static extern void DeleteSignal(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowMovedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowMovedSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Moved_Signal")]
             public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Moved_Signal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Moved_Signal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -36,10 +32,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Moved_Signal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Moved_Signal_Emit")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Moved_Signal")]
             public static extern void DeleteSignal(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowOrientationChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowOrientationChangedSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Orientation_Changed_Signal")]
             public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Orientation_Changed_Signal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Orientation_Changed_Signal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -36,10 +32,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Orientation_Changed_Signal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Orientation_Changed_Signal_Emit")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Orientation_Changed_Signal")]
             public static extern void DeleteSignal(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowPointerConstraintsSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowPointerConstraintsSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal")]
             public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -36,9 +32,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef mouseEvent);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowPointerConstraintsEventSignal")]
             public static extern void DeleteWindowPointerConstraintsSignal(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowResizeCompletedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowResizeCompletedSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Resize_Completed_Signal")]
             public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Resize_Completed_Signal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Resize_Completed_Signal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -36,10 +32,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Resize_Completed_Signal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Resize_Completed_Signal_Emit")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Resize_Completed_Signal")]
             public static extern void DeleteSignal(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowVisibilityChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowVisibilityChangedSignal.cs
@@ -26,10 +26,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal")]
             public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef window);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef signalType);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal_GetConnectionCount")]
             public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef signalType);
 
@@ -38,9 +34,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef callback);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef window, bool visibility);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Visibility_Changed_Signal_delete")]
             public static extern void DeleteSignal(global::System.Runtime.InteropServices.HandleRef signalType);

--- a/src/Tizen.NUI/src/internal/Transition/TransitionSet.cs
+++ b/src/Tizen.NUI/src/internal/Transition/TransitionSet.cs
@@ -61,9 +61,8 @@ namespace Tizen.NUI
             {
                 if (transitionSetFinishedEventHandler == null && disposed == false)
                 {
-                    TransitionSetFinishedSignal finishedSignal = FinishedSignal();
-                    finishedSignal.Connect(finishedCallbackOfNative);
-                    finishedSignal.Dispose();
+                    using TransitionSetFinishedSignal finishedSignal = FinishedSignal();
+                    finishedSignal?.Connect(finishedCallbackOfNative);
                 }
                 transitionSetFinishedEventHandler += value;
             }
@@ -71,12 +70,11 @@ namespace Tizen.NUI
             {
                 transitionSetFinishedEventHandler -= value;
 
-                TransitionSetFinishedSignal finishedSignal = FinishedSignal();
-                if (transitionSetFinishedEventHandler == null && finishedSignal.Empty() == false)
+                if (transitionSetFinishedEventHandler == null && disposed == false)
                 {
-                    finishedSignal.Disconnect(finishedCallbackOfNative);
+                    using TransitionSetFinishedSignal finishedSignal = FinishedSignal();
+                    finishedSignal?.Disconnect(finishedCallbackOfNative);
                 }
-                finishedSignal.Dispose();
             }
         }
 
@@ -180,9 +178,8 @@ namespace Tizen.NUI
 
             if (transitionSetFinishedEventHandler != null)
             {
-                TransitionSetFinishedSignal finishedSignal = FinishedSignal();
+                using TransitionSetFinishedSignal finishedSignal = FinishedSignal();
                 finishedSignal?.Disconnect(finishedCallbackOfNative);
-                finishedSignal?.Dispose();
                 transitionSetFinishedEventHandler = null;
             }
 

--- a/src/Tizen.NUI/src/internal/Utility/GaussianBlurViewSignal.cs
+++ b/src/Tizen.NUI/src/internal/Utility/GaussianBlurViewSignal.cs
@@ -28,13 +28,6 @@ namespace Tizen.NUI
             Interop.GaussianBlurViewSignal.DeleteGaussianBlurViewSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.GaussianBlurViewSignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.GaussianBlurViewSignal.GetConnectionCount(SwigCPtr);
@@ -58,12 +51,6 @@ namespace Tizen.NUI
                 Interop.GaussianBlurViewSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(GaussianBlurView arg)
-        {
-            Interop.GaussianBlurViewSignal.Emit(SwigCPtr, GaussianBlurView.getCPtr(arg));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public GaussianBlurViewSignal() : this(Interop.GaussianBlurViewSignal.NewGaussianBlurViewSignal(), true)

--- a/src/Tizen.NUI/src/internal/Widget/WidgetViewSignal.cs
+++ b/src/Tizen.NUI/src/internal/Widget/WidgetViewSignal.cs
@@ -39,17 +39,6 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Queries whether there are any connected slots.
-        /// </summary>
-        /// <returns>True if there are any slots connected to the signal</returns>
-        internal bool Empty()
-        {
-            bool ret = Interop.WidgetView.WidgetViewSignalEmpty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        /// <summary>
         /// Queries the number of slots.
         /// </summary>
         /// <returns>The number of slots connected to this signal</returns>
@@ -84,16 +73,6 @@ namespace Tizen.NUI
                 Interop.WidgetView.WidgetViewSignalDisconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        /// <summary>
-        /// Connects a member function.
-        /// </summary>
-        /// <param name="arg">The member function to connect</param>
-        internal void Emit(WidgetView arg)
-        {
-            Interop.WidgetView.WidgetViewSignalEmit(SwigCPtr, WidgetView.getCPtr(arg));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/internal/Window/WindowEffectSignal.cs
+++ b/src/Tizen.NUI/src/internal/Window/WindowEffectSignal.cs
@@ -29,14 +29,6 @@ namespace Tizen.NUI
             Interop.WindowTransitionEffectSignal.DeleteSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.WindowTransitionEffectSignal.Empty(SwigCPtr);
-
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.WindowTransitionEffectSignal.GetConnectionCount(SwigCPtr);
@@ -61,13 +53,6 @@ namespace Tizen.NUI
                 Interop.WindowTransitionEffectSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public bool Emit(Window arg1, int state, int type)
-        {
-            bool ret = Interop.WindowTransitionEffectSignal.Emit(SwigCPtr, Window.getCPtr(arg1), state, type);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
         }
 
         public WindowTransitionEffectSignal(Window window) : this(Interop.WindowTransitionEffectSignal.GetSignal(Window.getCPtr(window)), false)

--- a/src/Tizen.NUI/src/internal/Window/WindowFocusSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Window/WindowFocusSignalType.cs
@@ -28,13 +28,6 @@ namespace Tizen.NUI
             Interop.WindowFocusSignalType.DeleteWindowFocusSignalType(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.WindowFocusSignalType.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.WindowFocusSignalType.GetConnectionCount(SwigCPtr);
@@ -58,12 +51,6 @@ namespace Tizen.NUI
                 Interop.WindowFocusSignalType.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(Window window, bool focusIn)
-        {
-            Interop.WindowFocusSignalType.Emit(SwigCPtr, Window.getCPtr(window), focusIn);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public WindowFocusSignalType() : this(Interop.WindowFocusSignalType.NewWindowFocusSignalType(), true)

--- a/src/Tizen.NUI/src/internal/Window/WindowMouseInOutEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Window/WindowMouseInOutEventSignal.cs
@@ -33,17 +33,6 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Queries whether there are any connected slots.
-        /// </summary>
-        /// <returns>True if there are any slots connected to the signal</returns>
-        public bool Empty()
-        {
-            bool ret = Interop.WindowMouseInOutEventSignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        /// <summary>
         /// Queries the number of slots.
         /// </summary>
         /// <returns>The number of slots connected to this signal</returns>
@@ -78,17 +67,6 @@ namespace Tizen.NUI
                 Interop.WindowMouseInOutEventSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        /// <summary>
-        /// Emits the signal.
-        /// </summary>
-        /// <param name="window">The first value to pass to callbacks</param>
-        /// <param name="mouseInOut">The second value to pass to callbacks</param>
-        public void Emit(Window window, MouseInOut mouseInOut)
-        {
-            Interop.WindowMouseInOutEventSignal.Emit(SwigCPtr, Window.getCPtr(window), MouseInOut.getCPtr(mouseInOut));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/internal/Window/WindowMouseRelativeEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Window/WindowMouseRelativeEventSignal.cs
@@ -33,17 +33,6 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Queries whether there are any connected slots.
-        /// </summary>
-        /// <returns>True if there are any slots connected to the signal</returns>
-        public bool Empty()
-        {
-            bool ret = Interop.WindowMouseRelativeEventSignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        /// <summary>
         /// Queries the number of slots.
         /// </summary>
         /// <returns>The number of slots connected to this signal</returns>
@@ -78,17 +67,6 @@ namespace Tizen.NUI
                 Interop.WindowMouseRelativeEventSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        /// <summary>
-        /// Emits the signal.
-        /// </summary>
-        /// <param name="window">The first value to pass to callbacks</param>
-        /// <param name="MouseRelative">The second value to pass to callbacks</param>
-        public void Emit(Window window, MouseRelative MouseRelative)
-        {
-            Interop.WindowMouseRelativeEventSignal.Emit(SwigCPtr, Window.getCPtr(window), MouseRelative.getCPtr(MouseRelative));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/internal/Window/WindowMoveCompletedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Window/WindowMoveCompletedSignal.cs
@@ -28,14 +28,6 @@ namespace Tizen.NUI
             Interop.WindowMoveCompletedSignal.DeleteSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.WindowMoveCompletedSignal.Empty(SwigCPtr);
-
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.WindowMoveCompletedSignal.GetConnectionCount(SwigCPtr);
@@ -60,13 +52,6 @@ namespace Tizen.NUI
                 Interop.WindowMoveCompletedSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public bool Emit(Window window, Position2D position)
-        {
-            bool ret = Interop.WindowMoveCompletedSignal.Emit(SwigCPtr, Window.getCPtr(window), Position2D.getCPtr(position));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
         }
 
         public WindowMoveCompletedSignal(Window window) : this(Interop.WindowMoveCompletedSignal.GetSignal(Window.getCPtr(window)), false)

--- a/src/Tizen.NUI/src/internal/Window/WindowMovedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Window/WindowMovedSignal.cs
@@ -28,14 +28,6 @@ namespace Tizen.NUI
             Interop.WindowMovedSignal.DeleteSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.WindowMovedSignal.Empty(SwigCPtr);
-
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.WindowMovedSignal.GetConnectionCount(SwigCPtr);
@@ -60,13 +52,6 @@ namespace Tizen.NUI
                 Interop.WindowMovedSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public bool Emit(Window window, Position2D position)
-        {
-            bool ret = Interop.WindowMovedSignal.Emit(SwigCPtr, Window.getCPtr(window), Position2D.getCPtr(position));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
         }
 
         public WindowMovedSignal(Window window) : this(Interop.WindowMovedSignal.GetSignal(Window.getCPtr(window)), false)

--- a/src/Tizen.NUI/src/internal/Window/WindowOrientationChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Window/WindowOrientationChangedSignal.cs
@@ -28,14 +28,6 @@ namespace Tizen.NUI
             Interop.WindowOrientationChangedSignal.DeleteSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.WindowOrientationChangedSignal.Empty(SwigCPtr);
-
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.WindowOrientationChangedSignal.GetConnectionCount(SwigCPtr);
@@ -60,13 +52,6 @@ namespace Tizen.NUI
                 Interop.WindowOrientationChangedSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public bool Emit(Window window, int orientation)
-        {
-            bool ret = Interop.WindowOrientationChangedSignal.Emit(SwigCPtr, Window.getCPtr(window), orientation);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
         }
 
         public WindowOrientationChangedSignal(Window window) : this(Interop.WindowOrientationChangedSignal.GetSignal(Window.getCPtr(window)), false)

--- a/src/Tizen.NUI/src/internal/Window/WindowPointerConstraintsSignal.cs
+++ b/src/Tizen.NUI/src/internal/Window/WindowPointerConstraintsSignal.cs
@@ -33,17 +33,6 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Queries whether there are any connected slots.
-        /// </summary>
-        /// <returns>True if there are any slots connected to the signal</returns>
-        public bool Empty()
-        {
-            bool ret = Interop.WindowPointerConstraintsSignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        /// <summary>
         /// Queries the number of slots.
         /// </summary>
         /// <returns>The number of slots connected to this signal</returns>
@@ -78,17 +67,6 @@ namespace Tizen.NUI
                 Interop.WindowPointerConstraintsSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        /// <summary>
-        /// Emits the signal.
-        /// </summary>
-        /// <param name="window">The first value to pass to callbacks</param>
-        /// <param name="pointerConstraints">The second value to pass to callbacks</param>
-        public void Emit(Window window, PointerConstraints pointerConstraints)
-        {
-            Interop.WindowPointerConstraintsSignal.Emit(SwigCPtr, Window.getCPtr(window), PointerConstraints.getCPtr(pointerConstraints));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/internal/Window/WindowResizeCompletedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Window/WindowResizeCompletedSignal.cs
@@ -28,14 +28,6 @@ namespace Tizen.NUI
             Interop.WindowResizeCompletedSignal.DeleteSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.WindowResizeCompletedSignal.Empty(SwigCPtr);
-
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.WindowResizeCompletedSignal.GetConnectionCount(SwigCPtr);
@@ -60,13 +52,6 @@ namespace Tizen.NUI
                 Interop.WindowResizeCompletedSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public bool Emit(Window window, Size2D size)
-        {
-            bool ret = Interop.WindowResizeCompletedSignal.Emit(SwigCPtr, Window.getCPtr(window), Size2D.getCPtr(size));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
         }
 
         public WindowResizeCompletedSignal(Window window) : this(Interop.WindowResizeCompletedSignal.GetSignal(Window.getCPtr(window)), false)

--- a/src/Tizen.NUI/src/internal/Window/WindowVisibilityChangedEvent.cs
+++ b/src/Tizen.NUI/src/internal/Window/WindowVisibilityChangedEvent.cs
@@ -33,14 +33,6 @@ namespace Tizen.NUI
             Interop.WindowVisibilityChangedSignal.DeleteSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.WindowVisibilityChangedSignal.Empty(SwigCPtr);
-
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.WindowVisibilityChangedSignal.GetConnectionCount(SwigCPtr);
@@ -65,12 +57,6 @@ namespace Tizen.NUI
                 Interop.WindowVisibilityChangedSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(Window window, bool visibility)
-        {
-            Interop.WindowVisibilityChangedSignal.Emit(SwigCPtr, Window.getCPtr(window), visibility);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Animation/Animation.cs
+++ b/src/Tizen.NUI/src/public/Animation/Animation.cs
@@ -117,9 +117,8 @@ namespace Tizen.NUI
             {
                 if (animationFinishedEventHandler == null && disposed == false)
                 {
-                    AnimationSignal finishedSignal = FinishedSignal();
-                    finishedSignal.Connect(finishedCallbackOfNative);
-                    finishedSignal.Dispose();
+                    using AnimationSignal finishedSignal = FinishedSignal();
+                    finishedSignal?.Connect(finishedCallbackOfNative);
                 }
                 animationFinishedEventHandler += value;
             }
@@ -127,12 +126,11 @@ namespace Tizen.NUI
             {
                 animationFinishedEventHandler -= value;
 
-                AnimationSignal finishedSignal = FinishedSignal();
-                if (animationFinishedEventHandler == null && finishedSignal.Empty() == false)
+                if (animationFinishedEventHandler == null && disposed == false)
                 {
-                    finishedSignal.Disconnect(finishedCallbackOfNative);
+                    using AnimationSignal finishedSignal = FinishedSignal();
+                    finishedSignal?.Disconnect(finishedCallbackOfNative);
                 }
-                finishedSignal.Dispose();
             }
         }
 
@@ -153,9 +151,8 @@ namespace Tizen.NUI
                 if (animationProgressReachedEventHandler == null)
                 {
                     animationProgressReachedEventCallback = OnProgressReached;
-                    AnimationSignal progressReachedSignal = ProgressReachedSignal();
+                    using AnimationSignal progressReachedSignal = ProgressReachedSignal();
                     progressReachedSignal?.Connect(animationProgressReachedEventCallback);
-                    progressReachedSignal?.Dispose();
                 }
 
                 animationProgressReachedEventHandler += value;
@@ -164,12 +161,12 @@ namespace Tizen.NUI
             {
                 animationProgressReachedEventHandler -= value;
 
-                AnimationSignal progressReachedSignal = ProgressReachedSignal();
-                if (animationProgressReachedEventHandler == null && progressReachedSignal?.Empty() == false)
+                if (animationProgressReachedEventHandler == null && animationProgressReachedEventCallback != null)
                 {
+                    using AnimationSignal progressReachedSignal = ProgressReachedSignal();
                     progressReachedSignal?.Disconnect(animationProgressReachedEventCallback);
+                    animationProgressReachedEventCallback = null;
                 }
-                progressReachedSignal.Dispose();
             }
         }
 
@@ -1890,17 +1887,15 @@ namespace Tizen.NUI
 
             if (animationFinishedEventHandler != null)
             {
-                AnimationSignal finishedSignal = FinishedSignal();
+                using AnimationSignal finishedSignal = FinishedSignal();
                 finishedSignal?.Disconnect(finishedCallbackOfNative);
-                finishedSignal?.Dispose();
                 animationFinishedEventHandler = null;
             }
 
             if (animationProgressReachedEventCallback != null)
             {
-                AnimationSignal progressReachedSignal = ProgressReachedSignal();
+                using AnimationSignal progressReachedSignal = ProgressReachedSignal();
                 progressReachedSignal?.Disconnect(animationProgressReachedEventCallback);
-                progressReachedSignal?.Dispose();
                 animationProgressReachedEventCallback = null;
             }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -1418,7 +1418,7 @@ namespace Tizen.NUI.BaseComponents
                 {
                     using VisualEventSignal visualEvent = VisualEventSignal();
                     visualEvent?.Disconnect(visualEventSignalCallback);
-                    if (visualEvent?.Empty() == true)
+                    if (visualEvent?.GetConnectionCount() == 0u)
                     {
                         ReleaseSafeCallback(ref visualEventSignalCallback);
                     }
@@ -1626,18 +1626,12 @@ namespace Tizen.NUI.BaseComponents
                 {
                     using VisualEventSignal visualEvent = VisualEventSignal();
                     visualEvent?.Disconnect(visualEventSignalCallback);
-                    if (visualEvent?.Empty() == true)
+                    if (visualEvent?.GetConnectionCount() == 0u)
                     {
                         ReleaseSafeCallback(ref visualEventSignalCallback);
                     }
                 }
             }
-        }
-
-        internal void EmitVisualEventSignal(int visualIndex, int signalId)
-        {
-            using VisualEventSignal visualEvent = VisualEventSignal();
-            visualEvent?.Emit(this, visualIndex, signalId);
         }
 
         internal VisualEventSignal VisualEventSignal()

--- a/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
@@ -241,10 +241,11 @@ namespace Tizen.NUI.BaseComponents
             remove
             {
                 videoViewFinishedEventHandler -= value;
-                using var signal = FinishedSignal();
-                if (videoViewFinishedEventHandler == null && signal.Empty() == false)
+                if (videoViewFinishedEventHandler == null && videoViewFinishedCallbackDelegate != null)
                 {
+                    using var signal = FinishedSignal();
                     signal.Disconnect(videoViewFinishedCallbackDelegate);
+                    videoViewFinishedCallbackDelegate = null;
                 }
             }
         }
@@ -759,6 +760,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 using var signal = FinishedSignal();
                 signal.Disconnect(videoViewFinishedCallbackDelegate);
+                videoViewFinishedCallbackDelegate = null;
             }
 
             base.Dispose(type);

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -499,6 +499,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual bool AccessibilityDoAction(string name)
         {
+            // TODO : Can we emit native callback signal directly here?
             if (name == AccessibilityActivateAction)
             {
                 using var handle = GetControl();

--- a/src/Tizen.NUI/src/public/Common/PropertyNotification.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyNotification.cs
@@ -81,17 +81,11 @@ namespace Tizen.NUI
             remove
             {
                 propertyNotificationNotifyEventHandler -= value;
-                if (propertyNotificationNotifyEventHandler == null)
+                if (propertyNotificationNotifyEventHandler == null && propertyNotificationNotifyEventCallback != null)
                 {
                     using PropertyNotifySignal signal = new PropertyNotifySignal(Interop.PropertyNotification.NotifySignal(SwigCPtr), false);
-                    if (signal?.Empty() == false)
-                    {
-                        signal?.Disconnect(propertyNotificationNotifyEventCallback);
-                        if (signal?.Empty() == true)
-                        {
-                            propertyNotificationNotifyEventCallback = null;
-                        }
-                    }
+                    signal?.Disconnect(propertyNotificationNotifyEventCallback);
+                    propertyNotificationNotifyEventCallback = null;
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/Common/PropertyNotifySignal.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyNotifySignal.cs
@@ -38,17 +38,6 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Queries whether there are any connected slots.
-        /// </summary>
-        /// <returns>True if there are any slots connected to the signal.</returns>
-        internal bool Empty()
-        {
-            bool ret = Interop.PropertyNotifySignal.Empty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        /// <summary>
         /// Queries the number of slots.
         /// </summary>
         /// <returns>The number of slots connected to this signal</returns>
@@ -83,16 +72,6 @@ namespace Tizen.NUI
                 Interop.PropertyNotifySignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        /// <summary>
-        /// Emits a signal with 1 parameter.
-        /// </summary>
-        /// <param name="arg">The first value to pass to callbacks.</param>
-        internal void Emit(PropertyNotification arg)
-        {
-            Interop.PropertyNotifySignal.Emit(SwigCPtr, PropertyNotification.getCPtr(arg));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// This will not be public opened.

--- a/src/Tizen.NUI/src/public/Common/StyleManager.cs
+++ b/src/Tizen.NUI/src/public/Common/StyleManager.cs
@@ -74,10 +74,11 @@ namespace Tizen.NUI
             remove
             {
                 styleManagerStyleChangedEventHandler -= value;
-                using var signal = StyleChangedSignal();
-                if (styleManagerStyleChangedEventHandler == null && signal.Empty() == false)
+                if (styleManagerStyleChangedEventHandler == null && styleManagerStyleChangedCallbackDelegate != null)
                 {
+                    using var signal = StyleChangedSignal();
                     signal.Disconnect(styleManagerStyleChangedCallbackDelegate);
+                    styleManagerStyleChangedCallbackDelegate = null;
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/Events/LongPressGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/LongPressGestureDetector.cs
@@ -112,10 +112,11 @@ namespace Tizen.NUI
             remove
             {
                 detectedEventHandler -= value;
-                using var signal = DetectedSignal();
-                if (detectedEventHandler == null && signal.Empty() == false)
+                if (detectedEventHandler == null && detectedCallback != null)
                 {
+                    using var signal = DetectedSignal();
                     signal.Disconnect(detectedCallback);
+                    detectedCallback = null;
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
@@ -100,17 +100,11 @@ namespace Tizen.NUI
             remove
             {
                 detectedEventHandler -= value;
-                if (detectedEventHandler == null)
+                if (detectedEventHandler == null && detectedCallback != null)
                 {
                     using PanGestureDetectedSignal signal = new PanGestureDetectedSignal(Interop.PanGestureDetector.DetectedSignal(SwigCPtr), false);
-                    if (signal?.Empty() == false)
-                    {
-                        signal?.Disconnect(detectedCallback);
-                        if (signal?.Empty() == true)
-                        {
-                            detectedCallback = null;
-                        }
-                    }
+                    signal?.Disconnect(detectedCallback);
+                    detectedCallback = null;
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/Events/PinchGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/PinchGestureDetector.cs
@@ -85,10 +85,11 @@ namespace Tizen.NUI
             remove
             {
                 detectedEventHandler -= value;
-                using var signal = DetectedSignal();
-                if (detectedEventHandler == null && signal.Empty() == false)
+                if (detectedEventHandler == null && detectedCallback != null)
                 {
+                    using var signal = DetectedSignal();
                     signal.Disconnect(detectedCallback);
+                    detectedCallback = null;
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/Events/RotationGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/RotationGestureDetector.cs
@@ -85,10 +85,11 @@ namespace Tizen.NUI
             remove
             {
                 detectedEventHandler -= value;
-                using var signal = DetectedSignal();
-                if (detectedEventHandler == null && signal.Empty() == false)
+                if (detectedEventHandler == null && detectedCallback != null)
                 {
+                    using var signal = DetectedSignal();
                     signal.Disconnect(detectedCallback);
+                    detectedCallback = null;
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/Events/TapGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/TapGestureDetector.cs
@@ -97,10 +97,11 @@ namespace Tizen.NUI
             remove
             {
                 _detectedEventHandler -= value;
-                using var signal = DetectedSignal();
-                if (_detectedEventHandler == null && signal.Empty() == false)
+                if (_detectedEventHandler == null && _detectedCallback != null)
                 {
+                    using var signal = DetectedSignal();
                     signal.Disconnect(_detectedCallback);
+                    _detectedCallback = null;
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/Input/FocusManager.cs
+++ b/src/Tizen.NUI/src/public/Input/FocusManager.cs
@@ -104,10 +104,11 @@ namespace Tizen.NUI
             remove
             {
                 preFocusChangeEventHandler -= value;
-                using PreFocusChangeSignal signal = PreFocusChangeSignal();
-                if (preFocusChangeEventHandler == null && signal?.Empty() == false)
+                if (preFocusChangeEventHandler == null && preFocusChangeCallback != null)
                 {
+                    using PreFocusChangeSignal signal = PreFocusChangeSignal();
                     signal?.Disconnect(preFocusChangeCallback);
+                    preFocusChangeCallback = null;
                 }
             }
         }
@@ -140,10 +141,11 @@ namespace Tizen.NUI
             {
                 focusChangingEventHandler -= value;
                 //this is same as old PreFocusChangeSignal, so the body will be same. (only name is changed, behavior is same)
-                using PreFocusChangeSignal signal = PreFocusChangeSignal();
-                if (focusChangingEventHandler == null && signal?.Empty() == false)
+                if (focusChangingEventHandler == null && focusChangingCallback != null)
                 {
+                    using PreFocusChangeSignal signal = PreFocusChangeSignal();
                     signal?.Disconnect(focusChangingCallback);
+                    focusChangingCallback = null;
                 }
             }
         }
@@ -168,10 +170,11 @@ namespace Tizen.NUI
             {
                 focusChangedEventHandler -= value;
 
-                using FocusChangedSignal signal = FocusChangedSignal();
-                if (focusChangedEventCallback == null && signal?.Empty() == false)
+                if (focusChangedEventHandler == null && focusChangedEventCallback != null)
                 {
+                    using FocusChangedSignal signal = FocusChangedSignal();
                     signal?.Disconnect(focusChangedEventCallback);
+                    focusChangedEventCallback = null;
                 }
             }
         }
@@ -198,10 +201,11 @@ namespace Tizen.NUI
             {
                 focusGroupChangedEventHandler -= value;
 
-                using FocusGroupChangedSignal signal = FocusGroupChangedSignal();
-                if (focusGroupChangedEventCallback == null && signal?.Empty() == false)
+                if (focusGroupChangedEventHandler == null && focusGroupChangedEventCallback != null)
                 {
+                    using FocusGroupChangedSignal signal = FocusGroupChangedSignal();
                     signal?.Disconnect(focusGroupChangedEventCallback);
+                    focusGroupChangedEventCallback = null;
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/Utility/Capture.cs
+++ b/src/Tizen.NUI/src/public/Utility/Capture.cs
@@ -424,13 +424,6 @@ namespace Tizen.NUI
             // Do nothing because native didn't create new signal handle.
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.Capture.SignalEmpty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.Capture.SignalGetConnectionCount(SwigCPtr);
@@ -454,12 +447,6 @@ namespace Tizen.NUI
                 Interop.Capture.SignalDisconnect(SwigCPtr, new HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(Capture src, bool success)
-        {
-            Interop.Capture.SignalEmit(SwigCPtr, src.SwigCPtr, (success ? 0 : 1));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Utility/TTSPlayer.cs
+++ b/src/Tizen.NUI/src/public/Utility/TTSPlayer.cs
@@ -66,7 +66,7 @@ namespace Tizen.NUI
                 {
                     stateChangedEventCallback = OnStateChanged;
                     using var signal = StateChangedSignal();
-                    signal.Connect(stateChangedEventCallback);
+                    signal?.Connect(stateChangedEventCallback);
                 }
 
                 stateChangedEventHandler += value;
@@ -74,10 +74,11 @@ namespace Tizen.NUI
             remove
             {
                 stateChangedEventHandler -= value;
-                using var signal = StateChangedSignal();
-                if (stateChangedEventHandler == null && signal.Empty() == false && stateChangedEventCallback != null)
+                if (stateChangedEventHandler == null && stateChangedEventCallback != null)
                 {
-                    signal.Disconnect(stateChangedEventCallback);
+                    using var signal = StateChangedSignal();
+                    signal?.Disconnect(stateChangedEventCallback);
+                    stateChangedEventCallback = null;
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/Utility/Timer.cs
+++ b/src/Tizen.NUI/src/public/Utility/Timer.cs
@@ -104,9 +104,9 @@ namespace Tizen.NUI
             remove
             {
                 timerTickEventHandler -= value;
-                using var signal = TickSignal();
-                if (timerTickEventHandler == null && signal.Empty() == false)
+                if (timerTickEventHandler == null && disposed == false)
                 {
+                    using var signal = TickSignal();
                     signal.Disconnect(timerTickCallbackOfNative);
                 }
             }

--- a/src/Tizen.NUI/src/public/Widget/WidgetView.cs
+++ b/src/Tizen.NUI/src/public/Widget/WidgetView.cs
@@ -286,12 +286,12 @@ namespace Tizen.NUI
             {
                 widgetAddedEventHandler -= value;
 
-                WidgetViewSignal widgetAdded = WidgetAddedSignal();
-                if (widgetAddedEventHandler == null && widgetAdded?.Empty() == false)
+                if (widgetAddedEventHandler == null && widgetAddedEventCallback != null)
                 {
+                    using WidgetViewSignal widgetAdded = WidgetAddedSignal();
                     widgetAdded?.Disconnect(widgetAddedEventCallback);
+                    widgetAddedEventCallback = null;
                 }
-                widgetAdded?.Dispose();
             }
         }
 
@@ -319,12 +319,12 @@ namespace Tizen.NUI
             {
                 widgetContentUpdatedEventHandler -= value;
 
-                WidgetViewSignal widgetContentUpdated = WidgetContentUpdatedSignal();
-                if (widgetContentUpdatedEventHandler == null && widgetContentUpdated?.Empty() == false)
+                if (widgetContentUpdatedEventHandler == null && widgetContentUpdatedEventCallback != null)
                 {
+                    using WidgetViewSignal widgetContentUpdated = WidgetContentUpdatedSignal();
                     widgetContentUpdated?.Disconnect(widgetContentUpdatedEventCallback);
+                    widgetContentUpdatedEventCallback = null;
                 }
-                widgetContentUpdated?.Dispose();
             }
         }
 
@@ -352,12 +352,12 @@ namespace Tizen.NUI
             {
                 widgetDeletedEventHandler -= value;
 
-                WidgetViewSignal widgetDeleted = WidgetDeletedSignal();
-                if (widgetDeletedEventHandler == null && widgetDeleted?.Empty() == false)
+                if (widgetDeletedEventHandler == null && widgetDeletedEventCallback != null)
                 {
+                    using WidgetViewSignal widgetDeleted = WidgetDeletedSignal();
                     widgetDeleted?.Disconnect(widgetDeletedEventCallback);
+                    widgetDeletedEventCallback = null;
                 }
-                widgetDeleted?.Dispose();
             }
         }
 
@@ -385,12 +385,12 @@ namespace Tizen.NUI
             {
                 widgetCreationAbortedEventHandler -= value;
 
-                WidgetViewSignal widgetCreationAborted = WidgetCreationAbortedSignal();
-                if (widgetCreationAbortedEventHandler == null && widgetCreationAborted?.Empty() == false)
+                if (widgetCreationAbortedEventHandler == null && widgetCreationAbortedEventCallback != null)
                 {
+                    using WidgetViewSignal widgetCreationAborted = WidgetCreationAbortedSignal();
                     widgetCreationAborted?.Disconnect(widgetCreationAbortedEventCallback);
+                    widgetCreationAbortedEventCallback = null;
                 }
-                widgetCreationAborted?.Dispose();
             }
         }
 
@@ -418,12 +418,12 @@ namespace Tizen.NUI
             {
                 widgetUpdatePeriodChangedEventHandler -= value;
 
-                WidgetViewSignal widgetUpdatePeriodChanged = WidgetUpdatePeriodChangedSignal();
-                if (widgetUpdatePeriodChangedEventHandler == null && widgetUpdatePeriodChanged?.Empty() == false)
+                if (widgetUpdatePeriodChangedEventHandler == null && widgetUpdatePeriodChangedEventCallback != null)
                 {
+                    using WidgetViewSignal widgetUpdatePeriodChanged = WidgetUpdatePeriodChangedSignal();
                     widgetUpdatePeriodChanged?.Disconnect(widgetUpdatePeriodChangedEventCallback);
+                    widgetUpdatePeriodChangedEventCallback = null;
                 }
-                widgetUpdatePeriodChanged?.Dispose();
             }
         }
 
@@ -451,12 +451,12 @@ namespace Tizen.NUI
             {
                 widgetFaultedEventHandler -= value;
 
-                WidgetViewSignal widgetFaulted = WidgetFaultedSignal();
-                if (widgetFaultedEventHandler == null && widgetFaulted?.Empty() == false)
+                if (widgetFaultedEventHandler == null && widgetFaultedEventCallback != null)
                 {
+                    using WidgetViewSignal widgetFaulted = WidgetFaultedSignal();
                     widgetFaulted?.Disconnect(widgetFaultedEventCallback);
+                    widgetFaultedEventCallback = null;
                 }
-                widgetFaulted?.Dispose();
             }
         }
 
@@ -1035,6 +1035,7 @@ namespace Tizen.NUI
                 WidgetViewSignal widgetAdded = this.WidgetAddedSignal();
                 widgetAdded?.Disconnect(widgetAddedEventCallback);
                 widgetAdded?.Dispose();
+                widgetAddedEventCallback = null;
             }
 
             if (widgetContentUpdatedEventCallback != null)
@@ -1042,6 +1043,7 @@ namespace Tizen.NUI
                 WidgetViewSignal widgetContentUpdated = this.WidgetContentUpdatedSignal();
                 widgetContentUpdated?.Disconnect(widgetContentUpdatedEventCallback);
                 widgetContentUpdated?.Dispose();
+                widgetContentUpdatedEventCallback = null;
             }
 
             if (widgetCreationAbortedEventCallback != null)
@@ -1049,6 +1051,7 @@ namespace Tizen.NUI
                 WidgetViewSignal widgetCreationAborted = this.WidgetCreationAbortedSignal();
                 widgetCreationAborted?.Disconnect(widgetCreationAbortedEventCallback);
                 widgetCreationAborted?.Dispose();
+                widgetCreationAbortedEventCallback = null;
             }
 
             if (widgetDeletedEventCallback != null)
@@ -1056,6 +1059,7 @@ namespace Tizen.NUI
                 WidgetViewSignal widgetDeleted = this.WidgetDeletedSignal();
                 widgetDeleted?.Disconnect(widgetDeletedEventCallback);
                 widgetDeleted?.Dispose();
+                widgetDeletedEventCallback = null;
             }
 
             if (widgetFaultedEventCallback != null)
@@ -1063,6 +1067,7 @@ namespace Tizen.NUI
                 WidgetViewSignal widgetFaulted = this.WidgetFaultedSignal();
                 widgetFaulted?.Disconnect(widgetFaultedEventCallback);
                 widgetFaulted?.Dispose();
+                widgetFaultedEventCallback = null;
             }
 
             if (widgetUpdatePeriodChangedEventCallback != null)
@@ -1070,6 +1075,7 @@ namespace Tizen.NUI
                 WidgetViewSignal widgetUpdatePeriodChanged = this.WidgetUpdatePeriodChangedSignal();
                 widgetUpdatePeriodChanged?.Disconnect(widgetUpdatePeriodChangedEventCallback);
                 widgetUpdatePeriodChanged?.Dispose();
+                widgetUpdatePeriodChangedEventCallback = null;
             }
 
             base.Dispose(type);

--- a/src/Tizen.NUI/src/public/Window/GLWindowEvent.cs
+++ b/src/Tizen.NUI/src/public/Window/GLWindowEvent.cs
@@ -56,10 +56,11 @@ namespace Tizen.NUI
             remove
             {
                 focusChangedEventHandler -= value;
-                using var signal = FocusChangedSignal();
-                if (focusChangedEventHandler == null && signal.Empty() == false && focusChangedEventCallback != null)
+                if (focusChangedEventHandler == null && focusChangedEventCallback != null)
                 {
+                    using var signal = FocusChangedSignal();
                     signal.Disconnect(focusChangedEventCallback);
+                    focusChangedEventCallback = null;
                 }
             }
         }
@@ -114,10 +115,11 @@ namespace Tizen.NUI
             remove
             {
                 stageKeyHandler -= value;
-                using var signal = KeyEventSignal();
-                if (stageKeyHandler == null && signal.Empty() == false)
+                if (stageKeyHandler == null && windowKeyCallbackDelegate != null)
                 {
+                    using var signal = KeyEventSignal();
                     signal.Disconnect(windowKeyCallbackDelegate);
+                    windowKeyCallbackDelegate = null;
                 }
             }
         }
@@ -142,10 +144,11 @@ namespace Tizen.NUI
             remove
             {
                 windowResizedEventHandler -= value;
-                using var signal = GLWindowResizedSignal();
-                if (windowResizedEventHandler == null && signal.Empty() == false && windowResizedEventCallback != null)
+                if (windowResizedEventHandler == null && windowResizedEventCallback != null)
                 {
+                    using var signal = GLWindowResizedSignal();
                     signal.Disconnect(windowResizedEventCallback);
+                    windowResizedEventCallback = null;
                 }
             }
         }
@@ -185,24 +188,28 @@ namespace Tizen.NUI
             {
                 using var signal = FocusChangedSignal();
                 signal.Disconnect(focusChangedEventCallback);
+                focusChangedEventCallback = null;
             }
 
             if (windowTouchDataCallback != null)
             {
                 Interop.GLWindow.GlWindowTouchSignalDisconnect(SwigCPtr, windowTouchDataCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
+                windowTouchDataCallback = null;
             }
 
             if (windowKeyCallbackDelegate != null)
             {
                 using var signal = KeyEventSignal();
                 signal.Disconnect(windowKeyCallbackDelegate);
+                windowKeyCallbackDelegate = null;
             }
 
             if (windowResizedEventCallback != null)
             {
                 using var signal = GLWindowResizedSignal();
                 signal.Disconnect(windowResizedEventCallback);
+                windowResizedEventCallback = null;
             }
         }
 
@@ -425,15 +432,15 @@ namespace Tizen.NUI
             remove
             {
                 visibilityChangedEventHandler -= value;
-                if (visibilityChangedEventHandler == null)
+                if (visibilityChangedEventHandler == null && glVisibilityChangedEventCallback != null)
                 {
                     if (glVisibilityChangedEventSignal != null)
                     {
-                        if (glVisibilityChangedEventSignal.Empty() == false)
-                        {
-                            glVisibilityChangedEventSignal.Disconnect(glVisibilityChangedEventCallback);
-                        }
+                        glVisibilityChangedEventSignal.Disconnect(glVisibilityChangedEventCallback);
+                        glVisibilityChangedEventSignal.Dispose();
+                        glVisibilityChangedEventSignal = null;
                     }
+                    glVisibilityChangedEventCallback = null;
                 }
             }
         }
@@ -442,13 +449,11 @@ namespace Tizen.NUI
         /// VisibiltyChangedSignalEmit
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Do not use this, which is not supported.")]
         public void VisibiltyChangedSignalEmit(bool visibility)
         {
-            if (glVisibilityChangedEventSignal == null)
-            {
-                glVisibilityChangedEventSignal = new GLWindowVisibilityChangedEvent(this);
-            }
-            glVisibilityChangedEventSignal.Emit(this, visibility);
+            Tizen.Log.Fatal("NUI", "VisibiltyChangedSignalEmit is not supported. Do not use this function.");
+            NUILog.ErrorBacktrace("VisibiltyChangedSignalEmit is not supported. Do not use this function.");
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Window/GLWindowVisibilityChangedEvent.cs
+++ b/src/Tizen.NUI/src/public/Window/GLWindowVisibilityChangedEvent.cs
@@ -33,14 +33,6 @@ namespace Tizen.NUI
             Interop.GLWindowVisibilityChangedSignal.DeleteSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Interop.GLWindowVisibilityChangedSignal.Empty(SwigCPtr);
-
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Interop.GLWindowVisibilityChangedSignal.GetConnectionCount(SwigCPtr);
@@ -65,12 +57,6 @@ namespace Tizen.NUI
                 Interop.GLWindowVisibilityChangedSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(GLWindow glWindow, bool visibility)
-        {
-            Interop.GLWindowVisibilityChangedSignal.Emit(SwigCPtr, GLWindow.getCPtr(glWindow), visibility);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Window/WindowEvent.cs
+++ b/src/Tizen.NUI/src/public/Window/WindowEvent.cs
@@ -1744,7 +1744,6 @@ namespace Tizen.NUI
         private delegate void VisibilityChangedEventCallbackType(IntPtr window, bool visibility);
         private VisibilityChangedEventCallbackType VisibilityChangedEventCallback;
         private event EventHandler<VisibilityChangedEventArgs> VisibilityChangedEventHandler;
-        private WindowVisibilityChangedEvent VisibilityChangedEventSignal;
 
         /// <summary>
         /// EffectStart
@@ -1778,13 +1777,11 @@ namespace Tizen.NUI
         /// VisibiltyChangedSignalEmit
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Do not use this, which is not supported.")]
         public void VisibiltyChangedSignalEmit(bool visibility)
         {
-            if (VisibilityChangedEventSignal == null)
-            {
-                VisibilityChangedEventSignal = new WindowVisibilityChangedEvent(this);
-            }
-            VisibilityChangedEventSignal.Emit(this, visibility);
+            Tizen.Log.Fatal("NUI", "VisibiltyChangedSignalEmit is not supported. Do not use this function.");
+            NUILog.ErrorBacktrace("VisibiltyChangedSignalEmit is not supported. Do not use this function.");
         }
 
         private void OnAuxiliaryMessage(IntPtr kData, IntPtr vData, IntPtr optionsArray)

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Components/ScrollViewSnapStartedSignal.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Components/ScrollViewSnapStartedSignal.cs
@@ -31,13 +31,6 @@ namespace Tizen.NUI.Samples
             Tizen.NUI.Interop.ScrollView.DeleteScrollViewSnapStartedSignal(swigCPtr);
         }
 
-        public bool Empty()
-        {
-            bool ret = Tizen.NUI.Interop.ScrollView.ScrollViewSnapStartedSignalEmpty(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public uint GetConnectionCount()
         {
             uint ret = Tizen.NUI.Interop.ScrollView.ScrollViewSnapStartedSignalGetConnectionCount(SwigCPtr);
@@ -61,12 +54,6 @@ namespace Tizen.NUI.Samples
                 Tizen.NUI.Interop.ScrollView.ScrollViewSnapStartedSignalDisconnect(SwigCPtr, new HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        public void Emit(ScrollView.SnapEvent arg)
-        {
-            Tizen.NUI.Interop.ScrollView.ScrollViewSnapStartedSignalEmit(SwigCPtr, ScrollView.SnapEvent.getCPtr(arg));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         public ScrollViewSnapStartedSignal() : this(Tizen.NUI.Interop.ScrollView.NewScrollViewSnapStartedSignal(), true)


### PR DESCRIPTION
Most of event lifecycle of native side designed that signal invoked at native side, and C# just consume the events. Since most of events also need to change some native side status too, directly emit signals at C# side must not works well.

To guard some mis-implements for future developer, delete those features, and just keep 3 functions - GetConnectionCount, Connect, Disconnect.

TODO : Tizen.NUI.Components Navigator use AnimationSignal.Emit(), which is not recommanded. Since Navigator code implemented that finished callback comes immediatly, which is not match with DALi animation common behavior, we must change Navigator code first. After then, we can remove AnimationSignal.Emit().

TODO : AccessibilityDoAction() Looks not a common logic, and we may have similar API to emit native callback without touch emit API directly. We need to bind it first, and then remove AccessibilityDoAction() side Emit() API calls

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
