### PR TITLE
[NUI] Add LottieAnimationView.RefreshDynamicProperty()

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.LottieAnimationView.cs
@@ -29,6 +29,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_AnimatedVectorImageVisual_Actions_FLUSH_get")]
             public static extern int AnimatedVectorImageVisualActionFlushGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_AnimatedVectorImageVisual_Actions_REFRESH_DYNAMIC_PROPERTY_get")]
+            public static extern int AnimatedVectorImageVisualActionRefreshDynamicPropertyGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -1261,6 +1261,27 @@ namespace Tizen.NUI.BaseComponents
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        /// <summary>
+        /// Forces dynamic properties registered via DoActionExtension() to be re-evaluated
+        /// at the current frame, without changing which frame is displayed.
+        /// </summary>
+        /// <remarks>
+        /// Useful when the value returned by a dynamic property callback changes while the
+        /// animation is paused or stopped: simply re-setting CurrentFrame to the same value
+        /// has no effect (the underlying engine treats it as a no-op), so this action is
+        /// needed to force the callback to be re-invoked and the result rendered.
+        /// </remarks>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void RefreshDynamicProperty()
+        {
+            if (Disposed)
+            {
+                return;
+            }
+            Interop.View.DoActionWithEmptyAttributes(this.SwigCPtr, ImageView.Property.IMAGE, ActionRefreshDynamicProperty);
+        }
+
         private void CleanCallbackDictionaries(bool disposing)
         {
             // Called from main, or GC threads
@@ -1568,6 +1589,7 @@ namespace Tizen.NUI.BaseComponents
         // This is used for internal purpose.
         internal static readonly int ActionSetDynamicProperty = Interop.LottieAnimationView.AnimatedVectorImageVisualActionSetDynamicPropertyGet();
         internal static readonly int ActionFlush = Interop.LottieAnimationView.AnimatedVectorImageVisualActionFlushGet();
+        internal static readonly int ActionRefreshDynamicProperty = Interop.LottieAnimationView.AnimatedVectorImageVisualActionRefreshDynamicPropertyGet();
 
         internal class VisualEventSignalArgs : EventArgs
         {


### PR DESCRIPTION


### Description of Change ###
<!-- Describe your changes here. -->
Forces dynamic properties registered via DoActionExtension() to be re-evaluated at the current frame without changing which frame is displayed. Needed while the animation is paused or stopped, where re-setting CurrentFrame to the same value is a no-op for the underlying renderer, so a dynamic property callback's updated return value would otherwise never be picked up.

Marked EditorBrowsable(Never) as Inhouse API pending ACR, same as the existing DoActionExtension()/FlushLottieMessages() pattern.

refer
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/348329
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/348327
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-adaptor/+/348326

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
