### PR TITLE
[AI Task] [Tizen.Network.Bluetooth] Add RunContinuationsAsynchronously to async TCS

### DIFF
--- a/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothAvrcpControl.cs
+++ b/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothAvrcpControl.cs
@@ -137,7 +137,7 @@ namespace Tizen.Network.Bluetooth
                 BluetoothErrorFactory.ThrowBluetoothException((int)BluetoothError.NowInProgress);
             }
 
-            _taskForConnection = new TaskCompletionSource<bool>();
+            _taskForConnection = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             BluetoothAvrcpControlImpl.Instance.Connect(RemoteAddress);
             return _taskForConnection.Task;
         }
@@ -156,7 +156,7 @@ namespace Tizen.Network.Bluetooth
             {
                 BluetoothErrorFactory.ThrowBluetoothException((int)BluetoothError.NowInProgress);
             }
-            _taskForDisconnection = new TaskCompletionSource<bool>();
+            _taskForDisconnection = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             BluetoothAvrcpControlImpl.Instance.Disconnect(RemoteAddress);
             return _taskForDisconnection.Task;
         }

--- a/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothGatt.cs
+++ b/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothGatt.cs
@@ -425,7 +425,7 @@ namespace Tizen.Network.Bluetooth
             {
                 BluetoothErrorFactory.ThrowBluetoothException((int)BluetoothError.NowInProgress);
             }
-            _taskForConnection = new TaskCompletionSource<bool>();
+            _taskForConnection = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             _impl.Connect(_remoteAddress, autoConnect);
             return _taskForConnection.Task;
         }
@@ -445,7 +445,7 @@ namespace Tizen.Network.Bluetooth
             {
                 BluetoothErrorFactory.ThrowBluetoothException((int)BluetoothError.NowInProgress);
             }
-            _taskForDisconnection = new TaskCompletionSource<bool>();
+            _taskForDisconnection = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             _impl.Disconnect(_remoteAddress);
             return _taskForDisconnection.Task;
         }

--- a/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothGattImpl.cs
+++ b/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothGattImpl.cs
@@ -135,7 +135,7 @@ namespace Tizen.Network.Bluetooth
 
         internal Task<bool> SendIndicationAsync(BluetoothGattServer server, BluetoothGattCharacteristic characteristic, string clientAddress)
         {
-            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
+            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             int requestId = 0;
 
             lock (this)
@@ -320,7 +320,7 @@ namespace Tizen.Network.Bluetooth
 
         internal Task<bool> ReadValueAsyncTask(BluetoothGattAttributeHandle handle)
         {
-            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
+            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             int requestId = 0;
 
             lock (this)
@@ -359,7 +359,7 @@ namespace Tizen.Network.Bluetooth
 
         internal Task<bool> WriteValueAsyncTask(BluetoothGattAttributeHandle handle)
         {
-            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
+            TaskCompletionSource<bool> task = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             int requestId = 0;
 
             lock (this)

--- a/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothHidDevice.cs
+++ b/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothHidDevice.cs
@@ -105,7 +105,7 @@ namespace Tizen.Network.Bluetooth
             {
                 BluetoothErrorFactory.ThrowBluetoothException((int)BluetoothError.NowInProgress);
             }
-            _taskForConnection = new TaskCompletionSource<bool>();
+            _taskForConnection = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             int ret = BluetoothHidDeviceImpl.Instance.ConnectHidDevice(RemoteAddress);
             if (ret != (int)BluetoothError.None)
@@ -132,7 +132,7 @@ namespace Tizen.Network.Bluetooth
             {
                 BluetoothErrorFactory.ThrowBluetoothException((int)BluetoothError.NowInProgress);
             }
-            _taskForDisconnection = new TaskCompletionSource<bool>();
+            _taskForDisconnection = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             int ret = BluetoothHidDeviceImpl.Instance.DisconnectHidDevice(RemoteAddress);
             if (ret != (int)BluetoothError.None)

--- a/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothServerSocket.cs
+++ b/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothServerSocket.cs
@@ -187,7 +187,7 @@ namespace Tizen.Network.Bluetooth
             {
                 BluetoothErrorFactory.ThrowBluetoothException((int)BluetoothError.NowInProgress);
             }
-            _taskForAccept = new TaskCompletionSource<SocketConnection>();
+            _taskForAccept = new TaskCompletionSource<SocketConnection>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             int ret = Interop.Bluetooth.Accept(socketFd);
             if (ret != (int)BluetoothError.None)


### PR DESCRIPTION
## Summary
Adds `TaskCreationOptions.RunContinuationsAsynchronously` to all 10 `TaskCompletionSource` instances in the Bluetooth module. These TCSs are completed (`SetResult`/`SetException`) from native Bluetooth daemon callback threads, so with the default options user `await` continuations run inline on the BT callback dispatch thread — risking deadlocks (continuation calling back into BT APIs), callback queue stalls, and unpredictable execution context. With this option, continuations are queued to the ThreadPool instead.

Follow-up to the same pattern already applied in #7620 (Tizen.Network.WiFi) and #7639 (Tizen.Multimedia.Remoting).

## Changes
- `src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothServerSocket.cs` — `_taskForAccept` (1 site)
- `src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothGatt.cs` — `_taskForConnection`, `_taskForDisconnection` (2 sites)
- `src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothGattImpl.cs` — SendIndicationAsync, ReadValueAsyncTask, WriteValueAsyncTask (3 sites)
- `src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothHidDevice.cs` — `_taskForConnection`, `_taskForDisconnection` (2 sites)
- `src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothAvrcpControl.cs` — `_taskForConnection`, `_taskForDisconnection` (2 sites)

## Mode
Refactoring

## Verification
- [x] Build: passed (0 errors; 1 pre-existing CS8509 warning in BluetoothStructs.cs, unrelated)
- [ ] Tests: N/A
- [ ] Benchmark: skipped (sdb error: no device connected)

Public API signatures are unchanged; only the TCS creation option flag is added, so returned `Task`/`Task<T>` semantics remain the same for callers.

Fixes #7666

🤖 Generated with [Claude Code](https://claude.com/claude-code)
