### PR TITLE
[AI Task] [Tizen.Pims.Contacts] Remove Convert.ChangeType boxing from ContactsRecord Get/Set

### DIFF
--- a/src/Tizen.Pims.Contacts/Tizen.Pims.Contacts/ContactsRecord.cs
+++ b/src/Tizen.Pims.Contacts/Tizen.Pims.Contacts/ContactsRecord.cs
@@ -201,7 +201,6 @@ namespace Tizen.Pims.Contacts
         /// <since_tizen> 4 </since_tizen>
         public T Get<T>(uint propertyId)
         {
-            object parsedValue = null;
             if (typeof(T) == typeof(string))
             {
                 string val;
@@ -211,7 +210,7 @@ namespace Tizen.Pims.Contacts
                     Log.Error(Globals.LogTag, $"Get String Failed with error {error}");
                     throw ContactsErrorFactory.CheckAndCreateException(error);
                 }
-                parsedValue = Convert.ChangeType(val, typeof(T));
+                return (T)(object)val;
             }
             else if (typeof(T) == typeof(int))
             {
@@ -222,7 +221,7 @@ namespace Tizen.Pims.Contacts
                     Log.Error(Globals.LogTag, $"Get Int Failed with error {error}");
                     throw ContactsErrorFactory.CheckAndCreateException(error);
                 }
-                parsedValue = Convert.ChangeType(val, typeof(T));
+                return (T)(object)val;
             }
             else if (typeof(T) == typeof(bool))
             {
@@ -233,7 +232,7 @@ namespace Tizen.Pims.Contacts
                     Log.Error(Globals.LogTag, $"Get Bool Failed with error {error}");
                     throw ContactsErrorFactory.CheckAndCreateException(error);
                 }
-                parsedValue = Convert.ChangeType(val, typeof(T));
+                return (T)(object)val;
             }
             else if (typeof(T) == typeof(long))
             {
@@ -244,7 +243,7 @@ namespace Tizen.Pims.Contacts
                     Log.Error(Globals.LogTag, $"Get Long Failed with error {error}");
                     throw ContactsErrorFactory.CheckAndCreateException(error);
                 }
-                parsedValue = Convert.ChangeType(val, typeof(T));
+                return (T)(object)val;
             }
             else if (typeof(T) == typeof(double))
             {
@@ -255,14 +254,13 @@ namespace Tizen.Pims.Contacts
                     Log.Error(Globals.LogTag, $"Get Long Failed with error {error}");
                     throw ContactsErrorFactory.CheckAndCreateException(error);
                 }
-                parsedValue = Convert.ChangeType(val, typeof(T));
+                return (T)(object)val;
             }
             else
             {
                 Log.Error(Globals.LogTag, "Not Supported Data Type");
                 throw ContactsErrorFactory.CheckAndCreateException((int)ContactsError.NotSupported);
             }
-            return (T)parsedValue;
         }
 
         /// <summary>
@@ -278,7 +276,7 @@ namespace Tizen.Pims.Contacts
         {
             if (typeof(T) == typeof(string))
             {
-                string val = Convert.ToString(value);
+                string val = (string)(object)value ?? string.Empty;
                 int error = Interop.Record.SetStr(_recordHandle, propertyId, val);
                 if ((int)ContactsError.None != error)
                 {
@@ -288,7 +286,7 @@ namespace Tizen.Pims.Contacts
             }
             else if (typeof(T) == typeof(int))
             {
-                int val = Convert.ToInt32(value);
+                int val = (int)(object)value;
                 int error = Interop.Record.SetInt(_recordHandle, propertyId, val);
                 if ((int)ContactsError.None != error)
                 {
@@ -298,7 +296,7 @@ namespace Tizen.Pims.Contacts
             }
             else if (typeof(T) == typeof(bool))
             {
-                bool val = Convert.ToBoolean(value);
+                bool val = (bool)(object)value;
                 int error = Interop.Record.SetBool(_recordHandle, propertyId, val);
                 if ((int)ContactsError.None != error)
                 {
@@ -308,7 +306,7 @@ namespace Tizen.Pims.Contacts
             }
             else if (typeof(T) == typeof(long))
             {
-                long val = Convert.ToInt64(value);
+                long val = (long)(object)value;
                 int error = Interop.Record.SetLli(_recordHandle, propertyId, val);
                 if ((int)ContactsError.None != error)
                 {
@@ -318,7 +316,7 @@ namespace Tizen.Pims.Contacts
             }
             else if (typeof(T) == typeof(double))
             {
-                double val = Convert.ToDouble(value);
+                double val = (double)(object)value;
                 int error = Interop.Record.SetDouble(_recordHandle, propertyId, val);
                 if ((int)ContactsError.None != error)
                 {

--- a/src/Tizen.Pims.Contacts/Tizen.Pims.Contacts/ContactsRecord.cs
+++ b/src/Tizen.Pims.Contacts/Tizen.Pims.Contacts/ContactsRecord.cs
@@ -251,7 +251,7 @@ namespace Tizen.Pims.Contacts
                 int error = Interop.Record.GetDouble(_recordHandle, propertyId, out val);
                 if ((int)ContactsError.None != error)
                 {
-                    Log.Error(Globals.LogTag, $"Get Long Failed with error {error}");
+                    Log.Error(Globals.LogTag, $"Get Double Failed with error {error}");
                     throw ContactsErrorFactory.CheckAndCreateException(error);
                 }
                 return (T)(object)val;
@@ -276,7 +276,7 @@ namespace Tizen.Pims.Contacts
         {
             if (typeof(T) == typeof(string))
             {
-                string val = (string)(object)value ?? string.Empty;
+                string val = value as string ?? string.Empty;
                 int error = Interop.Record.SetStr(_recordHandle, propertyId, val);
                 if ((int)ContactsError.None != error)
                 {
@@ -320,7 +320,7 @@ namespace Tizen.Pims.Contacts
                 int error = Interop.Record.SetDouble(_recordHandle, propertyId, val);
                 if ((int)ContactsError.None != error)
                 {
-                    Log.Error(Globals.LogTag, $"Get Long Failed with error {error}");
+                    Log.Error(Globals.LogTag, $"Set Double Failed with error {error}");
                     throw ContactsErrorFactory.CheckAndCreateException(error);
                 }
             }


### PR DESCRIPTION
## Summary
Removes the `Convert.ChangeType` / `Convert.To*` conversion paths from `ContactsRecord.Get<T>(uint)` and `Set<T>(uint, T)`. Each branch already verifies the exact type via `typeof(T) == typeof(X)`, so the value is converted with a direct cast (`(T)(object)val`) instead of going through the culture-aware `IConvertible` dispatch. `Get<T>` also drops the intermediate `object parsedValue` local and returns directly from each branch.

Per-call effect (e.g. `Get<int>`): no `Convert.ChangeType` call, no `IConvertible` vtable dispatch, no `CultureInfo` lookup. For `Get<string>`/`Set<string>` the boxing allocation disappears entirely (reference-type cast). `ContactsRecord` property access is the per-field unit of contact serialization, so bulk sync/import workloads (10k records × ~10 properties) save hundreds of thousands of dispatch/boxing operations.

## Changes
- `src/Tizen.Pims.Contacts/Tizen.Pims.Contacts/ContactsRecord.cs`
  - `Get<T>`: each type branch now ends with `return (T)(object)val;`; removed `object parsedValue` local, `Convert.ChangeType` calls (5), and the trailing unbox `return (T)parsedValue;`. Unsupported-type branch still throws `NotSupported` as before.
  - `Set<T>`: `Convert.ToString/ToInt32/ToBoolean/ToInt64/ToDouble` replaced with direct casts. The string branch uses `(string)(object)value ?? string.Empty` to preserve the exact prior behavior of `Convert.ToString(object)`, which maps `null` to `string.Empty` (so native `SetStr` still receives an empty string, not `null`).

## Mode
Refactoring

## Verification
- [x] Build: passed (0 errors, 0 warnings)
- [ ] Tests: N/A
- [ ] Benchmark: skipped (sdb error: no device connected)

Public API signatures (`T Get<T>(uint)`, `void Set<T>(uint, T)`) are unchanged. Every direct cast is guarded by the exact `typeof(T)` check, so no `InvalidCastException` is reachable on paths that previously succeeded; normal-path results are bit-identical, including `Get<string>` returning `null` when the native value is `NULL`.

Fixes #7667

🤖 Generated with [Claude Code](https://claude.com/claude-code)
