### PR TITLE
[NUI] To ensure that native-side exceptions are properly propagated to C#, use NDAlicPINVOKE.SWIGPendingException.Pending to check for pending SWIG exceptions.

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -1280,6 +1280,8 @@ namespace Tizen.NUI.BaseComponents
                 return;
             }
             Interop.View.DoActionWithEmptyAttributes(this.SwigCPtr, ImageView.Property.IMAGE, ActionRefreshDynamicProperty);
+
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         private void CleanCallbackDictionaries(bool disposing)


### PR DESCRIPTION

### Description of Change ###
<!-- Describe your changes here. -->
To ensure that native-side exceptions are properly propagated to C#, use NDAlicPINVOKE.SWIGPendingException.Pending to check for pending SWIG exceptions.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
