### PR TITLE
[VoiceControlManager] Fix svace null-dereference issue in recognized …

### DIFF
--- a/src/Tizen.Uix.VoiceControlManager/Tizen.Uix.VoiceControlManager/VoiceControlManagerClient.cs
+++ b/src/Tizen.Uix.VoiceControlManager/Tizen.Uix.VoiceControlManager/VoiceControlManagerClient.cs
@@ -378,8 +378,8 @@ namespace Tizen.Uix.VoiceControlManager
 
         private static VcMgrAllResultCallback _recognizedCommandsSelectionCallback = (RecognizedResult result, IntPtr vcCmdList, IntPtr recognizedText, IntPtr msg, IntPtr userData) =>
         {
-            string recognizedString = Marshal.PtrToStringAnsi(recognizedText);
-            string msgString = Marshal.PtrToStringAnsi(msg);
+            string recognizedString = Marshal.PtrToStringAnsi(recognizedText) ?? string.Empty;
+            string msgString = Marshal.PtrToStringAnsi(msg) ?? string.Empty;
 
             if (_allRecognitionResult != null)
             {


### PR DESCRIPTION
…commands callback



### Description of Change ###
Marshal.PtrToStringAnsi() returns null when the native pointer is IntPtr.Zero. The resulting null msgString (and recognizedString) was passed into SelectRecognizedCommandsDelegate.Invoke(), which svace reports as a null-value dereference and which could cause a NullReferenceException inside consumer delegate implementations.

Coalesce both marshaled strings to string.Empty at the source so the delegate and AllRecognitionResultEventArgs always receive non-null values.



