### PR TITLE
[AI Task] Pre-size MediaVision result lists with known native count

### DIFF
--- a/src/Tizen.Multimedia.Vision/MediaVision/FaceDetector.cs
+++ b/src/Tizen.Multimedia.Vision/MediaVision/FaceDetector.cs
@@ -188,7 +188,7 @@ namespace Tizen.Multimedia.Vision
                 return Enumerable.Empty<FaceDetectionResult>();
             }
 
-            var results = new List<FaceDetectionResult>();
+            var results = new List<FaceDetectionResult>(number);
 
             for (int i = 0; i < number; i++)
             {

--- a/src/Tizen.Multimedia.Vision/MediaVision/FacialLandmarkDetector.cs
+++ b/src/Tizen.Multimedia.Vision/MediaVision/FacialLandmarkDetector.cs
@@ -126,7 +126,7 @@ namespace Tizen.Multimedia.Vision
                 return Enumerable.Empty<Point>();
             }
 
-            var results = new List<Point>();
+            var results = new List<Point>(number);
 
             for (int i = 0; i < number; i++)
             {

--- a/src/Tizen.Multimedia.Vision/MediaVision/ImageClassifier.cs
+++ b/src/Tizen.Multimedia.Vision/MediaVision/ImageClassifier.cs
@@ -122,7 +122,7 @@ namespace Tizen.Multimedia.Vision
                 return Enumerable.Empty<ImageClassificationResult>();
             }
 
-            var results = new List<ImageClassificationResult>();
+            var results = new List<ImageClassificationResult>(number);
 
             for (int i = 0; i < number; i++)
             {

--- a/src/Tizen.Multimedia.Vision/MediaVision/InferenceFaceDetectorResult.cs
+++ b/src/Tizen.Multimedia.Vision/MediaVision/InferenceFaceDetectorResult.cs
@@ -32,7 +32,7 @@ namespace Tizen.Multimedia.Vision
                 Validate("Failed to get result count.");
 
             RequestId = requestId;
-            var boundingBoxes = new List<Rectangle>();
+            var boundingBoxes = new List<Rectangle>((int)count);
 
             for (uint i = 0 ; i < count ; i++)
             {

--- a/src/Tizen.Multimedia.Vision/MediaVision/InferenceFacialLandmarkDetectorResult.cs
+++ b/src/Tizen.Multimedia.Vision/MediaVision/InferenceFacialLandmarkDetectorResult.cs
@@ -33,7 +33,7 @@ namespace Tizen.Multimedia.Vision
                 Validate("Failed to get result count.");
 
             RequestId = requestId;
-            var points = new List<Point>();
+            var points = new List<Point>((int)count);
 
             for (uint i = 0 ; i < count ; i++)
             {

--- a/src/Tizen.Multimedia.Vision/MediaVision/InferenceImageClassifierResult.cs
+++ b/src/Tizen.Multimedia.Vision/MediaVision/InferenceImageClassifierResult.cs
@@ -33,7 +33,7 @@ namespace Tizen.Multimedia.Vision
                 Validate("Failed to get result count.");
 
             RequestId = requestId;
-            var labels = new List<string>();
+            var labels = new List<string>((int)count);
 
             for (uint i = 0 ; i < count ; i++)
             {

--- a/src/Tizen.Multimedia.Vision/MediaVision/InferenceObjectDetectorResult.cs
+++ b/src/Tizen.Multimedia.Vision/MediaVision/InferenceObjectDetectorResult.cs
@@ -32,7 +32,7 @@ namespace Tizen.Multimedia.Vision
                 Validate("Failed to get result count.");
 
             RequestId = requestId;
-            var boundingBoxes = new List<Rectangle>();
+            var boundingBoxes = new List<Rectangle>((int)count);
 
             for (uint i = 0 ; i < count ; i++)
             {

--- a/src/Tizen.Multimedia.Vision/MediaVision/InferencePoseLandmarkDetectorResult.cs
+++ b/src/Tizen.Multimedia.Vision/MediaVision/InferencePoseLandmarkDetectorResult.cs
@@ -33,7 +33,7 @@ namespace Tizen.Multimedia.Vision
                 Validate("Failed to get result count.");
 
             RequestId = requestId;
-            var points = new List<Point>();
+            var points = new List<Point>((int)count);
 
             for (uint i = 0 ; i < count ; i++)
             {

--- a/src/Tizen.Multimedia.Vision/MediaVision/ObjectDetector.cs
+++ b/src/Tizen.Multimedia.Vision/MediaVision/ObjectDetector.cs
@@ -101,7 +101,7 @@ namespace Tizen.Multimedia.Vision
                 return Enumerable.Empty<ObjectDetectionResult>();
             }
 
-            var results = new List<ObjectDetectionResult>();
+            var results = new List<ObjectDetectionResult>(number);
 
             for (int i = 0; i < number; i++)
             {


### PR DESCRIPTION
## Summary
The five `Inference*Result` constructors read the exact element `count` from native code, then built their `List<T>` with the default (zero) capacity and `Add()`-ed in a `count`-bounded loop. Since each result is constructed once per inferred frame (17+ points for pose landmarks, 68+ for facial landmarks), the ignored count caused ~3–5 avoidable backing-array reallocations plus element copies per frame. All five constructors — and the four legacy `GetResults` helpers with the same shape — now pass the already-known count as the initial `List<T>` capacity, so one right-sized array is allocated instead of a geometric growth chain. List contents and order are unchanged.

## Changes
- `src/Tizen.Multimedia.Vision/MediaVision/InferencePoseLandmarkDetectorResult.cs`: `new List<Point>()` → `new List<Point>((int)count)`
- `src/Tizen.Multimedia.Vision/MediaVision/InferenceFacialLandmarkDetectorResult.cs`: `new List<Point>()` → `new List<Point>((int)count)`
- `src/Tizen.Multimedia.Vision/MediaVision/InferenceFaceDetectorResult.cs`: `new List<Rectangle>()` → `new List<Rectangle>((int)count)`
- `src/Tizen.Multimedia.Vision/MediaVision/InferenceObjectDetectorResult.cs`: `new List<Rectangle>()` → `new List<Rectangle>((int)count)`
- `src/Tizen.Multimedia.Vision/MediaVision/InferenceImageClassifierResult.cs`: `new List<string>()` → `new List<string>((int)count)`
- `src/Tizen.Multimedia.Vision/MediaVision/FaceDetector.cs`: legacy `GetResults` list pre-sized with `number`
- `src/Tizen.Multimedia.Vision/MediaVision/ObjectDetector.cs`: legacy `GetResults` list pre-sized with `number`
- `src/Tizen.Multimedia.Vision/MediaVision/ImageClassifier.cs`: legacy `GetResults` list pre-sized with `number`
- `src/Tizen.Multimedia.Vision/MediaVision/FacialLandmarkDetector.cs`: legacy `GetResults` list pre-sized with `number`

## Mode
Refactoring

## Verification
- [x] Build: passed (0 errors; remaining warnings are pre-existing in dependency projects)
- [ ] Tests: N/A (no unit tests for this module; change is list initial capacity only, contents identical)
- [ ] Benchmark: skipped (sdb error: no device attached)

Fixes #7700
