### PR TITLE
[AI Task] [Tizen.Pims.Calendar] Remove Convert.ChangeType boxing from CalendarRecord Get/Set

### DIFF
--- a/src/Tizen.Pims.Calendar/Tizen.Pims.Calendar/CalendarRecord.cs
+++ b/src/Tizen.Pims.Calendar/Tizen.Pims.Calendar/CalendarRecord.cs
@@ -251,7 +251,6 @@ namespace Tizen.Pims.Calendar
         /// <exception cref="ArgumentException">Thrown when one of the arguments provided to a method is not valid</exception>
         public T Get<T>(uint propertyId)
         {
-            object parsedValue = null;
             if (typeof(T) == typeof(string))
             {
                 string val;
@@ -261,7 +260,7 @@ namespace Tizen.Pims.Calendar
                     Log.Error(Globals.LogTag, $"Get String Failed [{error}]{propertyId:X}");
                     throw CalendarErrorFactory.GetException(error);
                 }
-                parsedValue = Convert.ChangeType(val, typeof(T));
+                return (T)(object)val;
             }
             else if (typeof(T) == typeof(int))
             {
@@ -272,7 +271,7 @@ namespace Tizen.Pims.Calendar
                     Log.Error(Globals.LogTag, $"Get Intger Failed [{error}]{propertyId:X}");
                     throw CalendarErrorFactory.GetException(error);
                 }
-                parsedValue = Convert.ChangeType(val, typeof(T));
+                return (T)(object)val;
             }
             else if (typeof(T) == typeof(long))
             {
@@ -283,7 +282,7 @@ namespace Tizen.Pims.Calendar
                     Log.Error(Globals.LogTag, $"Get Long Failed [{error}]{propertyId:X}");
                     throw CalendarErrorFactory.GetException(error);
                 }
-                parsedValue = Convert.ChangeType(val, typeof(T));
+                return (T)(object)val;
             }
             else if (typeof(T) == typeof(double))
             {
@@ -294,7 +293,7 @@ namespace Tizen.Pims.Calendar
                     Log.Error(Globals.LogTag, $"Get Double Failed [{error}]{propertyId:X}");
                     throw CalendarErrorFactory.GetException(error);
                 }
-                parsedValue = Convert.ChangeType(val, typeof(T));
+                return (T)(object)val;
             }
             else if (typeof(T) == typeof(CalendarTime))
             {
@@ -306,14 +305,13 @@ namespace Tizen.Pims.Calendar
                     throw CalendarErrorFactory.GetException(error);
                 }
                 CalendarTime val = ConvertIntPtrToCalendarTime(time);
-                parsedValue = Convert.ChangeType(val, typeof(T));
+                return (T)(object)val;
             }
             else
             {
                 Log.Error(Globals.LogTag, "Not supported Data T/ype");
                 throw CalendarErrorFactory.GetException((int)CalendarError.NotSupported);
             }
-            return (T)parsedValue;
         }
 
         /// <summary>
@@ -329,7 +327,7 @@ namespace Tizen.Pims.Calendar
         {
             if (typeof(T) == typeof(string))
             {
-                string val = Convert.ToString(value);
+                string val = value as string ?? string.Empty;
                 int error = Interop.Record.SetString(_recordHandle, propertyId, val);
                 if (CalendarError.None != (CalendarError)error)
                 {
@@ -339,7 +337,7 @@ namespace Tizen.Pims.Calendar
             }
             else if (typeof(T) == typeof(int))
             {
-                int val = Convert.ToInt32(value);
+                int val = (int)(object)value;
                 int error = Interop.Record.SetInteger(_recordHandle, propertyId, val);
                 if (CalendarError.None != (CalendarError)error)
                 {
@@ -349,7 +347,7 @@ namespace Tizen.Pims.Calendar
             }
             else if (typeof(T) == typeof(long))
             {
-                long val = Convert.ToInt64(value);
+                long val = (long)(object)value;
                 int error = Interop.Record.SetLli(_recordHandle, propertyId, val);
                 if (CalendarError.None != (CalendarError)error)
                 {
@@ -359,7 +357,7 @@ namespace Tizen.Pims.Calendar
             }
             else if (typeof(T) == typeof(double))
             {
-                double val = Convert.ToDouble(value);
+                double val = (double)(object)value;
                 int error = Interop.Record.SetDouble(_recordHandle, propertyId, val);
                 if (CalendarError.None != (CalendarError)error)
                 {
@@ -369,7 +367,7 @@ namespace Tizen.Pims.Calendar
             }
             else if (typeof(T) == typeof(CalendarTime))
             {
-                CalendarTime time = (CalendarTime)Convert.ChangeType(value, typeof(CalendarTime));
+                CalendarTime time = (CalendarTime)(object)value;
                 //Interop.Record.DateTime val = ConvertCalendarTimeToStruct(time);
                 IntPtr val = ConvertCalendarTimeToStruct(time);
                 //int error = Interop.Record.SetCalendarTime(_recordHandle, propertyId, val);


### PR DESCRIPTION
## Summary
Removes the `Convert.ChangeType` / `Convert.To*` conversion paths from `CalendarRecord.Get<T>(uint)` and `Set<T>(uint, T)`. Each branch already verifies the exact type via `typeof(T) == typeof(X)`, so the value is now converted with a direct cast (`(T)(object)val`) instead of going through the culture-aware `IConvertible` dispatch. `Get<T>` also drops the intermediate `object parsedValue` local and returns directly from each branch.

Per-call effect (e.g. `Get<int>`): no `Convert.ChangeType` call, no `IConvertible` vtable dispatch, no `CultureInfo` lookup. For `Get<string>`/`Set<string>` and the `CalendarTime` branches the redundant conversion round-trip disappears entirely (reference-type cast). `Get`/`Set` run once per record field, so iterating a `CalendarList` multiplies the savings by (records x fields).

This applies the identical pattern already approved for the sibling module in #7762 (`ContactsRecord`, issue #7667).

## Changes
- `src/Tizen.Pims.Calendar/Tizen.Pims.Calendar/CalendarRecord.cs`
  - `Get<T>`: each type branch now ends with `return (T)(object)val;`; removed the `object parsedValue` local, the `Convert.ChangeType` calls (5), and the trailing unbox `return (T)parsedValue;`. The unsupported-type branch still throws `NotSupported` as before.
  - `Set<T>`: `Convert.ToString/ToInt32/ToInt64/ToDouble` replaced with direct casts; `Convert.ChangeType` in the `CalendarTime` branch replaced with `(CalendarTime)(object)value`. The string branch uses `value as string ?? string.Empty` to preserve the exact prior behavior of `Convert.ToString(object)`, which maps `null` to `string.Empty` (so native `SetString` still receives an empty string, not `null`).

## Mode
Refactoring

## Verification
- [x] Build: passed (0 errors, 0 warnings)
- [ ] Tests: N/A
- [ ] Benchmark: skipped (sdb error: no device connected)

Public API signatures (`T Get<T>(uint)`, `void Set<T>(uint, T)`) are unchanged. Every direct cast is guarded by the exact `typeof(T)` check, so no `InvalidCastException` is reachable on paths that previously succeeded; normal-path results are bit-identical, including `Get<string>` returning `null` when the native value is `NULL` and `Convert.ChangeType`'s same-type shortcut for `CalendarTime` (not `IConvertible`).

Fixes #7710

🤖 Generated with [Claude Code](https://claude.com/claude-code)
