### PR TITLE
[AI Task] [Tizen.Pims.Calendar] Remove debug artifacts and use DateTime.UnixEpoch in CalendarRecord time helpers

### DIFF
--- a/src/Tizen.Pims.Calendar/Tizen.Pims.Calendar/CalendarRecord.cs
+++ b/src/Tizen.Pims.Calendar/Tizen.Pims.Calendar/CalendarRecord.cs
@@ -166,7 +166,7 @@ namespace Tizen.Pims.Calendar
 
             if ((int)CalendarTime.Type.Utc == value._type)
             {
-                Interop.Record.SetCalTimeUtime(caltime, (value.UtcTime.Ticks - DateTime.UnixEpoch.Ticks) / 10_000_000);
+                Interop.Record.SetCalTimeUtime(caltime, (value.UtcTime.Ticks - DateTime.UnixEpoch.Ticks) / TimeSpan.TicksPerSecond);
             }
             else
             {
@@ -185,7 +185,7 @@ namespace Tizen.Pims.Calendar
             CalendarTime value;
             if ((int)CalendarTime.Type.Utc == Interop.Record.GetCalTimeType(caltime))
             {
-                value = new CalendarTime(Interop.Record.GetCalTimeUtime(caltime) * 10_000_000 + DateTime.UnixEpoch.Ticks);
+                value = new CalendarTime(Interop.Record.GetCalTimeUtime(caltime) * TimeSpan.TicksPerSecond + DateTime.UnixEpoch.Ticks);
             }
             else
             {

--- a/src/Tizen.Pims.Calendar/Tizen.Pims.Calendar/CalendarRecord.cs
+++ b/src/Tizen.Pims.Calendar/Tizen.Pims.Calendar/CalendarRecord.cs
@@ -161,16 +161,12 @@ namespace Tizen.Pims.Calendar
 
         internal static IntPtr ConvertCalendarTimeToStruct(CalendarTime value)
         {
-            Console.WriteLine("convert calendar");
             IntPtr caltime = Interop.Record.CreateCalTime();
             Interop.Record.SetCalTimeType(caltime, value._type);
 
             if ((int)CalendarTime.Type.Utc == value._type)
             {
-                DateTime epoch = new DateTime(1970, 1, 1, 0, 0, 0);
-                Interop.Record.SetCalTimeUtime(caltime, (value.UtcTime.Ticks - epoch.Ticks) / 10_000_000);
-                //Log.Debug(Globals.LogTag, "Sameer local time is if:" + Interop.Record.GetCalTimeLocalMonth(caltime) + "," + Interop.Record.GetCalTimeLocalMday(caltime) + "," + Interop.Record.GetCalTimeLocalHour(caltime) + "," + Interop.Record.GetCalTimeLocalMinute(caltime));
-
+                Interop.Record.SetCalTimeUtime(caltime, (value.UtcTime.Ticks - DateTime.UnixEpoch.Ticks) / 10_000_000);
             }
             else
             {
@@ -180,7 +176,6 @@ namespace Tizen.Pims.Calendar
                 Interop.Record.SetCalTimeLocalHour(caltime, value.LocalTime.Hour);
                 Interop.Record.SetCalTimeLocalMinute(caltime, value.LocalTime.Minute);
                 Interop.Record.SetCalTimeLocalSecond(caltime, value.LocalTime.Second);
-                //Log.Debug(Globals.LogTag, "Sameer local time is:" + Interop.Record.GetCalTimeLocalHour(caltime) + "," + Interop.Record.GetCalTimeLocalMinute(caltime));
             }
             return caltime;
         }
@@ -190,8 +185,7 @@ namespace Tizen.Pims.Calendar
             CalendarTime value;
             if ((int)CalendarTime.Type.Utc == Interop.Record.GetCalTimeType(caltime))
             {
-                DateTime epoch = new DateTime(1970, 1, 1, 0, 0, 0);
-                value = new CalendarTime(Interop.Record.GetCalTimeUtime(caltime) * 10_000_000 + epoch.Ticks);
+                value = new CalendarTime(Interop.Record.GetCalTimeUtime(caltime) * 10_000_000 + DateTime.UnixEpoch.Ticks);
             }
             else
             {
@@ -370,9 +364,7 @@ namespace Tizen.Pims.Calendar
             else if (typeof(T) == typeof(CalendarTime))
             {
                 CalendarTime time = (CalendarTime)Convert.ChangeType(value, typeof(CalendarTime));
-                //Interop.Record.DateTime val = ConvertCalendarTimeToStruct(time);
                 IntPtr val = ConvertCalendarTimeToStruct(time);
-                //int error = Interop.Record.SetCalendarTime(_recordHandle, propertyId, val);
                 int error = Interop.Record.SetCalTime(_recordHandle, propertyId, val);
                 if (CalendarError.None != (CalendarError)error)
                 {


### PR DESCRIPTION
## Summary
Cleans up the two `CalendarTime`/native conversion helpers in `CalendarRecord.cs`: removes a shipped `Console.WriteLine("convert calendar")` debug artifact that performed a synchronous stdout write on every call, deletes four dead commented-out developer-debug lines, and replaces the two hand-rolled `new DateTime(1970, 1, 1, 0, 0, 0)` Unix epochs with the framework constant `DateTime.UnixEpoch`.

`ConvertCalendarTimeToStruct` runs on a warm path — every `Set<CalendarTime>` and every time-based filter condition (`CalendarFilter.cs:181`, `CalendarFilter.cs:450`) — so a batch insert of N event/todo records previously emitted N stray console writes into the consuming app's stdout, bypassing the `Log` facility used everywhere else in the module.

## Changes
- `src/Tizen.Pims.Calendar/Tizen.Pims.Calendar/CalendarRecord.cs`
  - `ConvertCalendarTimeToStruct`: removed `Console.WriteLine("convert calendar")`; removed two dead `//Log.Debug(... "Sameer local time is ..." ...)` lines (plus a stray blank line); the UTC branch now computes ticks against `DateTime.UnixEpoch.Ticks` inline instead of constructing an epoch `DateTime` per call.
  - `ConvertIntPtrToCalendarTime`: same epoch replacement (`new DateTime(1970, 1, 1, 0, 0, 0)` → `DateTime.UnixEpoch`).
  - `Set<T>` (`CalendarTime` branch): removed the two superseded commented-out lines (`//Interop.Record.DateTime val = ...` and `//int error = Interop.Record.SetCalendarTime(...)`).

## Mode
Refactoring

## Verification
- [x] Build: passed (0 errors, 0 warnings)
- [ ] Tests: N/A
- [ ] Benchmark: skipped (sdb error: no device connected)

Public API signature change: none (both helpers are `internal static`; the `Set<T>` change touches only comments). Behavior change: none observable — `DateTime.UnixEpoch.Ticks` is the identical tick value (`621355968000000000`) previously produced by the hand-rolled epoch (only `.Ticks` is read, so `DateTimeKind` does not affect the result), and the removed lines are a stray stdout write and dead comments. `DateTime.UnixEpoch` is available since .NET Standard 2.1; the assembly targets `net8.0`.

Fixes #7711

🤖 Generated with [Claude Code](https://claude.com/claude-code)
