### PR TITLE
Restore document deployment: rewrite workflows for the net8.0 toolchain

### DIFF
--- a/.github/workflows/deploy-documents-for-tizen-docs.yml
+++ b/.github/workflows/deploy-documents-for-tizen-docs.yml
@@ -49,11 +49,12 @@ jobs:
     - name: Install DocFX
       run: dotnet tool install -g docfx --version 2.78.4
 
-    - name: Get TizenFX branch heads
+    - name: Get build cache key inputs
       id: info
       run: |
         HEADS=$(git ls-remote https://github.com/Samsung/TizenFX.git refs/heads/main "refs/heads/API[0-9]*" | sort | sha256sum | cut -d' ' -f1)
         echo "heads=$HEADS" >> $GITHUB_OUTPUT
+        echo "docs_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
     - name: Cache DocFX output
       id: cache-site
@@ -62,7 +63,7 @@ jobs:
         path: |
           _site
           obj
-        key: docfx-tizen-docs-site-v5-${{ steps.info.outputs.heads }}-${{ hashFiles('docfx_tizen_docs.json', 'filterConfig.yml', 'build.sh', 'templates/**', 'csproj/**') }}
+        key: docfx-tizen-docs-site-v5-${{ steps.info.outputs.docs_sha }}-${{ steps.info.outputs.heads }}
 
     - name: Free disk space
       if: steps.cache-site.outputs.cache-hit != 'true'

--- a/.github/workflows/deploy-documents-for-tizen-docs.yml
+++ b/.github/workflows/deploy-documents-for-tizen-docs.yml
@@ -4,67 +4,105 @@ on:
   schedule:
   - cron: "0 17 * * *"
   workflow_dispatch:
+    inputs:
+      docs-repository:
+        description: "TizenFX-Docs repository to build with"
+        type: string
+        default: "TizenAPI/TizenFX-Docs"
+      docs-ref:
+        description: "TizenFX-Docs branch/tag to build with"
+        type: string
+        default: "net8.0"
 
+# TODO: switch DOCS_REF to 'master' once TizenAPI/TizenFX-Docs net8.0 is merged
 env:
+  DOCS_REPOSITORY: ${{ inputs.docs-repository || 'TizenAPI/TizenFX-Docs' }}
+  DOCS_REF: ${{ inputs.docs-ref || 'net8.0' }}
   DEPLOY_BRANCH: tizen-docs-pages
-  CACHE_NAME: docfx-tizen-docs-pages-site
+
+concurrency:
+  group: deploy-documents-for-tizen-docs
+  cancel-in-progress: false
+
+permissions:
+  contents: write
 
 jobs:
 
   build:
-    runs-on: ubuntu-22.04
-    container:
-      image: tizendotnet/tizenfx-build-worker:2.5
-      options: --ulimit nofile=10240:10240
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
       with:
-        repository: TizenAPI/TizenFX-Docs
+        repository: ${{ env.DOCS_REPOSITORY }}
+        ref: ${{ env.DOCS_REF }}
 
-    - name: Checkout TizenFX sources
+    - uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Install DocFX
+      run: dotnet tool install -g docfx --version 2.78.4
+
+    - name: Get TizenFX branch heads
+      id: info
       run: |
-        ./build.sh clone
+        HEADS=$(git ls-remote https://github.com/Samsung/TizenFX.git refs/heads/main "refs/heads/API[0-9]*" | sort | sha256sum | cut -d' ' -f1)
+        echo "heads=$HEADS" >> $GITHUB_OUTPUT
 
     - name: Cache DocFX output
       id: cache-site
       uses: actions/cache@v4
       with:
-        path: _site
-        key: ${{ env.CACHE_NAME }}-${{ hashFiles('repos/commits') }}
+        path: |
+          _site
+          obj
+        key: docfx-tizen-docs-site-v5-${{ steps.info.outputs.heads }}-${{ hashFiles('docfx_tizen_docs.json', 'filterConfig.yml', 'build.sh') }}
 
-    - name: Build Documents
-      env:
-        DOCFX_FILE: "docfx_tizen_docs.json"
+    - name: Free disk space
       if: steps.cache-site.outputs.cache-hit != 'true'
       run: |
+        sudo rm -rf /usr/local/lib/android /opt/hostedtoolcache/CodeQL /usr/local/.ghcup
+        df -h /
+
+    - name: Build Documents
+      if: steps.cache-site.outputs.cache-hit != 'true'
+      env:
+        DOCFX_FILE: "docfx_tizen_docs.json"
+      run: |
+        ./build.sh clone
         ./build.sh restore
         ./build.sh build
 
-    - name: Archive Artifacts
-      run: |
-        cp .gitattributes _site/
-        tar cfz site.tar.gz _site/
+    - name: Verify generated site
+      run: ./build.sh verify
 
     - uses: actions/upload-artifact@v4
       with:
         name: documents
-        path: site.tar.gz
+        path: _site/
         overwrite: true
 
   deploy:
     needs: [build]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: ${{ env.DOCS_REPOSITORY }}
+        ref: ${{ env.DOCS_REF }}
+
     - uses: actions/download-artifact@v4
       with:
         name: documents
-        overwrite: true
+        path: _site
 
-    - name: Extract Artifacts
+    - name: Create version links
       run: |
-        tar xfz site.tar.gz
+        ./build.sh links
+        cp .gitattributes _site/
 
     - name: Deploy GitHub Pages
       uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/deploy-documents-for-tizen-docs.yml
+++ b/.github/workflows/deploy-documents-for-tizen-docs.yml
@@ -62,7 +62,7 @@ jobs:
         path: |
           _site
           obj
-        key: docfx-tizen-docs-site-v5-${{ steps.info.outputs.heads }}-${{ hashFiles('docfx_tizen_docs.json', 'filterConfig.yml', 'build.sh') }}
+        key: docfx-tizen-docs-site-v5-${{ steps.info.outputs.heads }}-${{ hashFiles('docfx_tizen_docs.json', 'filterConfig.yml', 'build.sh', 'templates/**', 'csproj/**') }}
 
     - name: Free disk space
       if: steps.cache-site.outputs.cache-hit != 'true'

--- a/.github/workflows/deploy-documents-for-tizen-docs.yml
+++ b/.github/workflows/deploy-documents-for-tizen-docs.yml
@@ -13,6 +13,10 @@ on:
         description: "TizenFX-Docs branch/tag to build with"
         type: string
         default: "net8.0"
+      dry-run:
+        description: "Build and verify only, skip deployment"
+        type: boolean
+        default: false
 
 # TODO: switch DOCS_REF to 'master' once TizenAPI/TizenFX-Docs net8.0 is merged
 env:
@@ -86,6 +90,7 @@ jobs:
 
   deploy:
     needs: [build]
+    if: ${{ !inputs.dry-run }}
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/deploy-documents.yml
+++ b/.github/workflows/deploy-documents.yml
@@ -48,11 +48,12 @@ jobs:
     - name: Install DocFX
       run: dotnet tool install -g docfx --version 2.78.4
 
-    - name: Get TizenFX branch heads
+    - name: Get build cache key inputs
       id: info
       run: |
         HEADS=$(git ls-remote https://github.com/Samsung/TizenFX.git refs/heads/main "refs/heads/API[0-9]*" | sort | sha256sum | cut -d' ' -f1)
         echo "heads=$HEADS" >> $GITHUB_OUTPUT
+        echo "docs_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
     - name: Cache DocFX output
       id: cache-site
@@ -61,7 +62,7 @@ jobs:
         path: |
           _site
           obj
-        key: docfx-gh-pages-site-v5-${{ steps.info.outputs.heads }}-${{ hashFiles('docfx.json', 'filterConfig.yml', 'build.sh', 'build-index2.js', 'templates/**', 'csproj/**') }}
+        key: docfx-gh-pages-site-v5-${{ steps.info.outputs.docs_sha }}-${{ steps.info.outputs.heads }}
 
     - name: Free disk space
       if: steps.cache-site.outputs.cache-hit != 'true'

--- a/.github/workflows/deploy-documents.yml
+++ b/.github/workflows/deploy-documents.yml
@@ -61,7 +61,7 @@ jobs:
         path: |
           _site
           obj
-        key: docfx-gh-pages-site-v5-${{ steps.info.outputs.heads }}-${{ hashFiles('docfx.json', 'filterConfig.yml', 'build.sh', 'build-index2.js') }}
+        key: docfx-gh-pages-site-v5-${{ steps.info.outputs.heads }}-${{ hashFiles('docfx.json', 'filterConfig.yml', 'build.sh', 'build-index2.js', 'templates/**', 'csproj/**') }}
 
     - name: Free disk space
       if: steps.cache-site.outputs.cache-hit != 'true'

--- a/.github/workflows/deploy-documents.yml
+++ b/.github/workflows/deploy-documents.yml
@@ -4,58 +4,108 @@ on:
   schedule:
   - cron: "0 16 * * *"
   workflow_dispatch:
+    inputs:
+      docs-repository:
+        description: "TizenFX-Docs repository to build with"
+        type: string
+        default: "TizenAPI/TizenFX-Docs"
+      docs-ref:
+        description: "TizenFX-Docs branch/tag to build with"
+        type: string
+        default: "net8.0"
+
+# TODO: switch DOCS_REF to 'master' once TizenAPI/TizenFX-Docs net8.0 is merged
+env:
+  DOCS_REPOSITORY: ${{ inputs.docs-repository || 'TizenAPI/TizenFX-Docs' }}
+  DOCS_REF: ${{ inputs.docs-ref || 'net8.0' }}
+
+concurrency:
+  group: deploy-documents
+  cancel-in-progress: false
+
+permissions:
+  contents: write
 
 jobs:
 
   build:
-    runs-on: ubuntu-22.04
-    container:
-      image: tizendotnet/tizenfx-build-worker:2.5
-      options: --ulimit nofile=10240:10240
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
       with:
-        repository: TizenAPI/TizenFX-Docs
+        repository: ${{ env.DOCS_REPOSITORY }}
+        ref: ${{ env.DOCS_REF }}
 
-    - name: Checkout TizenFX sources
+    - uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Install DocFX
+      run: dotnet tool install -g docfx --version 2.78.4
+
+    - name: Get TizenFX branch heads
+      id: info
       run: |
-        ./build.sh clone
+        HEADS=$(git ls-remote https://github.com/Samsung/TizenFX.git refs/heads/main "refs/heads/API[0-9]*" | sort | sha256sum | cut -d' ' -f1)
+        echo "heads=$HEADS" >> $GITHUB_OUTPUT
+
     - name: Cache DocFX output
       id: cache-site
       uses: actions/cache@v4
       with:
-        path: _site
-        key: docfx-gh-pages-site-${{ hashFiles('repos/commits') }}
+        path: |
+          _site
+          obj
+        key: docfx-gh-pages-site-v5-${{ steps.info.outputs.heads }}-${{ hashFiles('docfx.json', 'filterConfig.yml', 'build.sh', 'build-index2.js') }}
+
+    - name: Free disk space
+      if: steps.cache-site.outputs.cache-hit != 'true'
+      run: |
+        sudo rm -rf /usr/local/lib/android /opt/hostedtoolcache/CodeQL /usr/local/.ghcup
+        df -h /
 
     - name: Build Documents
       if: steps.cache-site.outputs.cache-hit != 'true'
       run: |
+        ./build.sh clone
         ./build.sh restore
         ./build.sh build
-        ./build.sh index
-    - name: Archive Artifacts
-      run: |
-        tar cfz site.tar.gz _site/
+
+    - name: Verify generated site
+      run: ./build.sh verify
+
     - uses: actions/upload-artifact@v4
       with:
         name: documents
-        path: site.tar.gz
+        path: _site/
         overwrite: true
 
   deploy:
     needs: [build]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: ${{ env.DOCS_REPOSITORY }}
+        ref: ${{ env.DOCS_REF }}
+
     - uses: actions/download-artifact@v4
       with:
         name: documents
-        overwrite: true
+        path: _site
 
-    - name: Extract Artifacts
-      run: |
-        tar xfz site.tar.gz
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - name: Install indexing dependencies
+      run: npm ci
+
+    - name: Generate search index and version links
+      run: ./build.sh index
+
     - name: Deploy GitHub Pages
       uses: peaceiris/actions-gh-pages@v4
       with:

--- a/.github/workflows/deploy-documents.yml
+++ b/.github/workflows/deploy-documents.yml
@@ -13,6 +13,10 @@ on:
         description: "TizenFX-Docs branch/tag to build with"
         type: string
         default: "net8.0"
+      dry-run:
+        description: "Build and verify only, skip deployment"
+        type: boolean
+        default: false
 
 # TODO: switch DOCS_REF to 'master' once TizenAPI/TizenFX-Docs net8.0 is merged
 env:
@@ -83,6 +87,7 @@ jobs:
 
   deploy:
     needs: [build]
+    if: ${{ !inputs.dry-run }}
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
## Problem

Both nightly documentation workflows have been failing since 2025-12-23, when #7357 moved the TargetFramework to net8.0: the docs were still built inside the .NET 6 based `tizendotnet/tizenfx-build-worker:2.5` container, so restore failed every night and neither samsung.github.io/TizenFX (gh-pages) nor the tizen-docs-pages branch had been updated for ~8 months.

An earlier recovery attempt (test-actions branch + TizenFX-Docs net8.0 branch, March 2026) validated a container-less approach but was never merged, and its build had a latent filter bug that silently dropped every class page.

## Changes

- drop the obsolete .NET 6 build container; build on ubuntu-24.04 with setup-dotnet 8.0 and DocFX 2.78.4 (ubuntu-22.04 runner deprecation starts 2026-09-17)
- restore the nightly schedules; keep workflow_dispatch with repository/ref/dry-run inputs so changes can be tested before touching the live site
- add a verify gate (per-version page counts + a landmark class page) so an empty or class-less site fails the run instead of silently deploying
- cache keyed on the TizenFX-Docs commit sha + all API branch heads
- free runner disk space before full builds
- port the same pipeline to the tizen-docs-pages variant, which the March effort never covered

Companion fixes already pushed to TizenAPI/TizenFX-Docs `net8.0`: API15/main version mapping (API14 is the TV branch now), .NET SDK 8 pin, sln-format fallback for SDK 8/9+, a filter rule fix (`uid:` -> `uidRegex`; the malformed rule degenerated to "exclude every class"), docfx 2.7x vendor CSS rename, and per-version landing page namespace sync.

## Validation

Dispatched from this branch with the default configuration (identical to what the nightly will run):

- [Deploy Documents run 2055](https://github.com/Samsung/TizenFX/actions/runs/31351417889) and [Deploy Documents for Tizen Docs run 1940](https://github.com/Samsung/TizenFX/actions/runs/31351423797): green end-to-end
- Live checks: class pages restored (e.g. Tizen.NUI.BaseComponents.View; API15 grew 716 -> 2466 pages), EditorBrowsable(Never) APIs remain hidden, styling fixed, stable/latest/main/devel version links, search index and /commits all serve correctly
- gh-pages and tizen-docs-pages were already refreshed by those validation runs; merging this PR resumes the nightly automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)