### PR TITLE
[AI Task] Fix async-bridge TCS inline continuations and Post<T> permanent hang in Tizen.Applications.Common

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
@@ -913,7 +913,7 @@ namespace Tizen.Applications
                 throw new ArgumentNullException(nameof(launchRequest));
             }
 
-            var task = new TaskCompletionSource<AppControlResult>();
+            var task = new TaskCompletionSource<AppControlResult>(TaskCreationOptions.RunContinuationsAsynchronously);
             Interop.AppControl.ErrorCode err;
             int requestId = 0;
 

--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -377,8 +377,18 @@ namespace Tizen.Applications
                 throw new ArgumentNullException(nameof(runner));
             }
 
-            var task = new TaskCompletionSource<T>();
-            GSourceManager.Post(() => { task.SetResult(runner()); }, true);
+            var task = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+            GSourceManager.Post(() =>
+            {
+                try
+                {
+                    task.SetResult(runner());
+                }
+                catch (Exception ex)
+                {
+                    task.SetException(ex);
+                }
+            }, true);
             return await task.Task.ConfigureAwait(false);
         }
 

--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -380,6 +380,7 @@ namespace Tizen.Applications
             var task = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
             GSourceManager.Post(() =>
             {
+#pragma warning disable CA1031
                 try
                 {
                     task.SetResult(runner());
@@ -388,6 +389,7 @@ namespace Tizen.Applications
                 {
                     task.SetException(ex);
                 }
+#pragma warning restore CA1031
             }, true);
             return await task.Task.ConfigureAwait(false);
         }

--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreTask.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreTask.cs
@@ -152,8 +152,18 @@ namespace Tizen.Applications
                 throw new ArgumentNullException(nameof(runner));
             }
 
-            var task = new TaskCompletionSource<T>();
-            GSourceManager.Post(() => { task.SetResult(runner()); });
+            var task = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+            GSourceManager.Post(() =>
+            {
+                try
+                {
+                    task.SetResult(runner());
+                }
+                catch (Exception ex)
+                {
+                    task.SetException(ex);
+                }
+            });
             return await task.Task.ConfigureAwait(false);
         }
     }

--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreTask.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreTask.cs
@@ -155,6 +155,7 @@ namespace Tizen.Applications
             var task = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
             GSourceManager.Post(() =>
             {
+#pragma warning disable CA1031
                 try
                 {
                     task.SetResult(runner());
@@ -163,6 +164,7 @@ namespace Tizen.Applications
                 {
                     task.SetException(ex);
                 }
+#pragma warning restore CA1031
             });
             return await task.Task.ConfigureAwait(false);
         }


### PR DESCRIPTION
## Summary
Fixes the three async bridges in `Tizen.Applications.Common` that created `TaskCompletionSource` without `RunContinuationsAsynchronously` and completed them from GLib main-loop callbacks, which could run arbitrary user continuations inline inside the main loop dispatch (stall/deadlock risk). Also fixes `CoreApplication.Post<T>`/`CoreTask.Post<T>` so a `runner()` exception no longer leaves the returned Task permanently incomplete (caller hangs forever on `await`) nor propagates across the GLib reverse P/Invoke boundary.

## Changes
- `src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs` — `SendLaunchRequestAsync`: create the `TaskCompletionSource<AppControlResult>` with `TaskCreationOptions.RunContinuationsAsynchronously`.
- `src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs` — `Post<T>`: add `RunContinuationsAsynchronously`; wrap `runner()` in try/catch and route exceptions to `task.SetException` so failures fault the Task instead of hanging the awaiter or crossing the reverse P/Invoke boundary.
- `src/Tizen.Applications.Common/Tizen.Applications/CoreTask.cs` — `Post<T>`: same fix as `CoreApplication.Post<T>`.

## Mode
Refactoring

## Verification
- [x] Build: passed (`dotnet build` on Tizen.Applications.Common — 0 errors)
- [ ] Tests: N/A
- [ ] Benchmark: skipped (sdb error: no device attached)

Public API signatures are unchanged; the only behavior change is on the exception path (permanent hang / process crash → faulted Task, matching the Task contract).

Fixes #7736
