### PR TITLE
[Tdbc] Fix SQLite update hook query and exception handling

### DIFF
--- a/src/Tizen.Data.Tdbc.Driver.Sqlite/Tizen.Data.Tdbc.Driver.Sqlite/Connection.cs
+++ b/src/Tizen.Data.Tdbc.Driver.Sqlite/Tizen.Data.Tdbc.Driver.Sqlite/Connection.cs
@@ -77,6 +77,27 @@ namespace Tizen.Data.Tdbc.Driver.Sqlite
 
         private void UpdateHookCallback(IntPtr data, int action, string db_name, string table_name, long rowid)
         {
+            try
+            {
+                NotifyRecordChanged(action, db_name, table_name, rowid);
+            }
+            catch (Exception)
+            {
+                // Notification failures must not escape the native SQLite callback.
+                // Do not expose SQL, identifiers or subscriber exception details.
+                try
+                {
+                    Console.Error.WriteLine("TDBC SQLite change notification failed.");
+                }
+                catch (Exception)
+                {
+                    // A failing diagnostic sink must not cross the native boundary either.
+                }
+            }
+        }
+
+        private void NotifyRecordChanged(int action, string db_name, string table_name, long rowid)
+        {
             OperationType operationType = OperationType.None;
             switch (((Interop.Sqlite.UpdateHookAction)action))
             {

--- a/src/Tizen.Data.Tdbc.Driver.Sqlite/Tizen.Data.Tdbc.Driver.Sqlite/Connection.cs
+++ b/src/Tizen.Data.Tdbc.Driver.Sqlite/Tizen.Data.Tdbc.Driver.Sqlite/Connection.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 
 namespace Tizen.Data.Tdbc.Driver.Sqlite
@@ -90,7 +91,13 @@ namespace Tizen.Data.Tdbc.Driver.Sqlite
                     break;
             }
 
-            Sql sql = new Sql($"SELECT * from {table_name} WHERE rowid = {rowid}");
+            // Callback names are identifiers, not SQL fragments. Qualify the table
+            // to avoid resolving a same-named table in another attached database.
+            string database = db_name.Replace("\"", "\"\"");
+            string table = table_name.Replace("\"", "\"\"");
+            // Sql.Bind has no Int64 overload; preserve the native rowid exactly.
+            string row = rowid.ToString(CultureInfo.InvariantCulture);
+            Sql sql = new Sql($"SELECT * from \"{database}\".\"{table}\" WHERE rowid = {row}");
             using (IStatement stmt = CreateStatement())
             using (IResultSet resultSet = stmt.ExecuteQuery(sql))
             {

--- a/test/Tizen.Data.Tdbc.Driver.Sqlite.Regression/CallbackRegression.cs
+++ b/test/Tizen.Data.Tdbc.Driver.Sqlite.Regression/CallbackRegression.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using Tizen.Data.Tdbc;
+using Tizen.Data.Tdbc.Driver.Sqlite;
+
+internal static class CallbackRegression
+{
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate int Authorizer(IntPtr data, int action, IntPtr first,
+        IntPtr second, IntPtr database, IntPtr source);
+
+    [DllImport("libsqlite3.so.0", EntryPoint = "sqlite3_set_authorizer", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int SetAuthorizer(IntPtr database, Authorizer callback, IntPtr data);
+
+    private sealed class ThrowingWriter : TextWriter
+    {
+        public override Encoding Encoding => Encoding.UTF8;
+        public override void WriteLine(string value) => throw new IOException("Diagnostic sink failed");
+    }
+
+    internal static void Run(string path)
+    {
+        using var connection = new Connection();
+        connection.Open(new UriBuilder("tdbc", "localhost") { Path = path, Query = "mode=rwc" }.Uri);
+        using var statement = connection.CreateStatement();
+        void Execute(string command)
+        {
+            if (!statement.Execute(new Sql(command)))
+                throw new Exception("Command failed: " + command);
+        }
+
+        Execute("CREATE TABLE callback_records(id INTEGER PRIMARY KEY, data TEXT)");
+        EventHandler<RecordChangedEventArgs> throwing = (_, __) =>
+            throw new InvalidOperationException("synthetic-sensitive-detail");
+        int received = 0;
+        EventHandler<RecordChangedEventArgs> counting = (_, __) => received++;
+        connection.RecordChanged += throwing;
+        connection.RecordChanged += counting;
+        TextWriter originalError = Console.Error;
+        using var diagnostics = new StringWriter();
+        try
+        {
+            Console.SetError(diagnostics);
+            Execute("INSERT INTO callback_records VALUES(1, 'subscriber failure')");
+            if (received != 0)
+                throw new Exception("The failed notification should stop at the throwing subscriber");
+
+            using (var writer = new ThrowingWriter())
+            {
+                Console.SetError(writer);
+                Execute("INSERT INTO callback_records VALUES(2, 'diagnostic failure')");
+            }
+            Console.SetError(diagnostics);
+            connection.RecordChanged -= throwing;
+            Execute("INSERT INTO callback_records VALUES(3, 'recovered')");
+
+            // SQLITE_SELECT = 21, SQLITE_DENY = 1. Deny only the SELECT prepared
+            // by the native update callback, while allowing the outer INSERT.
+            Authorizer denySelect = (_, action, first, second, database, source) => action == 21 ? 1 : 0;
+            if (SetAuthorizer(connection.GetHandle(), denySelect, IntPtr.Zero) != 0)
+                throw new Exception("Could not install the test authorizer");
+            try
+            {
+                Execute("INSERT INTO callback_records VALUES(4, 'query failure')");
+            }
+            finally
+            {
+                SetAuthorizer(connection.GetHandle(), null, IntPtr.Zero);
+                GC.KeepAlive(denySelect);
+            }
+            Execute("INSERT INTO callback_records VALUES(5, 'recovered again')");
+        }
+        finally
+        {
+            Console.SetError(originalError);
+            connection.RecordChanged -= throwing;
+            connection.RecordChanged -= counting;
+        }
+
+        using (var result = statement.ExecuteQuery(new Sql("SELECT COUNT(*) FROM callback_records")))
+        {
+            if (result.First().GetInt(0) != 5 || received != 2)
+                throw new Exception("Callback failures disrupted writes or later notifications");
+        }
+        string output = diagnostics.ToString();
+        if (string.IsNullOrWhiteSpace(output) || output.Contains("synthetic-sensitive-detail") ||
+            output.Contains("callback_records"))
+            throw new Exception("Expected a diagnostic without sensitive exception or SQL details");
+        Console.WriteLine("PASS: subscriber/query/diagnostic exceptions contained; writes and later notifications preserved");
+    }
+}

--- a/test/Tizen.Data.Tdbc.Driver.Sqlite.Regression/Program.cs
+++ b/test/Tizen.Data.Tdbc.Driver.Sqlite.Regression/Program.cs
@@ -16,6 +16,7 @@ internal static class Program
         try
         {
             Run(path);
+            CallbackRegression.Run(path);
         }
         finally
         {

--- a/test/Tizen.Data.Tdbc.Driver.Sqlite.Regression/Program.cs
+++ b/test/Tizen.Data.Tdbc.Driver.Sqlite.Regression/Program.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Globalization;
+using System.IO;
+using Tizen.Data.Tdbc;
+using Tizen.Data.Tdbc.Driver.Sqlite;
+
+// Run on Linux with libsqlite3.so.0: dotnet run --project Regression.csproj
+// Compile the production sources to exercise the internal driver without publishing APIs.
+internal static class Program
+{
+    private static string Quote(string value) => "\"" + value.Replace("\"", "\"\"") + "\"";
+
+    private static void Main()
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            Run(path);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static void Run(string path)
+    {
+        using var connection = new Connection();
+        connection.Open(new UriBuilder("tdbc", "localhost") { Path = path, Query = "mode=rwc" }.Uri);
+        using var statement = connection.CreateStatement();
+        void Execute(string command)
+        {
+            if (!statement.Execute(new Sql(command)))
+                throw new Exception("Command failed: " + command);
+        }
+
+        Execute("CREATE TABLE normal_table(id INTEGER PRIMARY KEY, data TEXT)");
+        Execute("INSERT INTO normal_table VALUES(1, 'decoy')");
+        Execute("CREATE TABLE secret_users(id INTEGER PRIMARY KEY, password TEXT)");
+        Execute("INSERT INTO secret_users VALUES(1, 'synthetic-secret')");
+
+        int notifications = 0;
+        int deletions = 0;
+        bool wrongRecord = false;
+        string expected = "expected";
+        connection.RecordChanged += (_, e) =>
+        {
+            if (e.OperationType == OperationType.Delete)
+            {
+                deletions++;
+                return;
+            }
+            if (e.Record == null || e.Record.GetString(1) != expected)
+                wrongRecord = true;
+            notifications++;
+        };
+
+        foreach (string name in new[] { "normal_table JOIN secret_users --", "my table", "order-log", "order", "tbl\"quote", "한글" })
+        {
+            Execute($"CREATE TABLE {Quote(name)}(id INTEGER PRIMARY KEY, data TEXT)");
+            Execute($"INSERT INTO {Quote(name)} VALUES(1, 'expected')");
+            expected = "updated";
+            Execute($"UPDATE {Quote(name)} SET data = 'updated' WHERE id = 1");
+            Execute($"DELETE FROM {Quote(name)} WHERE id = 1");
+            expected = "expected";
+        }
+
+        Execute("CREATE TABLE boundary(id INTEGER PRIMARY KEY, data TEXT)");
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            var culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+            culture.NumberFormat.NegativeSign = "~";
+            CultureInfo.CurrentCulture = culture;
+            foreach (long id in new[] { long.MinValue, -1L, 0L, 9007199254740993L, long.MaxValue })
+                Execute($"INSERT INTO boundary VALUES({id.ToString(CultureInfo.InvariantCulture)}, 'expected')");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+
+        Execute("ATTACH DATABASE ':memory:' AS \"attached\"\"db\"");
+        Execute("CREATE TABLE main.shared(id INTEGER PRIMARY KEY, data TEXT)");
+        Execute("CREATE TABLE \"attached\"\"db\".shared(id INTEGER PRIMARY KEY, data TEXT)");
+        expected = "main";
+        Execute("INSERT INTO main.shared VALUES(1, 'main')");
+        expected = "attached";
+        Execute("INSERT INTO \"attached\"\"db\".shared VALUES(1, 'attached')");
+        Execute("CREATE TEMP TABLE shared(id INTEGER PRIMARY KEY, data TEXT)");
+        expected = "temp";
+        Execute("INSERT INTO temp.shared VALUES(1, 'temp')");
+        expected = "main-updated";
+        Execute("UPDATE main.shared SET data = 'main-updated' WHERE id = 1");
+
+        if (wrongRecord)
+            throw new Exception("Event returned data from the wrong table or row");
+        if (notifications != 21 || deletions != 6)
+            throw new Exception($"Expected 21 row notifications and 6 deletions, got {notifications} and {deletions}");
+        Console.WriteLine("PASS: identifier injection, special names, INSERT/UPDATE/DELETE, Int64 boundaries, culture, attached/temp schema isolation");
+    }
+}

--- a/test/Tizen.Data.Tdbc.Driver.Sqlite.Regression/README.md
+++ b/test/Tizen.Data.Tdbc.Driver.Sqlite.Regression/README.md
@@ -1,0 +1,22 @@
+# SQLite identifier regression tests
+
+Run on Linux with the .NET 8 SDK/runtime and `libsqlite3.so.0`:
+
+```sh
+dotnet run --project test/Tizen.Data.Tdbc.Driver.Sqlite.Regression/Regression.csproj
+```
+
+The executable compiles the production TDBC sources directly to access the internal
+driver without adding public APIs or test packages. It creates a temporary database
+and removes it after normal completion or a managed failure.
+
+Coverage includes SQL syntax embedded in table names, quoted and Unicode names,
+INSERT/UPDATE/DELETE notifications, signed 64-bit rowids, a custom negative sign,
+and identical table names in main, attached, and temporary databases. Assertions
+run outside the native callback; failures exit with a nonzero status.
+
+This verifies identifier handling, not the safety of querying within an update
+hook. The existing same-connection callback reentrancy is unchanged. Tizen runtime
+validation remains necessary. On a host with only .NET 9, build the net8.0 project
+and use `DOTNET_ROLL_FORWARD=Major dotnet` to execute its output; that does not
+constitute a .NET 8 runtime test.

--- a/test/Tizen.Data.Tdbc.Driver.Sqlite.Regression/README.md
+++ b/test/Tizen.Data.Tdbc.Driver.Sqlite.Regression/README.md
@@ -15,8 +15,22 @@ INSERT/UPDATE/DELETE notifications, signed 64-bit rowids, a custom negative sign
 and identical table names in main, attached, and temporary databases. Assertions
 run outside the native callback; failures exit with a nonzero status.
 
-This verifies identifier handling, not the safety of querying within an update
-hook. The existing same-connection callback reentrancy is unchanged. Tizen runtime
+Callback tests cover a throwing subscriber, an authorizer-denied callback SELECT,
+and a throwing diagnostic writer. All five INSERTs must persist, and notifications
+must resume after the failures. A throwing subscriber stops the current multicast
+notification; later subscribers are not invoked for that notification. The driver
+contains ordinary managed notification exceptions and emits a fixed diagnostic
+without exception details. Notification failure does not signal a failed write.
+
+Before the callback guard, the throwing-subscriber test exits with code 134 and
+`PAL_SEHException` on the Linux .NET 9 host. This confirms a host availability
+impact; it does not establish a Tizen runtime result or an external attack path.
+Sensitive data reaching an unauthorized recipient remains unproven, so this
+observation alone does not establish a higher security severity.
+
+This verifies identifiers and managed exception containment, not the safety of
+querying within an update hook or recovery from fatal runtime/native failures.
+The existing same-connection callback reentrancy is unchanged. Tizen runtime
 validation remains necessary. On a host with only .NET 9, build the net8.0 project
 and use `DOTNET_ROLL_FORWARD=Major dotnet` to execute its output; that does not
 constitute a .NET 8 runtime test.

--- a/test/Tizen.Data.Tdbc.Driver.Sqlite.Regression/Regression.csproj
+++ b/test/Tizen.Data.Tdbc.Driver.Sqlite.Regression/Regression.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />
+    <Compile Include="CallbackRegression.cs" />
     <Compile Include="../../src/Tizen.Data.Tdbc/Tizen.Data.Tdbc/*.cs" />
     <Compile Include="../../src/Tizen.Data.Tdbc.Driver.Sqlite/Tizen.Data.Tdbc.Driver.Sqlite/**/*.cs" />
   </ItemGroup>

--- a/test/Tizen.Data.Tdbc.Driver.Sqlite.Regression/Regression.csproj
+++ b/test/Tizen.Data.Tdbc.Driver.Sqlite.Regression/Regression.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="../../src/Tizen.Data.Tdbc/Tizen.Data.Tdbc/*.cs" />
+    <Compile Include="../../src/Tizen.Data.Tdbc.Driver.Sqlite/Tizen.Data.Tdbc.Driver.Sqlite/**/*.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
### Description of Change

The SQLite update hook interpolates table names into a SELECT without
identifier quoting. A legal table name containing SQL syntax can change
the query, and an unqualified name can resolve to the wrong database.

Quote database and table names separately and preserve native Int64 rowids
using invariant formatting. A separate commit contains ordinary managed
exceptions from notification processing and diagnostic output within the
native callback. Failed notifications no longer propagate these exceptions
across the unmanaged boundary; subsequent writes and notifications continue.

Validation:
- Driver and regression executable build successfully for net8.0.
- Regression tests pass on the Tizen 10.1 x86_64 emulator
  (`tizen-10.1-unified_20260903.205955`), with exit code 0.
- Coverage includes SQL-like/special/Unicode identifiers, Int64 boundaries,
  culture, attached/temp schema isolation, and notification exceptions.
- Subscriber, callback-query and diagnostic failures preserve all five test
  writes and allow subsequent notifications to resume.
- The unguarded throwing-subscriber test aborts with exit 134 on the Linux
  .NET 9 host; that negative case was not run on the emulator.
- Formatting checks and independent code review completed.

The emulator test compiles production sources directly and runs through the
SDB root shell. It does not validate packaged application permissions or
demonstrate information disclosure to an unauthorized recipient. Existing
same-connection update-hook reentrancy and SQL console output are outside
this change. Regression tests are manually executed, not integrated into CI.

### API Changes

None.

🤖 Generated with Codex
