### PR TITLE
[NUI] Use dedicated interop for Renderable.UpdateArea

### DIFF
--- a/src/Tizen.NUI/src/deprecated/Rendering/Renderer_Deprecated.cs
+++ b/src/Tizen.NUI/src/deprecated/Rendering/Renderer_Deprecated.cs
@@ -728,32 +728,23 @@ namespace Tizen.NUI
         /// Gets and Sets extents of partial update area.
         /// </summary>
         /// <remarks>
-        /// Extents the area - the position and the size - used for the attached View's partial update area calculation.
+        /// Extends the area - the position and the size - used for the attached View's partial update area calculation.
         /// This value be appended after calculate all update area, like visual offset.
         /// Change  <see cref="Tizen.NUI.BaseComponents.View.UpdateAreaHint"/> value if you want to change View's partial update area.
-        /// Warning : Only 0u ~ 65535u integer values are allowed for each parameters.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public UIExtents UpdateArea
         {
             get
             {
-                // TODO : Clean up below logics
-                using Extents temp = new Extents();
-                using var pValue = Tizen.NUI.Object.GetProperty(SwigCPtr, Renderer.Property.UpdateAreaExtents);
-                pValue.Get(temp);
-
-                if (temp == null)
-                {
-                    return new UIExtents(0.0f);
-                }
-                UIExtents result = new UIExtents((float)temp.Start, (float)temp.End, (float)temp.Top, (float)temp.Bottom);
-                return result;
+                Interop.Renderer.GetUpdateAreaMargin(SwigCPtr, out float start, out float end, out float top, out float bottom);
+                NDalicPINVOKE.ThrowExceptionIfExists();
+                return new UIExtents(start, end, top, bottom);
             }
             set
             {
-                using var temp = new Tizen.NUI.PropertyValue((Extents)value);
-                Tizen.NUI.Object.SetProperty(SwigCPtr, Renderer.Property.UpdateAreaExtents, temp);
+                Interop.Renderer.SetUpdateAreaMargin(SwigCPtr, value.Start, value.End, value.Top, value.Bottom);
+                NDalicPINVOKE.ThrowExceptionIfExists();
             }
         }
 
@@ -972,7 +963,6 @@ namespace Tizen.NUI
             internal static readonly int VertexRangeFirst = Interop.Renderer.IndexRangeFirstGet();
             internal static readonly int VertexRangeCount = Interop.Renderer.IndexRangeCountGet();
             internal static readonly int InstanceCount = Interop.Renderer.InstanceCountGet();
-            internal static readonly int UpdateAreaExtents = Interop.Renderer.UpdateAreaExtentsGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Renderer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Renderer.cs
@@ -132,8 +132,11 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_INSTANCE_COUNT_get")]
             public static extern int InstanceCountGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_Property_UPDATE_AREA_EXTENTS_get")]
-            public static extern int UpdateAreaExtentsGet();
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_SetUpdateAreaMargin")]
+            public static extern void SetUpdateAreaMargin(global::System.Runtime.InteropServices.HandleRef renderer, float start, float end, float top, float bottom);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_GetUpdateAreaMargin")]
+            public static extern void GetUpdateAreaMargin(global::System.Runtime.InteropServices.HandleRef renderer, out float start, out float end, out float top, out float bottom);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Renderer_New")]
             public static extern global::System.IntPtr New(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);

--- a/src/Tizen.NUI/src/internal/Rendering/RendererProperty.cs
+++ b/src/Tizen.NUI/src/internal/Rendering/RendererProperty.cs
@@ -59,6 +59,5 @@ namespace Tizen.NUI
         internal static readonly int VertexRangeFirst = IndexRangeFirst;
         internal static readonly int VertexRangeCount = IndexRangeCount;
         internal static readonly int InstanceCount = Interop.Renderer.InstanceCountGet();
-        internal static readonly int UpdateAreaExtents = Interop.Renderer.UpdateAreaExtentsGet();
     }
 }

--- a/src/Tizen.NUI/src/public/Rendering/Renderable.cs
+++ b/src/Tizen.NUI/src/public/Rendering/Renderable.cs
@@ -503,33 +503,23 @@ namespace Tizen.NUI
         /// Gets and Sets extents of partial update area.
         /// </summary>
         /// <remarks>
-        /// Extents the area - the position and the size - used for the attached View's partial update area calculation.
+        /// Extends the area - the position and the size - used for the attached View's partial update area calculation.
         /// This value be appended after calculate all update area, like visual offset.
         /// Change  <see cref="Tizen.NUI.BaseComponents.View.UpdateAreaHint"/> value if you want to change View's partial update area.
-        /// Warning : Only 0u ~ 65535u integer values are allowed for each parameters.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public UIExtents UpdateArea
         {
             get
             {
-                // TODO : Clean up below logics after implement Object.InternalGetPropertyExtents
-                using Extents temp = new Extents();
-                using var pValue = Tizen.NUI.Object.GetProperty(SwigCPtr, RendererProperty.UpdateAreaExtents);
-                pValue.Get(temp);
-
-                if (temp == null)
-                {
-                    return new UIExtents(0.0f);
-                }
-                UIExtents result = new UIExtents((float)temp.Start, (float)temp.End, (float)temp.Top, (float)temp.Bottom);
-                return result;
+                Interop.Renderer.GetUpdateAreaMargin(SwigCPtr, out float start, out float end, out float top, out float bottom);
+                NDalicPINVOKE.ThrowExceptionIfExists();
+                return new UIExtents(start, end, top, bottom);
             }
             set
             {
-                // TODO : Clean up below logics after implement Object.InternalSetPropertyExtents
-                using var temp = new Tizen.NUI.PropertyValue((Extents)value);
-                Tizen.NUI.Object.SetProperty(SwigCPtr, RendererProperty.UpdateAreaExtents, temp);
+                Interop.Renderer.SetUpdateAreaMargin(SwigCPtr, value.Start, value.End, value.Top, value.Bottom);
+                NDalicPINVOKE.ThrowExceptionIfExists();
             }
         }
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

DALi now stores the renderer update area margin as Insets, so setting it through an Extents PropertyValue no longer works. Renderable.UpdateArea and the deprecated Renderer.UpdateArea call
CSharp_Dali_Renderer_Set/GetUpdateAreaMargin with four floats instead, and the unused UpdateAreaExtents property index is removed. The values are no longer limited to integers.

Requires the matching dali-csharp-binder change.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
